### PR TITLE
Fixed: issue of shipped qty not visible for some items in the TransferOrder

### DIFF
--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -49,21 +49,38 @@ const fetchOrderItems = async (orderId: string): Promise<any> => {
 }
 
 const fetchShippedQuantity = async (orderId: string): Promise<any> => {
-  const params = {
-    "entityName": "ShippedItemQuantitySum",
-    "inputFields": {
-      "orderId": orderId,
-    },
-    "fieldList": ["orderId", "orderItemSeqId", "productId", "shippedQuantity"],
-    "viewSize": 250,  // maximum records we could have
-    "distinct": "Y"
-  } as any;
+  let docCount = 0;
+  let shippedItemQuantitySum = [] as any
+  let viewIndex = 0;
 
-  return await api({
-    url: "performFind",
-    method: "get",
-    params
-  })
+  do {
+    const params = {
+      "entityName": "ShippedItemQuantitySum",
+      "inputFields": {
+        "orderId": orderId,
+      },
+      "fieldList": ["orderId", "orderItemSeqId", "productId", "shippedQuantity"],
+      "viewSize": 250,  // maximum records we could have
+      "distinct": "Y",
+      viewIndex
+    } as any;
+
+    const resp = await api({
+      url: "performFind",
+      method: "get",
+      params
+    }) as any
+
+    if (!hasError(resp) && resp.data.count) {
+      shippedItemQuantitySum = [...shippedItemQuantitySum, ...resp.data.docs]
+      docCount = resp.data.docs.length;
+      viewIndex++;
+    } else {
+      docCount = 0
+    }
+  } while(docCount >= 250);
+
+  return shippedItemQuantitySum;
 }
 
 const fetchShipmentItems = async (orderId: string, shipmentId: string): Promise<any> => {

--- a/src/store/modules/transferorder/actions.ts
+++ b/src/store/modules/transferorder/actions.ts
@@ -110,13 +110,11 @@ const actions: ActionTree<TransferOrderState, RootState> = {
           //fetch shipped quantity
           const shippedQuantityInfo = {} as any;
           resp = await OrderService.fetchShippedQuantity(payload.orderId);
-          if (!hasError(resp)) {
-            resp.data.docs.forEach((doc:any) => {
-              shippedQuantityInfo[doc.orderItemSeqId] = doc.shippedQuantity;
-            });
-            orderDetail.shippedQuantityInfo = shippedQuantityInfo;
-          }
-  
+          resp.forEach((doc:any) => {
+            shippedQuantityInfo[doc.orderItemSeqId] = doc.shippedQuantity;
+          });
+          orderDetail.shippedQuantityInfo = shippedQuantityInfo;
+
           //fetch product details
           const productIds = [...new Set(orderDetail.items.map((item:any) => item.productId))];
   


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
For a TransferOrder having a lot of items, the shipped qty for some items are not displayed, as we were only fetching specific number of records due to which after a specific limit the items shipped qty is not fetched.
#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added check to identify the number of records fetched and the total number of records in the database and made the api call until all the records are not fetched

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)