### PR TITLE
Improved: added support for enum creation in case force scan setting enum not exists (#612)

### DIFF
--- a/src/services/UtilService.ts
+++ b/src/services/UtilService.ts
@@ -449,6 +449,31 @@ const getProductStoreSetting = async (payload: any): Promise<any> => {
   });
 }
 
+const isEnumExists = async (enumId: string): Promise<any> => {
+  try {
+    const resp = await api({
+      url: 'performFind',
+      method: 'POST',
+      data: {
+        entityName: "Enumeration",
+        inputFields: {
+          enumId
+        },
+        viewSize: 1,
+        fieldList: ["enumId"],
+        noConditionFind: 'Y'
+      }
+    }) as any
+
+    if (!hasError(resp) && resp.data.docs.length) {
+      return true
+    }
+    return false
+  } catch (err) {
+    return false
+  }
+}
+
 export const UtilService = {
   createForceScanSetting,
   createPicklist,
@@ -479,6 +504,7 @@ export const UtilService = {
   fetchTransferOrderFacets,
   getAvailablePickers,
   getProductStoreSetting,
+  isEnumExists,
   resetPicker,
   deleteEnumeration,
   updateEnumeration,

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -487,6 +487,7 @@ const actions: ActionTree<UtilState, RootState> = {
       }
     } catch(err) {
       console.error(err)
+      commit(types.UTIL_FORCE_SCAN_STATUS_UPDATED, "false")
     }
   },
 
@@ -531,6 +532,13 @@ const actions: ActionTree<UtilState, RootState> = {
     let prefValue = state.isForceScanEnabled
     const eComStoreId = store.getters['user/getCurrentEComStore'].productStoreId;
 
+    // when selecting none as ecom store, not updating the pref as it's not possible to save pref with empty productStoreId
+    if(!eComStoreId) {
+      showToast(translate("Unable to update force scan preference."))
+      commit(types.UTIL_FORCE_SCAN_STATUS_UPDATED, prefValue)
+      return;
+    }
+
     let fromDate;
 
     try {
@@ -549,13 +557,6 @@ const actions: ActionTree<UtilState, RootState> = {
       }
     } catch(err) {
       console.error(err)
-    }
-
-    // when selecting none as ecom store, not updating the pref as it's not possible to save pref with empty productStoreId
-    if(!eComStoreId) {
-      showToast(translate("Unable to update force scan preference."))
-      commit(types.UTIL_FORCE_SCAN_STATUS_UPDATED, prefValue)
-      return;
     }
 
     if(!fromDate) {

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -494,14 +494,28 @@ const actions: ActionTree<UtilState, RootState> = {
     const ecomStore = store.getters['user/getCurrentEComStore'];
     const fromDate = Date.now()
 
-    const params = {
-      fromDate,
-      "productStoreId": ecomStore.productStoreId,
-      "settingTypeEnumId": "FULFILL_FORCE_SCAN",
-      "settingValue": false
-    }
-
     try {
+      if(!await UtilService.isEnumExists("FULFILL_FORCE_SCAN")) {
+        const resp = await UtilService.createEnumeration({
+          "enumId": "FULFILL_FORCE_SCAN",
+          "enumTypeId": "PROD_STR_STNG",
+          "description": "Impose force scanning of items while packing from fulfillment app",
+          "enumName": "Fulfillment Force Scan",
+          "enumCode": "FULFILL_FORCE_SCAN"
+        })
+
+        if(hasError(resp)) {
+          throw resp.data;
+        }
+      }
+
+      const params = {
+        fromDate,
+        "productStoreId": ecomStore.productStoreId,
+        "settingTypeEnumId": "FULFILL_FORCE_SCAN",
+        "settingValue": "false"
+      }
+
       await UtilService.createForceScanSetting(params) as any
     } catch(err) {
       console.error(err)


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#612

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improved logic for force scan setting creation to create enumeration for it if not exists already.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)