### PR TITLE
Fixed: Boxes Added on Detail Page Not Displayed on Order List Page (#838).

### DIFF
--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -1135,6 +1135,7 @@ export default defineComponent({
         if(!hasError(resp)) {
           showToast(translate('Box added successfully'))
           await this.store.dispatch('order/getInProgressOrder', { orderId: this.orderId, shipGroupSeqId: this.shipGroupSeqId, isModified: true })
+          this.store.dispatch('order/updateInProgressOrder', this.order);
         } else {
           throw resp.data
         }


### PR DESCRIPTION

### Related Issues
#838 
#

### Short Description and Why It's Useful
Fixed: Updated the in progress order list on adding new shipment box from order detail page in order to fix the issue where box added from order detail page was not appears on the list page on clicking back button (#838).

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)