### PR TITLE
Fixed: tracking code label disappearing after shipping label generation of transfer order item (#676)

### DIFF
--- a/src/views/TransferShipmentReview.vue
+++ b/src/views/TransferShipmentReview.vue
@@ -27,7 +27,10 @@
               </ion-item>
               <ion-item>
                 <ion-input :label="translate('Tracking Code')" placeholder="add tracking code" v-if="!currentShipment.trackingCode" v-model="trackingCode"></ion-input>
-                <p v-else slot="end">{{ currentShipment.trackingCode }}</p>
+                <template v-else>
+                  <ion-label>{{ translate("Tracking Code") }}</ion-label>
+                  <p slot="end">{{ currentShipment.trackingCode }}</p>
+                </template>
               </ion-item>
               <ion-item>
                 <ion-label>{{ translate('Carrier') }}</ion-label>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#676

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improve to code to fix the tracking code label disappearing when shipping label generated successfully.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)