### PR TITLE
Implemented: force scan functionality on packing order from order details page (#612)

### DIFF
--- a/src/components/ScanOrderItemModal.vue
+++ b/src/components/ScanOrderItemModal.vue
@@ -30,6 +30,7 @@
             <ion-label>
               <p class="overline">{{ getProductIdentificationValue(productIdentificationPref.secondaryId, getProduct(item.productId)) }}</p>
               {{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) : item.productName }}
+              <ion-badge color="dark" v-if="isKit(item)">{{ translate("Kit") }}</ion-badge>
               <p>{{ getFeature(getProduct(item.productId).featureHierarchy, '1/COLOR/')}} {{ getFeature(getProduct(item.productId).featureHierarchy, '1/SIZE/')}}</p>
             </ion-label>
           </ion-item>
@@ -73,6 +74,7 @@ import { getProductIdentificationValue, DxpShopifyImg, translate, useProductIden
 import { mapGetters } from 'vuex';
 import { getFeature, showToast } from "@/utils"
 import Scanner from "@/components/Scanner.vue"
+import { isKit } from '@/utils/order'
 
 export default defineComponent({
   name: "ScanOrderItemModal",
@@ -169,6 +171,7 @@ export default defineComponent({
       copyOutline,
       getFeature,
       getProductIdentificationValue,
+      isKit,
       productIdentificationPref,
       saveOutline,
       translate

--- a/src/components/ScanOrderItemModal.vue
+++ b/src/components/ScanOrderItemModal.vue
@@ -107,7 +107,7 @@ export default defineComponent({
   },
   props: ["order"],
   mounted() {
-    this.orderItems = this.order.orderItems.length ? JSON.parse(JSON.stringify(this.order.orderItems)) : []
+    this.orderItems = this.order.items.length ? JSON.parse(JSON.stringify(this.order.items)) : []
   },
   methods: {
     closeModal(payload= {}) {

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -480,7 +480,7 @@ const actions: ActionTree<UtilState, RootState> = {
     try {
       const resp = await UtilService.getProductStoreSetting(payload) as any
       if(!hasError(resp)) {
-        const respValue = resp.data.docs[0].settingValue
+        const respValue = resp.data.docs[0].settingValue === "true" ? true : false
         commit(types.UTIL_FORCE_SCAN_STATUS_UPDATED, respValue)
       } else {
         dispatch('createForceScanSetting');
@@ -552,7 +552,7 @@ const actions: ActionTree<UtilState, RootState> = {
       "fromDate": fromDate,
       "productStoreId": eComStoreId,
       "settingTypeEnumId": "FULFILL_FORCE_SCAN",
-      "settingValue": value
+      "settingValue": `${value}`
     }
 
     try {

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -480,7 +480,7 @@ const actions: ActionTree<UtilState, RootState> = {
     try {
       const resp = await UtilService.getProductStoreSetting(payload) as any
       if(!hasError(resp)) {
-        const respValue = resp.data.docs[0].settingValue === "true" ? true : false
+        const respValue = resp.data.docs[0].settingValue === "true"
         commit(types.UTIL_FORCE_SCAN_STATUS_UPDATED, respValue)
       } else {
         dispatch('createForceScanSetting');

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -183,7 +183,7 @@
 
             <div class="actions">
               <div>
-                <ion-button :disabled="order.hasRejectedItem || order.isModified || order.hasMissingInfo" @click.stop="!isForceScanEnabled ? scanOrder(order) : packOrder(order)">{{ translate("Pack") }}</ion-button>
+                <ion-button :disabled="order.hasRejectedItem || order.isModified || order.hasMissingInfo" @click.stop="isForceScanEnabled ? scanOrder(order) : packOrder(order)">{{ translate("Pack") }}</ion-button>
                 <ion-button :disabled="order.hasMissingInfo" fill="outline" @click.stop="save(order)">{{ translate("Save") }}</ion-button>
               </div>
 

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -174,7 +174,7 @@
 
             <div class="mobile-only">
               <ion-item>
-                <ion-button fill="clear"  :disabled="order.isModified || order.hasMissingInfo" @click.stop="packOrder(order)">{{ translate("Pack using default packaging") }}</ion-button>
+                <ion-button fill="clear"  :disabled="order.isModified || order.hasMissingInfo" @click.stop="isForceScanEnabled ? scanOrder(order) : packOrder(order)">{{ translate("Pack using default packaging") }}</ion-button>
                 <ion-button slot="end" fill="clear" color="medium" @click.stop="packagingPopover">
                   <ion-icon slot="icon-only" :icon="ellipsisVerticalOutline" />
                 </ion-button>
@@ -197,7 +197,7 @@
           </ion-infinite-scroll>
         </div>
       </div>
-      <ion-fab v-if="inProgressOrders.total" class="mobile-only" vertical="bottom" horizontal="end" slot="fixed">
+      <ion-fab v-if="inProgressOrders.total && !isForceScanEnabled" class="mobile-only" vertical="bottom" horizontal="end" slot="fixed">
         <ion-fab-button @click="packOrders()">
           <ion-icon :icon="checkmarkDoneOutline" />
         </ion-fab-button>

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -183,7 +183,7 @@
 
             <div class="actions">
               <div>
-                <ion-button :disabled="order.hasRejectedItem || order.isModified || order.hasMissingInfo" @click.stop="isForceScanEnabled ? scanOrder(order) : packOrder(order)">{{ translate("Pack") }}</ion-button>
+                <ion-button :disabled="order.hasRejectedItem || order.isModified || order.hasMissingInfo" @click.stop="!isForceScanEnabled ? scanOrder(order) : packOrder(order)">{{ translate("Pack") }}</ion-button>
                 <ion-button :disabled="order.hasMissingInfo" fill="outline" @click.stop="save(order)">{{ translate("Save") }}</ion-button>
               </div>
 

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -149,7 +149,7 @@
           
           <div v-if="category === 'in-progress'" class="mobile-only">
             <ion-item>
-              <ion-button fill="clear" :disabled="order.hasMissingInfo" @click="packOrder(order)">{{ translate("Pack using default packaging") }}</ion-button>
+              <ion-button fill="clear" :disabled="order.hasMissingInfo" @click="isForceScanEnabled ? scanOrder(order) :packOrder(order)">{{ translate("Pack using default packaging") }}</ion-button>
               <ion-button slot="end" fill="clear" color="medium" @click="packagingPopover">
                 <ion-icon slot="icon-only" :icon="ellipsisVerticalOutline" />
               </ion-button>
@@ -169,7 +169,7 @@
             <!-- positive -->
             <div>
               <template v-if="category === 'in-progress'">
-                <ion-button :disabled="order.hasRejectedItem || order.isModified || order.hasMissingInfo" @click="packOrder(order)">
+                <ion-button :disabled="order.hasRejectedItem || order.isModified || order.hasMissingInfo" @click="isForceScanEnabled ? scanOrder(order) : packOrder(order)">
                   <ion-icon slot="start" :icon="personAddOutline" />
                   {{ translate("Pack order") }}
                 </ion-button>
@@ -347,6 +347,7 @@ import ShipmentBoxPopover from '@/components/ShipmentBoxPopover.vue'
 import ReportIssuePopover from '@/components/ReportIssuePopover.vue'
 import ShippingDetails from '@/views/ShippingDetails.vue';
 import { isKit } from '@/utils/order'
+import ScanOrderItemModal from "@/components/ScanOrderItemModal.vue";
 
 export default defineComponent({
   name: "OrderDetail",
@@ -393,7 +394,8 @@ export default defineComponent({
       getPaymentMethodDesc: 'util/getPaymentMethodDesc',
       getStatusDesc: 'util/getStatusDesc',
       productStoreShipmentMethCount: 'util/getProductStoreShipmentMethCount',
-      partialOrderRejectionConfig: 'user/getPartialOrderRejectionConfig'
+      partialOrderRejectionConfig: 'user/getPartialOrderRejectionConfig',
+      isForceScanEnabled: 'util/isForceScanEnabled',
     })
   },
   data() {
@@ -1287,6 +1289,20 @@ export default defineComponent({
     },
     isTrackingRequiredForAnyShipmentPackage(order: any) {
       return order.shipmentPackages?.some((shipmentPackage: any) => shipmentPackage.isTrackingRequired === 'Y')
+    },
+    async scanOrder(order: any) {
+      const modal = await modalController.create({
+        component: ScanOrderItemModal,
+        componentProps: { order }
+      })
+
+      modal.onDidDismiss().then((result: any) => {
+        if(result.data?.packOrder) {
+          this.packOrder(order);
+        }
+      })
+
+      modal.present();
     }
   },
   setup() {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#612

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Added force scan functionality on packing order from order details page.
- Fixed force scan setting type dataType while getting and setting setting value.
- Used items instead of OrderItems from the current order.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)