### PR TITLE
Fixed: Passed itemSeqId and orderItemSeqId explicitly while creating shipment for the TO to handle the case of multiple order items with the same product. (#579)

### DIFF
--- a/src/store/modules/transferorder/actions.ts
+++ b/src/store/modules/transferorder/actions.ts
@@ -141,10 +141,13 @@ const actions: ActionTree<TransferOrderState, RootState> = {
     
     try {
       let eligibleItems = payload.items.filter((item: any) => item.pickedQuantity > 0)
+      let seqIdCounter = 1;
       eligibleItems = eligibleItems.map((item:any) => ({
+        orderItemSeqId: item.orderItemSeqId, //This is needed to map shipment item with order item correctly if multiple order items for the same product are there in the TO.
         productId: item.productId,
         sku: item.internalName,
-        quantity: parseInt(item.pickedQuantity) // Using parseInt to convert to an integer
+        quantity: parseInt(item.pickedQuantity), // Using parseInt to convert to an integer
+        itemSeqId: String(seqIdCounter++).padStart(5, '0') // This is needed to correctly create the shipment package content if multiple order items for the same product are there in the TO.
       }));  
 
       const params = {


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
Fixed: Passed itemSeqId explicitly while creating shipment for the TO to handle the case of multiple order items with the same product. (#579)

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)