### PR TITLE
Fixed: discrepancy in order count and display when applying filters in transfer order section (#675)

### DIFF
--- a/src/components/TransferOrderFilters.vue
+++ b/src/components/TransferOrderFilters.vue
@@ -113,6 +113,8 @@ export default defineComponent({
         }
         transferOrdersQuery.selectedStatuses = selectedStatuses
       }
+
+      transferOrdersQuery.viewIndex = 0;
       await this.store.dispatch('transferorder/updateTransferOrderQuery', { ...transferOrdersQuery })
     },
     async fetchFilters() {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#675

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Reseting the viewIndex for fetching transfer orders whenever we change the filters for fetching.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)