### PR TITLE
Improved: Show TO filters if the facet has orders; disable if none.(#673)

### DIFF
--- a/src/components/TransferOrderFilters.vue
+++ b/src/components/TransferOrderFilters.vue
@@ -49,10 +49,6 @@ import {
 import { defineComponent, computed } from "vue";
 import { albumsOutline, banOutline, barChartOutline, calendarNumberOutline, checkmarkDoneOutline, closeOutline, filterOutline, iceCreamOutline, libraryOutline, pulseOutline, settings, shirtOutline, ticketOutline } from "ionicons/icons";
 import { mapGetters, useStore } from 'vuex'
-import { escapeSolrSpecialChars, prepareOrderQuery } from '@/utils/solrHelper';
-import { UtilService } from '@/services/UtilService';
-import { hasError } from '@/adapter';
-import logger from '@/logger';
 import { translate, useUserStore } from '@hotwax/dxp-components';
 
 export default defineComponent({
@@ -68,23 +64,13 @@ export default defineComponent({
     IonTitle,
     IonToolbar
   },
-  props: ["queryString"],
-  data () {
-    return {
-      shipmentMethods: [] as Array<any>,
-      statuses: [] as Array<any>
-    }
-  },
+  props: ["queryString", "shipmentMethods", "statuses"],
   computed: {
     ...mapGetters({
       transferOrders: 'transferorder/getTransferOrders',
       getStatusDesc: 'util/getStatusDesc',
       getShipmentMethodDesc: 'util/getShipmentMethodDesc',
-      currentEComStore: 'user/getCurrentEComStore',
     })
-  },
-  async mounted() {
-    await this.fetchFilters();
   },
   unmounted() {
     this.store.dispatch('transferorder/clearTransferOrderFilters');
@@ -115,58 +101,6 @@ export default defineComponent({
 
       transferOrdersQuery.viewIndex = 0;
       await this.store.dispatch('transferorder/updateTransferOrderQuery', { ...transferOrdersQuery })
-    },
-    async fetchFilters() {
-      let resp: any;
-      const payload = prepareOrderQuery({
-        docType: "ORDER",
-        queryFields: 'orderId',
-        viewSize: '0',  // passed viewSize as 0 to not fetch any data
-        filters: {
-          '-orderStatusId': { value: 'ORDER_CREATED' },
-          orderTypeId: { value: 'TRANSFER_ORDER' },
-          facilityId: { value: escapeSolrSpecialChars(this.currentFacility?.facilityId) },
-          productStoreId: { value: this.currentEComStore.productStoreId }
-        },
-        facet: {
-          "shipmentMethodTypeIdFacet":{
-            "excludeTags":"shipmentMethodTypeIdFilter",
-            "field":"shipmentMethodTypeId",
-            "mincount":1,
-            "limit":-1,
-            "sort":"index",
-            "type":"terms",
-            "facet": {
-              "ordersCount": "unique(orderId)"
-            }
-          },
-          "orderStatusIdFacet":{
-            "excludeTags":"orderStatusIdFilter",
-            "field":"orderStatusId",
-            "mincount":1,
-            "limit":-1,
-            "sort":"index",
-            "type":"terms",
-            "facet": {
-              "ordersCount": "unique(orderId)"
-            }
-          }
-        }
-      })
-
-      try {
-        resp = await UtilService.fetchTransferOrderFacets(payload);
-        if (resp.status == 200 && !hasError(resp) && resp.data.facets?.count > 0) {
-          this.shipmentMethods = resp.data.facets.shipmentMethodTypeIdFacet.buckets
-          this.statuses = resp.data.facets.orderStatusIdFacet.buckets
-          this.store.dispatch('util/fetchShipmentMethodTypeDesc', this.shipmentMethods.map((shipmentMethod: any) => shipmentMethod.val))
-          this.store.dispatch('util/fetchStatusDesc', this.statuses.map((status: any) => status.val))
-        } else {
-          throw resp.data;
-        }
-      } catch(err) {
-        logger.error('Failed to fetch transfer order filters.', err)
-      }
     },
   },
   setup() {

--- a/src/views/TransferOrders.vue
+++ b/src/views/TransferOrders.vue
@@ -8,7 +8,7 @@
         <ion-title v-if="!transferOrders.total">{{ transferOrders.total }} {{ translate('orders') }}</ion-title>
         <ion-title v-else>{{ transferOrders.list.length }} {{ translate('of') }} {{ transferOrders.total }} {{ translate('orders') }}</ion-title>
         <ion-buttons slot="end">
-          <ion-menu-button menu="transfer-order-filters" :disabled="!transferOrders.total">
+          <ion-menu-button menu="transfer-order-filters" :disabled="!transferOrderCount">
             <ion-icon :icon="optionsOutline" />
           </ion-menu-button>
         </ion-buttons>

--- a/src/views/TransferOrders.vue
+++ b/src/views/TransferOrders.vue
@@ -165,7 +165,7 @@ export default defineComponent({
       const transferOrdersQuery = JSON.parse(JSON.stringify(this.transferOrders.query))
       transferOrdersQuery.viewIndex = 0 // If the size changes, list index should be reintialised
       transferOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE
-      transferOrdersQuery.selectedStatuses = ["ORDER_COMPLETED", "ORDER_APPROVED"]
+      transferOrdersQuery.selectedStatuses = ["ORDER_COMPLETED"]
       await this.store.dispatch('transferorder/updateTransferOrderQuery', { ...transferOrdersQuery })
       this.hasCompletedTransferOrders = this.transferOrders.list.some((order: any) => order.orderStatusId === "ORDER_COMPLETED");
     },


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#673 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a check to display TO filters if the facet has orders, and disabled them if there are no orders at all.
- Improved the TransferOrder component by adding facet API fetching logic and removing it from the TransferOrderFilters page.
- Previously, TOs in open condition were fetched even when the facet had no order count, which caused unnecessary calls. This is now fixed.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2024-11-21 14-48-47](https://github.com/user-attachments/assets/7a223754-6197-47dc-a8fb-30163a0e118a)
![Screenshot from 2024-11-21 14-49-16](https://github.com/user-attachments/assets/78ec9e46-f295-46d8-bd35-8a15d0cc94dc)



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)