### PR TITLE
Improved: Changed the logic and made facility optional on shipped order import(#585)

### DIFF
--- a/src/views/UploadImportOrders.vue
+++ b/src/views/UploadImportOrders.vue
@@ -140,12 +140,20 @@ export default defineComponent({
         return;
       }
 
-      const uploadData = this.content.map((order: any) => ({
-        'orderIdValue': order[this.fieldMapping['orderId'].value],
-        'externalFacilityId': order[this.fieldMapping['facilityId'].value] ? order[this.fieldMapping['facilityId'].value] : this.currentFacility?.facilityId,
-        'trackingNumber': order[this.fieldMapping['trackingCode'].value]
-      }))
-
+      const uploadData = this.content.map((order: any) => {
+        const externalFacilityId = order[this.fieldMapping['facilityId'].value];
+        const data = {
+          'orderIdValue': order[this.fieldMapping['orderId'].value],
+          'trackingNumber': order[this.fieldMapping['trackingCode'].value]
+        } as any;
+        if (externalFacilityId) {
+          data['externalFacilityId'] = externalFacilityId;
+        } else {
+          data['facilityId'] = this.currentFacility?.facilityId;
+        }
+        return data;
+      });
+      
       const fileName = this.file.name.replace(".csv", ".json");
       const params = {
         "configId": "IMP_TRACK_NUM"

--- a/src/views/UploadImportOrders.vue
+++ b/src/views/UploadImportOrders.vue
@@ -95,7 +95,8 @@ export default defineComponent({
   },
   computed: {
     ...mapGetters({
-      fieldMappings: 'user/getFieldMappings'
+      fieldMappings: 'user/getFieldMappings',
+      currentFacility: 'user/getCurrentFacility',
     })
   },
   ionViewDidEnter() {
@@ -141,7 +142,7 @@ export default defineComponent({
 
       const uploadData = this.content.map((order: any) => ({
         'orderIdValue': order[this.fieldMapping['orderId'].value],
-        'externalFacilityId': order[this.fieldMapping['facilityId'].value],
+        'externalFacilityId': order[this.fieldMapping['facilityId'].value] ? order[this.fieldMapping['facilityId'].value] : this.currentFacility?.facilityId,
         'trackingNumber': order[this.fieldMapping['trackingCode'].value]
       }))
 

--- a/src/views/UploadImportOrders.vue
+++ b/src/views/UploadImportOrders.vue
@@ -143,7 +143,7 @@ export default defineComponent({
       const uploadData = this.content.map((order: any) => {
         const externalFacilityId = order[this.fieldMapping['facilityId'].value];
         const data = {
-          'orderIdValue': order[this.fieldMapping['orderId'].value],
+          'orderId': order[this.fieldMapping['orderId'].value],
           'trackingNumber': order[this.fieldMapping['trackingCode'].value]
         } as any;
         if (externalFacilityId) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#585 

### Short Description and Why It's Useful
- Made the facility mapping optional in shipped order import in EXIM feature.
- If user does not select / mapped the externalFacility then payload will contain the selected current logged it facility.
- Replaced the orderIdValue with orderId , to map the orderId submmited by user.


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)