### PR TITLE
Improved: Displayed shipGroupSeqId on order detail page (#332).

### DIFF
--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -39,6 +39,12 @@
                 <p>{{ translate("Ordered") }} {{ formatUtcDate(order.orderDate, 'dd MMMM yyyy t a ZZZZ') }}</p>
               </ion-label>
             </div>
+            <div class="order-tags">
+              <ion-chip outline>
+                <ion-icon :icon="pricetagOutline" />
+                <ion-label>{{ order.shipGroupSeqId }}</ion-label>
+              </ion-chip>
+            </div>
 
             <div class="order-metadata">
               <ion-label>
@@ -166,6 +172,7 @@
               <div>
                 <ion-card-subtitle class="overline">{{ getfacilityTypeDesc(shipGroup.facilityTypeId) }}</ion-card-subtitle>
                 <ion-card-title>{{ shipGroup.facilityName }}</ion-card-title>
+                {{ shipGroup.shipGroupSeqId }}
               </div>
               <ion-badge :color="shipGroup.category ? 'primary' : 'medium'">{{ shipGroup.category ? shipGroup.category : translate('Pending allocation') }}</ion-badge>
             </ion-card-header>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #332 

### Short Description and Why It's Useful
Improved: Displayed shipGroupSeqId on order detail page (#332).


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)