### PR TITLE
Improved: clearing the input on successfully scanning an item in scanOrderItem modal (#845)

### DIFF
--- a/src/components/ScanOrderItemModal.vue
+++ b/src/components/ScanOrderItemModal.vue
@@ -155,6 +155,7 @@ export default defineComponent({
       } else {
         showToast(translate((currentItem.productSku ? "Product is already received:" : "Scanned item is not present within the shipment:"), { itemName: payload }))
       }
+      this.queryString = ''
     },
     areAllItemsSelected() {
       return !this.orderItems.some((item: any) => !item.isChecked)


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#845

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Clearing the input query string on successfully scanning an item in scanOrderItem modal.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)