### PR TITLE
Improved: removed the generate label button from the shipment card for in-progress orders (#751)

### DIFF
--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -268,12 +268,12 @@
                 <ion-button :disabled="!shipmentMethodTypeId || !carrierPartyId" fill="clear" expand="block" color="medium" @click="openTrackingCodeModal()">
                   {{ translate("Add tracking code manually") }}
                 </ion-button>
-                <ion-item lines="none" v-if="shipmentLabelErrorMessages">
-                  <ion-label class="ion-text-wrap">
-                    {{ shipmentLabelErrorMessages }}
-                  </ion-label>
-                </ion-item>
               </template>
+              <ion-item lines="none" v-if="shipmentLabelErrorMessages">
+                <ion-label class="ion-text-wrap">
+                  {{ shipmentLabelErrorMessages }}
+                </ion-label>
+              </ion-item>
             </template>
             <ion-item v-else>
               <ion-label>

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -260,18 +260,20 @@
               </template>
             </ion-item>
             <template v-if="order.missingLabelImage">
-              <ion-button :disabled="!shipmentMethodTypeId" fill="outline" expand="block" class="ion-margin" @click.stop="regenerateShippingLabel(order)">
-                {{ shipmentLabelErrorMessages ? translate("Retry Label") : translate("Generate Label") }}
-                <ion-spinner color="primary" slot="end" data-spinner-size="medium" v-if="order.isGeneratingShippingLabel" name="crescent" />
-              </ion-button>
-              <ion-button :disabled="!shipmentMethodTypeId || !carrierPartyId" fill="clear" expand="block" color="medium" @click="openTrackingCodeModal()">
-                {{ translate("Add tracking code manually") }}
-              </ion-button>
-              <ion-item lines="none" v-if="shipmentLabelErrorMessages">
-                <ion-label class="ion-text-wrap">
-                  {{ shipmentLabelErrorMessages }}
-                </ion-label>
-              </ion-item>
+              <template v-if="category === 'completed'">
+                <ion-button :disabled="!shipmentMethodTypeId" fill="outline" expand="block" class="ion-margin" @click.stop="regenerateShippingLabel(order)">
+                  {{ shipmentLabelErrorMessages ? translate("Retry Label") : translate("Generate Label") }}
+                  <ion-spinner color="primary" slot="end" data-spinner-size="medium" v-if="order.isGeneratingShippingLabel" name="crescent" />
+                </ion-button>
+                <ion-button :disabled="!shipmentMethodTypeId || !carrierPartyId" fill="clear" expand="block" color="medium" @click="openTrackingCodeModal()">
+                  {{ translate("Add tracking code manually") }}
+                </ion-button>
+                <ion-item lines="none" v-if="shipmentLabelErrorMessages">
+                  <ion-label class="ion-text-wrap">
+                    {{ shipmentLabelErrorMessages }}
+                  </ion-label>
+                </ion-item>
+              </template>
             </template>
             <ion-item v-else>
               <ion-label>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#751

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Removed the generate label button and custom tracking code button from the shipment details card for the in-progress orders.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before
![Screenshot from 2024-09-12 16-25-25](https://github.com/user-attachments/assets/53db33ea-c765-4e06-ae51-2746ba6a4778)

After
![Screenshot from 2024-09-12 16-25-11](https://github.com/user-attachments/assets/87f59060-a2d8-445e-b0fa-bb8fc1b77cab)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)