### PR TITLE
Improved: returning the modal presentation on edit rejection reason modal opening (#629)

### DIFF
--- a/src/components/RejectReasonActionsPopver.vue
+++ b/src/components/RejectReasonActionsPopver.vue
@@ -59,7 +59,7 @@ export default defineComponent({
         popoverController.dismiss()
       })
 
-      editRejectionReasonModal.present()
+      return editRejectionReasonModal.present()
     },
     async removeRejectionReason() {
       const alert = await alertController.create({


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#629

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Returning modal.present() on opening rejection Reason modal

### Additional Information
The issue is intermittent and reproduces randomly, making it challenging to pinpoint exact steps or identify the root cause. While troubleshooting, I discovered a potential fix related to modal opening behavior and have implemented this in the current pull request. However, it remains uncertain if this change will fully resolve the issue.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)