### PR TITLE
Fixed: picker getting removed when adding a picker to a picklist(#570)

### DIFF
--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -931,13 +931,13 @@ export default defineComponent({
 
               const pickerIds = [] as Array<string> 
               // if firstName is not found then adding default name `System Generated`
-              const pickersName = pickersInformation.pickerFacet.buckets.length ? (pickersInformation.pickerFacet.buckets.length === 1 ? [pickersInformation.pickerFacet.buckets[0].val.split('/')[1]]:
+              const pickersName = pickersInformation.pickerFacet.buckets.length ?
                 pickersInformation.pickerFacet.buckets.reduce((pickers: Array<string>, picker: any) => {
-                const val = picker.val.split('/') // having picker val in format 10001/FirstName LastName, split will change it into [pickerId, FirstName LastName]
-                pickerIds.push(val[0]) // storing pickerIds for usage in edit pickers modal
-                pickers.push(val[1].split(' ')[0]) // having val[0] as 'firstname lastname', we only need to display firstName
-                return pickers
-              }, [])) : ['System Generated']
+                  const val = picker.val.split('/') // having picker val in format 10001/FirstName LastName, split will change it into [pickerId, FirstName LastName]
+                  pickerIds.push(val[0]) // storing pickerIds for usage in edit pickers modal
+                  pickers.push(val[1].split(' ')[0]) // having val[0] as 'firstname lastname', we only need to display firstName
+                  return pickers
+                }, []) : ['System Generated']
 
               picklists.push({
                 id: picklist.picklistId,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #570 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When adding a picker to a picklist that previously has a single picker associated with it, then the old picker gets removed automatically from the picklist. Removed the check to only get the name of the picker when having a single picker in the picklist

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)