### PR TITLE
Improved: fetching transfer order shipment detail before retrying (#745)

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -176,7 +176,8 @@ const isValidCarrierCode = (trackingCode : any) => {
 }
 
 const  isPdf = (url: any) => {
-  return url && url.toLowerCase().endsWith('.pdf');
+  const pdfUrlPattern = /\.pdf(\?.*)?$/;
+  return url && pdfUrlPattern.test(url.toLowerCase());
 }
 
 const currentSymbol: any = {

--- a/src/views/TransferShipmentReview.vue
+++ b/src/views/TransferShipmentReview.vue
@@ -201,15 +201,16 @@
           return;
         }
 
+        await this.store.dispatch('transferorder/fetchTransferShipmentDetail', { shipmentId: this.$route.params.shipmentId })
         currentShipment.isGeneratingShippingLabel = true;
-        let shippingLabelPdfUrls = currentShipment.shipmentPackages
+        let shippingLabelPdfUrls = this.currentShipment.shipmentPackages
           ?.filter((shipmentPackage: any) => shipmentPackage.labelPdfUrl)
           .map((shipmentPackage: any) => shipmentPackage.labelPdfUrl);
         
 
-        if (!currentShipment.trackingCode) {
+        if (!this.currentShipment.trackingCode) {
           //regenerate shipping label if missing tracking code
-          const resp = await OrderService.retryShippingLabel([currentShipment.shipmentId])
+          const resp = await OrderService.retryShippingLabel([this.currentShipment.shipmentId])
           if (!hasError(resp)) {
             this.showLabelError = false;
             showToast(translate("Shipping Label generated successfully"))
@@ -220,8 +221,7 @@
                 ?.filter((shipmentPackage: any) => shipmentPackage.labelPdfUrl)
                 .map((shipmentPackage: any) => shipmentPackage.labelPdfUrl);
 
-            await OrderService.printShippingLabel([currentShipment.shipmentId], shippingLabelPdfUrls)
-            await this.store.dispatch('transferorder/fetchTransferShipmentDetail', { shipmentId: this.$route.params.shipmentId })
+            await OrderService.printShippingLabel([this.currentShipment.shipmentId], shippingLabelPdfUrls)
           } else {
             this.showLabelError = true;
             showToast(translate("Failed to generate shipping label"))
@@ -229,7 +229,7 @@
         } else {
           this.showLabelError = false;
           //print shipping label if label already exists
-          await OrderService.printShippingLabel([currentShipment.shipmentId], shippingLabelPdfUrls)
+          await OrderService.printShippingLabel([this.currentShipment.shipmentId], shippingLabelPdfUrls)
         }
 
         currentShipment.isGeneratingShippingLabel = false;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#745

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Refetching TO shipment detail before retrying shipping label for avoid overhead.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)