### PR TITLE
Fixed: Added checks to avoid opening of new tab in case no custom document generation url is available (#441).

### DIFF
--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -512,6 +512,9 @@ const printShippingLabel = async (shipmentIds: Array<string>): Promise<any> => {
 }
 
 const printCustomDocuments = async (internationalInvoiceUrls: Array<string>): Promise<any> => {
+  if (!internationalInvoiceUrls || internationalInvoiceUrls.length === 0) {
+    return;
+  }
   try {
     internationalInvoiceUrls.forEach((url: string) => {
       try {

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -906,7 +906,7 @@ const actions: ActionTree<OrderState, RootState> = {
       if (shipmentIds.length) {
         try {
           const shipmentPackagesBatches = await UtilService.findShipmentPackages(shipmentIds)
-          shipmentPackages = shipmentPackagesBatches.flat();
+          shipmentPackages = Object.values(shipmentPackagesBatches).flat();
         } catch (err) {
           current.hasMissingPackageInfo = true;
           logger.error('Failed to fetch shipment packages for orders', err)

--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -646,7 +646,9 @@ export default defineComponent({
       }
 
       await OrderService.printShippingLabel(shipmentIds)
-      await OrderService.printCustomDocuments([order.shipmentPackages?.[0].internationalInvoiceUrl]);
+      if (order.shipmentPackages?.[0].internationalInvoiceUrl) {
+        await OrderService.printCustomDocuments([order.shipmentPackages?.[0].internationalInvoiceUrl]);
+      }
     },
     async regenerateShippingLabel(order: any) {
       // If there are no product store shipment method configured, then not generating the label and displaying an error toast

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -562,7 +562,9 @@ export default defineComponent({
                     await OrderService.printShippingLabel(shipmentIds)
                   }
 
-                  await OrderService.printCustomDocuments([order.shipmentPackages?.[0].internationalInvoiceUrl]);
+                  if (order.shipmentPackages?.[0].internationalInvoiceUrl) {
+                    await OrderService.printCustomDocuments([order.shipmentPackages?.[0].internationalInvoiceUrl]);
+                  }
 
                   toast.dismiss()
                 } else {
@@ -627,7 +629,14 @@ export default defineComponent({
               // Considering only unique shipment IDs
               // TODO check reason for redundant shipment IDs
               const shipmentIds = orderList.map((order: any) => [...new Set(order.items.map((item: any) => item.shipmentId).flat())]).flat() as Array<string>
-              const internationalInvoiceUrls = orderList.map((order: any) => [...new Set(order.shipmentPackages.map((shipmentPackage: any) => shipmentPackage.internationalInvoiceUrl).flat())]).flat() as Array<string>
+              const internationalInvoiceUrls = orderList
+              .map((order: any) =>
+                [...new Set(order.shipmentPackages
+                  .map((shipmentPackage: any) => shipmentPackage.internationalInvoiceUrl)
+                  .filter((url: string | null) => url !== null)
+                )]
+              )
+              .flat() as Array<string>;
 
               try {
                 const resp = await OrderService.packOrders({

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -530,7 +530,9 @@ export default defineComponent({
                   } else if (data.includes('printShippingLabel')) {
                     await OrderService.printShippingLabel(shipmentIds)
                   }
-                  await OrderService.printCustomDocuments([order.shipmentPackages?.[0].internationalInvoiceUrl]);
+                  if (order.shipmentPackages?.[0].internationalInvoiceUrl) {
+                    await OrderService.printCustomDocuments([order.shipmentPackages?.[0].internationalInvoiceUrl]);
+                  }
 
                   toast.dismiss()
                 } else {
@@ -781,7 +783,9 @@ export default defineComponent({
       }
 
       await OrderService.printShippingLabel(shipmentIds)
-      await OrderService.printCustomDocuments([order.shipmentPackages?.[0].internationalInvoiceUrl]);
+      if (order.shipmentPackages?.[0].internationalInvoiceUrl) {
+        await OrderService.printCustomDocuments([order.shipmentPackages?.[0].internationalInvoiceUrl]);
+      }
     },
     async addShipmentBox(order: any) {
       this.addingBoxForOrderIds.push(order.orderId)


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
Fixed: Added checks to avoid opening of new tab in case no custom document generation url is available.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)