### PR TITLE
Fixed: tracking code for the cancelled shipment showing on OrderLookUp page (#782)

### DIFF
--- a/src/store/modules/orderLookup/actions.ts
+++ b/src/store/modules/orderLookup/actions.ts
@@ -196,7 +196,9 @@ const actions: ActionTree<OrderLookupState, RootState> = {
         entityName: "OrderItemShipGroupAndFacility"
       }, {
         inputFields: {
-          orderId
+          orderId,
+          shipmentStatusId: "SHIPMENT_INPUT",
+          shipmentStatusId_op: "notEqual"
         },
         fieldList: ["orderId", "shipGroupSeqId", "shipmentId", "trackingIdNumber"],
         viewSize: 50,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#782

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added a filter to not fetch shipment in shipment input status to avoid invalid tracking code.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)