### PR TITLE
 Fixed: Prevented the multiple clicks on 'Reject all' button during rejection process(#524)

### DIFF
--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -10,7 +10,7 @@
         <ion-title v-else>{{ inProgressOrders.query.viewSize }} {{ translate('of') }} {{ inProgressOrders.total }} {{ translate('orders') }}</ion-title>
 
         <ion-buttons slot="end">
-          <ion-button :disabled="!hasPermission(Actions.APP_RECYCLE_ORDER) || !inProgressOrders.total" fill="clear" color="danger" @click="recycleInProgressOrders()">
+          <ion-button :disabled="!hasPermission(Actions.APP_RECYCLE_ORDER) || !inProgressOrders.total || isRejecting" fill="clear" color="danger" @click="recycleInProgressOrders()">
             {{ translate("Reject all") }}
           </ion-button>
           <ion-menu-button menu="view-size-selector-inprogress" :disabled="!inProgressOrders.total">
@@ -364,6 +364,7 @@ export default defineComponent({
       addingBoxForOrderIds: [] as any,
       selectedPicklistId: '',
       isScrollingEnabled: false,
+      isRejecting: false,
       rejectEntireOrderReasonId: 'REJECT_ENTIRE_ORDER'
     }
   },
@@ -1120,6 +1121,7 @@ export default defineComponent({
         }, {
           text: translate('Reject'),
           handler: async () => {
+            this.isRejecting = true;
             emitter.emit("presentLoader")  
             await alert.dismiss()  
 

--- a/src/views/OpenOrders.vue
+++ b/src/views/OpenOrders.vue
@@ -12,7 +12,7 @@
           <ion-button @click="viewNotifications()">
             <ion-icon slot="icon-only" :icon="notificationsOutline" :color="(unreadNotificationsStatus && notifications.length) ? 'primary' : ''" />
           </ion-button>
-          <ion-button :disabled="!hasPermission(Actions.APP_RECYCLE_ORDER) || !openOrders.total" fill="clear" color="danger" @click="recycleOutstandingOrders()">
+          <ion-button :disabled="!hasPermission(Actions.APP_RECYCLE_ORDER) || !openOrders.total || isRejecting" fill="clear" color="danger" @click="recycleOutstandingOrders()">
             {{ translate("Reject all") }}
           </ion-button>
           <ion-menu-button menu="view-size-selector-open" :disabled="!openOrders.total">
@@ -229,7 +229,8 @@ export default defineComponent({
     return {
       shipmentMethods: [] as Array<any>,
       searchedQuery: '',
-      isScrollingEnabled: false
+      isScrollingEnabled: false,
+      isRejecting: false
     }
   },
   async ionViewWillEnter() {
@@ -374,6 +375,7 @@ export default defineComponent({
         }, {
           text: translate('Reject'),
           handler: async () => {
+            this.isRejecting = true;
             emitter.emit("presentLoader")
             await alert.dismiss()
             


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#524 

### Short Description and Why It's Useful
- Set `isRejecting` to true in `recycleOutstandingOrders` to keep the "Reject all" button disabled during the rejection process.
- The `isRejecting` flag resets to false on page refresh, re-enabling the button for the next session.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)