### PR TITLE
Improved: logic for updating product count on scanning in transfer order details page (#670)

### DIFF
--- a/src/store/modules/transferorder/actions.ts
+++ b/src/store/modules/transferorder/actions.ts
@@ -276,6 +276,8 @@ const actions: ActionTree<TransferOrderState, RootState> = {
   },
 
   async updateOrderProductCount({ commit, state }, payload ) {
+    // When there exists multiple line item for a single product, then may arise discrepancy in scanning
+    // since some items might be completed and some pending. Hence searching is done with status check.
     const item = state.current.items.find((item: any) => (item.internalName === payload && item.statusId !== 'ITEM_COMPLETED' && item.statusId !== 'ITEM_REJECTED'));
     if(item){
       item.pickedQuantity = parseInt(item.pickedQuantity) + 1;
@@ -283,7 +285,7 @@ const actions: ActionTree<TransferOrderState, RootState> = {
       return { isProductFound: true, orderItem: item }
     }
 
-    const completedItem = state.current.items.find((item: any) => item.internalName === payload && item.statusId === 'ITEM_COMPLETED');
+    const completedItem = state.current.items.some((item: any) => item.internalName === payload && item.statusId === 'ITEM_COMPLETED');
     if(completedItem) {
       return { isCompleted: true }
     }

--- a/src/store/modules/transferorder/actions.ts
+++ b/src/store/modules/transferorder/actions.ts
@@ -276,14 +276,18 @@ const actions: ActionTree<TransferOrderState, RootState> = {
   },
 
   async updateOrderProductCount({ commit, state }, payload ) {
-    const item = state.current.items.find((item: any) => item.internalName === payload);
+    const item = state.current.items.find((item: any) => (item.internalName === payload && item.statusId !== 'ITEM_COMPLETED' && item.statusId !== 'ITEM_REJECTED'));
     if(item){
-      if(item.statusId === 'ITEM_COMPLETED') 
-      return { isCompleted: true }
       item.pickedQuantity = parseInt(item.pickedQuantity) + 1;
       commit(types.ORDER_CURRENT_UPDATED, state.current )
       return { isProductFound: true, orderItem: item }
     }
+
+    const completedItem = state.current.items.find((item: any) => item.internalName === payload && item.statusId === 'ITEM_COMPLETED');
+    if(completedItem) {
+      return { isCompleted: true }
+    }
+
     return { isProductFound: false }
   },
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#670

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improved logic for handling the case when same product is available in both completed and pending orders.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)