### PR TITLE
Improved: show message on login error page on no product store, dismissing loader and not changing facility on no store for new facility (#807)

### DIFF
--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -85,12 +85,12 @@ const recycleOutstandingOrders = async(payload: any): Promise<any> => {
   })
 }
 
-const getEComStores = async (token: any, facilityId: any): Promise<any> => {
+const getEComStores = async (token: any,  facility: any): Promise<any> => {
   try {
     const params = {
       "inputFields": {
         "storeName_op": "not-empty",
-        facilityId
+        facilityId: facility.facilityId
       },
       "fieldList": ["productStoreId", "storeName"],
       "entityName": "ProductStoreFacilityDetail",
@@ -110,12 +110,21 @@ const getEComStores = async (token: any, facilityId: any): Promise<any> => {
       }
     });
     if (hasError(resp)) {
-      return Promise.reject(resp.data);
+      // Following promise reject pattern as OMS api, to show error message on the login page.
+      return Promise.reject({
+        code: 'error',
+        message: `Failed to fetch product stores for ${facility.facilityName} facility.`,
+        serverResponse: resp.data
+      })
     } else {
       return Promise.resolve(resp.data.docs);
     }
   } catch(error: any) {
-    return Promise.reject(error)
+    return Promise.reject({
+      code: 'error',
+      message: 'Something went wrong',
+      serverResponse: error
+    })
   }
 }
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#807

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Showing error message on login error screen in case of no product store available for user current facility.
- Dismissing loader and not changing facility when new facility don't have any product store associated.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)