### PR TITLE
Improved: the overflow property for filters to only scroll it in x-axis(#1x0efxp)

### DIFF
--- a/changelogs/unreleased/-1x0efxp.yml
+++ b/changelogs/unreleased/-1x0efxp.yml
@@ -1,0 +1,6 @@
+---
+title: 'Improved: the overflow property for filters to only scroll it in x-axis'
+ticket_id: "#1x0efxp"
+merge_request: 33
+author: Yash Maheshwari
+type: added

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -251,7 +251,7 @@ ion-thumbnail > img {
 .filters {
   display: flex;
   flex-wrap: nowrap;
-  overflow: scroll;
+  overflow-x: scroll;
 }
 
 .filters > ion-item {


### PR DESCRIPTION
- Added `overflow-x` on the filters class