### PR TITLE
Improved: added a flag for generation of label when hitting retryShippingLabel (#745)

### DIFF
--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -634,7 +634,8 @@ const retryShippingLabel = async (shipmentIds: Array<string>, forceRateShop = fa
     url: 'retryShippingLabel',  // TODO: update the api
     data: {
       shipmentIds,
-      forceRateShop: forceRateShop ? 'Y' : 'N'
+      forceRateShop: forceRateShop ? 'Y' : 'N',
+      generateLabel: "Y" // This is needed to generate label after the new changes in backend related to auto generation of label.
     }
   })
 }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#745

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Sending 'generateLabel' flag for generating shipping label when retryShippingLabel is hit. To handle the changes in backend.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)