### PR TITLE
Improved: Handled the case to keep the carrier and shipment method type to the original one if changing carrier/method returns error (#681).

### DIFF
--- a/src/components/ShippingLabelActionPopover.vue
+++ b/src/components/ShippingLabelActionPopover.vue
@@ -69,12 +69,11 @@
               "shipmentRouteSegmentId": shipmentPackage.shipmentRouteSegmentId,
               "shipmentPackageSeqId": shipmentPackage.shipmentPackageSeqId,
               "trackingCode": "",
-              "labelImage": null,
-              "labelIntlSignImage": null,
+              "labelImage": "",
+              "labelIntlSignImage": "",
               "labelHtml": "",
               "labelImageUrl": "",
               "internationalInvoiceUrl": ""
-
             });
             if (!hasError(resp)) {
               resp = await OrderService.updateShipmentRouteSegment({

--- a/src/views/ShippingDetails.vue
+++ b/src/views/ShippingDetails.vue
@@ -181,6 +181,9 @@ export default defineComponent({
           throw resp.data;
         }
       } catch (err) {
+        this.carrierPartyId = this.currentOrder.shipmentPackages?.[0].carrierPartyId;
+        this.shipmentMethodTypeId = this.currentOrder.shipmentPackages?.[0].shipmentMethodTypeId;
+
         logger.error('Failed to update carrier and method', err);
         showToast(translate("Failed to update shipment method detail."));
       }


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
Improved: Handled the case to keep the carrier and shipment method type to the original one if changing carrier/method returns error (#681).

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)