### PR TITLE
Improved: used cursor default over scan order items (#587)

### DIFF
--- a/src/components/ScanOrderItemModal.vue
+++ b/src/components/ScanOrderItemModal.vue
@@ -182,6 +182,10 @@ export default defineComponent({
   --columns-desktop: 2;
 }
 
+.list-item:hover {
+  cursor: default;
+}
+
 ion-label {
   width: 100%;
 }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#587

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Used default cursor instead of pointer cursor on hovering items in scanOrderItem modal.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)