### PR TITLE
Improved: disabling save button in tracking code modal in case of no shipment methods and sorted order payment preferences in descending order of created date (#805)

### DIFF
--- a/src/components/GenerateTrackingCodeModal.vue
+++ b/src/components/GenerateTrackingCodeModal.vue
@@ -55,7 +55,7 @@
   </ion-content>
 
   <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-    <ion-fab-button :disabled="isGeneratingShippingLabel ? true : isTrackingRequired ? !shipmentMethodTypeId : false" @click="confirmSave()">
+    <ion-fab-button :disabled="isGeneratingShippingLabel ? true : !shipmentMethodTypeId" @click="confirmSave()">
       <ion-icon :icon="isForceScanEnabled ? barcodeOutline : saveOutline" />
     </ion-fab-button>
   </ion-fab>

--- a/src/store/modules/orderLookup/actions.ts
+++ b/src/store/modules/orderLookup/actions.ts
@@ -185,6 +185,7 @@ const actions: ActionTree<OrderLookupState, RootState> = {
           statusId: "PAYMENT_CANCELLED",
           statusId_op: "notEqual"
         },
+        orderBy: "createdDate DESC",
         viewSize: 50,
         fieldList: ["paymentMethodTypeId", "maxAmount", "statusId"],
         entityName: "OrderPaymentPreference"


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#805

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Disabled save button in case of no shipment methods available for an carrier in tracking code modal while packing.
- Sorted order payment pref in descending order of createdDate in orderLookup page.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)