### PR TITLE
Fixed: tracking url not coming on the order lookup page (#777)

### DIFF
--- a/src/components/OrderLookupLabelActionsPopover.vue
+++ b/src/components/OrderLookupLabelActionsPopover.vue
@@ -2,7 +2,7 @@
   <ion-content>
     <ion-list>
       <ion-list-header>{{ currentOrder.shipGroups[shipGroupSeqId][0]?.trackingIdNumber }}</ion-list-header>
-      <ion-item button :disabled="getCarriersTrackingInfo(carrierPartyId)?.trackingUrl" @click="redirectToTrackingUrl()">
+      <ion-item button :disabled="!getCarriersTrackingInfo(carrierPartyId)?.trackingUrl" @click="redirectToTrackingUrl()">
         {{ getCarriersTrackingInfo(carrierPartyId)?.carrierName ? getCarriersTrackingInfo(carrierPartyId).carrierName : carrierPartyId }}
         <ion-icon slot="end" :icon="openOutline" />
       </ion-item>
@@ -61,7 +61,7 @@ export default defineComponent({
     },
 
     redirectToTrackingUrl() {
-      const trackingUrl = this.getCarriersTrackingInfo(this.carrierPartyId)
+      const trackingUrl = this.getCarriersTrackingInfo(this.carrierPartyId)?.trackingUrl
       const trackingCode = this.currentOrder.shipGroups[this.shipGroupSeqId][0]?.trackingIdNumber
       window.open(trackingUrl.replace("${trackingNumber}", trackingCode), "_blank");
       popoverController.dismiss()

--- a/src/store/modules/orderLookup/actions.ts
+++ b/src/store/modules/orderLookup/actions.ts
@@ -119,7 +119,7 @@ const actions: ActionTree<OrderLookupState, RootState> = {
     carrierPartyIds.map((partyId: any) => {
       carriersTrackingInfo[partyId] = {
         carrierName: store.getters["util/getPartyName"](partyId),
-        trackingUrl: systemProperties[partyId.toUpperCase()]?.trackingUrl ? systemProperties[partyId.toUpperCase()].trackingUrl : ""
+        trackingUrl: systemProperties[partyId.toUpperCase()] ? systemProperties[partyId.toUpperCase()] : ""
       }
     })
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#777

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed the logic to fetch and redirect to trackingUrl in the orderlookup page.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)