### PR TITLE
Improved: Changed the save ion-button to default on import shipped orders csv page(#477)

### DIFF
--- a/src/views/UploadImportOrders.vue
+++ b/src/views/UploadImportOrders.vue
@@ -39,7 +39,7 @@
           </ion-item>
         </ion-list>
 
-        <ion-button :disabled="!content.length" color="medium" @click="save" expand="block">
+        <ion-button :disabled="!content.length" @click="save" expand="block">
           {{ translate("Save") }}
         </ion-button>
 


### PR DESCRIPTION
### 
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#477

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Removed the `color="medium"` attribute from the ion-button on the Import Shipped Orders page and set it to the default color.
### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/ea932a06-7cdc-4b46-b577-a573c44bb308)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)