### PR TITLE
Fixed: entire order rejection not working in case of multiple shipments in an order (#572)

### DIFF
--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -761,6 +761,19 @@ export default defineComponent({
           form.append(`${index}_${prefix}_rowSubmit_`, ''+index)
         }
       })
+      if (this.isEntierOrderRejectionEnabled(order)) {
+        const shipmentIds = rejectedOrderItems.map((item:any) => item.shipmentId);
+        items.map((item: any) => {
+          if (!shipmentIds.includes(item.shipmentId)) {
+            rejectedOrderItems.push({
+              "shipmentId": item.shipmentId,
+              "shipmentItemSeqId": item.shipmentItemSeqId,
+              "reason": this.rejectEntireOrderReasonId
+            })
+            shipmentIds.push(item.shipmentId)
+          }
+        })
+      }
 
       form.append('picklistBinId', order.picklistBinId)
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#572

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
In case of entire rejection order, all the shipment should be rejected if exists multiple shipment in an order.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)