### PR TITLE
Fixed: Updated retry shipping label payload to pass forceRateShop flag as Y/N instead of boolean true/false. This is needed as recent OMS release is accepting String instead of boolean for this flag. (#495)

### DIFF
--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -596,7 +596,7 @@ const retryShippingLabel = async (shipmentIds: Array<string>, forceRateShop = fa
     url: 'retryShippingLabel',  // TODO: update the api
     data: {
       shipmentIds,
-      forceRateShop
+      forceRateShop: forceRateShop ? 'Y' : 'N'
     }
   })
 }


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
Fixed: Updated retry shipping label payload to pass forceRateShop flag as Y/N instead of boolean true/false. This is needed as recent OMS release is accepting String instead of boolean for this flag. (#495)

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)