### PR TITLE
Fixed: Hide shipping instructions UI if there is no data. Also corrected field name from zipCode to postalCode.

### DIFF
--- a/src/views/ShippingDetails.vue
+++ b/src/views/ShippingDetails.vue
@@ -11,11 +11,11 @@
           <h3>{{ currentOrder?.shippingAddress?.toName }}</h3>
           <p>{{ currentOrder?.shippingAddress?.address1 }}</p>
           <p v-if="currentOrder?.shippingAddress?.address2">{{ currentOrder.shippingAddress.address2 }}</p>
-          <p>{{ currentOrder?.shippingAddress?.city ? currentOrder.shippingAddress.city + "," : "" }} {{ currentOrder.shippingAddress?.zipCode }}</p>
+          <p>{{ currentOrder?.shippingAddress?.city ? currentOrder.shippingAddress.city + "," : "" }} {{ currentOrder.shippingAddress?.postalCode }}</p>
           <p>{{ currentOrder?.shippingAddress?.stateName ? currentOrder.shippingAddress.stateName + "," : "" }} {{ currentOrder.shippingAddress?.countryName }}</p>
         </ion-label>
       </ion-item>
-      <ion-item color="light" lines="none">
+      <ion-item color="light" lines="none" v-if="currentOrder?.shippingInstructions">
         <ion-label class="ion-text-wrap">
           <p class="overline">{{ translate("Handling Instructions") }}</p>
           <p>{{ currentOrder?.shippingInstructions ? currentOrder.shippingInstructions : 'Sample Handling instructions' }}</p>


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
Fixed: Hide shipping instructions UI if there is no data. Also corrected the field name from zipCode to postalCode.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)