### PR TITLE
Improved: enable ion-spinner on 'Regenerate Shipping Label' Action in Completed Tab & upgrade the @hotwax/app-theme version(#678)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@capacitor/core": "^2.4.7",
         "@casl/ability": "^6.0.0",
         "@hotwax/app-version-info": "^1.0.0",
-        "@hotwax/apps-theme": "^1.2.6",
+        "@hotwax/apps-theme": "^1.2.8",
         "@hotwax/dxp-components": "^1.16.0",
         "@hotwax/oms-api": "^1.16.0",
         "@ionic/core": "^7.6.0",
@@ -2793,9 +2793,9 @@
       "integrity": "sha512-PnJTqTbFvvl9N23yi1DjL4aNmTkpYFrayyoJyfH1qDJXADFbQ9kB7gJmKcfiPpyYMGR86Yf3Is5ct0+wReUJGQ=="
     },
     "node_modules/@hotwax/apps-theme": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@hotwax/apps-theme/-/apps-theme-1.2.6.tgz",
-      "integrity": "sha512-zpUjGoY7LBlKeiP0V7tonrmoey8HQ5THQmyixQ+IDtrjmEJNBjynW/Ef3gC0FUNNPuVqxWPZdT5CVgaETLGTwg=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@hotwax/apps-theme/-/apps-theme-1.2.8.tgz",
+      "integrity": "sha512-6ZE2y4DKWcDdYNToPv7L6oYM71NS4zgxfoncIUvSvA9BYqi3MavfC36Z6ujHBEB/PsUhcbU8DOdpakTvyL5aGw=="
     },
     "node_modules/@hotwax/dxp-components": {
       "version": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@capacitor/core": "^2.4.7",
     "@casl/ability": "^6.0.0",
     "@hotwax/app-version-info": "^1.0.0",
-    "@hotwax/apps-theme": "^1.2.6",
+    "@hotwax/apps-theme": "^1.2.8",
     "@hotwax/dxp-components": "^1.16.0",
     "@hotwax/oms-api": "^1.16.0",
     "@ionic/core": "^7.6.0",

--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -44,7 +44,7 @@
         </div>
         <div class="results">
           <ion-button :disabled="isShipNowDisabled || !hasAnyPackedShipment() || hasAnyMissingInfo() || (hasAnyShipmentTrackingInfoMissing() && !hasPermission(Actions.APP_FORCE_SHIP_ORDER))" expand="block" class="bulk-action desktop-only" fill="outline" size="large" @click="bulkShipOrders()">{{ translate("Ship") }}</ion-button>
-          <ion-card class="order" v-for="(order, index) in getCompletedOrders()" :key="index">
+          <ion-card class="order" v-for="(order, index) in completedOrdersList" :key="index">
             <div class="order-header">
               <div class="order-primary-info">
                 <ion-label>
@@ -256,7 +256,8 @@ export default defineComponent({
       shipmentMethods: [] as Array<any>,
       carrierPartyIds: [] as Array<any>,
       searchedQuery: '',
-      isScrollingEnabled: false
+      isScrollingEnabled: false,
+      completedOrdersList: [] as any
     }
   },
   computed: {
@@ -275,6 +276,7 @@ export default defineComponent({
   async mounted() {
     await Promise.all([this.initialiseOrderQuery(), this.fetchShipmentMethods(), this.fetchCarrierPartyIds()]);
     emitter.on('updateOrderQuery', this.updateOrderQuery)
+    this.completedOrdersList = JSON.parse(JSON.stringify(this?.completedOrders.list)).slice(0, (this.completedOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
   },
   unmounted() {
     this.store.dispatch('order/clearCompletedOrders')
@@ -304,9 +306,6 @@ export default defineComponent({
       const updatedOrder = this.completedOrders.list.find((order: any) =>  order.orderId === orderItem.orderId && order.picklistBinId === orderItem.picklistBinId);
       const updatedItem = updatedOrder.items.find((item: any) => item.orderItemSeqId === orderItem.orderItemSeqId)
       updatedItem.showKitComponents = orderItem.showKitComponents ? false : true
-    },
-    getCompletedOrders() {
-      return ((this.completedOrders.list)).slice(0, (this.completedOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
     },
     enableScrolling() {
       const parentElement = (this as any).$refs.contentRef.$el

--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -306,7 +306,7 @@ export default defineComponent({
       updatedItem.showKitComponents = orderItem.showKitComponents ? false : true
     },
     getCompletedOrders() {
-      return JSON.parse(JSON.stringify(this.completedOrders.list)).slice(0, (this.completedOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
+      return ((this.completedOrders.list)).slice(0, (this.completedOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
     },
     enableScrolling() {
       const parentElement = (this as any).$refs.contentRef.$el


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#678 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Instead of using a function that lists the completed orders after cloning the completedOrders getter, which was not showing reactivity when changing the properties of an order, I replaced that function with a variable that maintains a cloned list of completed orders.
- Additionally, I updated the @hotwax/app-theme version to apply CSS to the ion-spinner inside the ion-button.
### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)