### PR TITLE
Fixed: lifecycle hooks used to fetching and clearing transfer orders (#669)

### DIFF
--- a/src/views/TransferOrders.vue
+++ b/src/views/TransferOrders.vue
@@ -113,6 +113,7 @@ export default defineComponent({
   },
   async ionViewWillEnter() {
     this.isScrollingEnabled = false;
+    await this.initialiseTransferOrderQuery();
   },
   methods: {
     getErrorMessage() {
@@ -162,10 +163,7 @@ export default defineComponent({
       this.router.push({ path: `/transfer-order-details/${order.orderId}` })
     },
   },
-  async mounted () {
-    await this.initialiseTransferOrderQuery();
-  },
-  unmounted() {
+  ionViewDidLeave() {
     this.store.dispatch('transferorder/clearTransferOrders');
   },
   setup() {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#669

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Use "ionViewWillEnter" instead of "onMounted" because the app caches and deactivates pages on route changes, reactivating them when needed.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)