### PR TITLE
Improved: check for empty state in Inprogress orders (#612)

### DIFF
--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -487,7 +487,7 @@ const actions: ActionTree<UtilState, RootState> = {
       }
     } catch(err) {
       console.error(err)
-      commit(types.UTIL_FORCE_SCAN_STATUS_UPDATED, "false")
+      commit(types.UTIL_FORCE_SCAN_STATUS_UPDATED, false)
     }
   },
 

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -197,11 +197,13 @@
           </ion-infinite-scroll>
         </div>
       </div>
-      <ion-fab v-if="inProgressOrders.total && !isForceScanEnabled" class="mobile-only" vertical="bottom" horizontal="end" slot="fixed">
-        <ion-fab-button @click="packOrders()">
-          <ion-icon :icon="checkmarkDoneOutline" />
-        </ion-fab-button>
-      </ion-fab>
+      <template v-if="inProgressOrders.total">
+        <ion-fab v-if="!isForceScanEnabled" class="mobile-only" vertical="bottom" horizontal="end" slot="fixed">
+          <ion-fab-button @click="packOrders()">
+            <ion-icon :icon="checkmarkDoneOutline" />
+          </ion-fab-button>
+        </ion-fab>
+      </template>
       <div class="empty-state" v-else>
         <p v-html="getErrorMessage()"></p>
       </div>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#612

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Updated the check of empty state in Inprogress orders page.
- Updated the forceScan setting getting saved to state on api failure.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)