### PR TITLE
Implemented: support to define custom component as a separate item in the additional details card(#86cx82032)

### DIFF
--- a/src/store/modules/orderLookup/actions.ts
+++ b/src/store/modules/orderLookup/actions.ts
@@ -124,6 +124,7 @@ const actions: ActionTree<OrderLookupState, RootState> = {
     })
 
     commit(types.ORDERLOOKUP_CARRIER_TRACKING_URLS_UPDATED, carriersTrackingInfo);
+    return carriersTrackingInfo;
   },
 
   async getOrderDetails({ commit, dispatch }, orderId) {
@@ -394,7 +395,13 @@ const actions: ActionTree<OrderLookupState, RootState> = {
       }
       order["shipGroups"] = shipGroups
       
-      dispatch("fetchCarriersTrackingInfo", Array.from(new Set(carrierPartyIds)));
+      const carrierInfo = await dispatch("fetchCarriersTrackingInfo", Array.from(new Set(carrierPartyIds)));
+
+      Object.keys(order["shipGroups"]).map((shipGroupId: any) => {
+        const shipGroup = order["shipGroups"][shipGroupId]
+        shipGroup.map((item: any) => item["carrierPartyName"] = carrierInfo[item.carrierPartyId]?.carrierName || "")
+      })
+
       this.dispatch("util/fetchShipmentMethodTypeDesc", shipmentMethodIds)
 
       order["shipGroupFulfillmentStatus"] = {}

--- a/src/views/OrderLookupDetail.vue
+++ b/src/views/OrderLookupDetail.vue
@@ -179,10 +179,11 @@
                   <ion-label class="ion-text-wrap">{{ translate("Municipio") }}</ion-label>
                   <ion-label slot="end">{{ order.orderAttributes.municipio || "-" }}</ion-label>
                 </ion-item>
-                <ion-item lines="none">
+                <ion-item>
                   <ion-label class="ion-text-wrap">{{ translate("Invoicing facility") }}</ion-label>
                   <ion-label class="ion-text-wrap" slot="end">{{ (invoicingFacility.facilityName ? invoicingFacility.facilityName : invoicingFacility.facilityId) || '-'  }}</ion-label>
                 </ion-item>
+                <Component :is="additionalDetailItemExt" :order="order" :invoicingFacilityId="invoicingFacility.facilityId"/>
               </ion-list>
             </ion-card>
           </div>
@@ -290,6 +291,7 @@ import OrderLookupLabelActionsPopover from '@/components/OrderLookupLabelActions
 import { hasError } from "@hotwax/oms-api";
 import logger from "@/logger";
 import { OrderService } from "@/services/OrderService";
+import { useDynamicImport } from "@/utils/moduleFederation";
 
 export default defineComponent({
   name: "OrderLookupDetail",
@@ -320,7 +322,8 @@ export default defineComponent({
       itemStatuses: JSON.parse(process.env.VUE_APP_ITEM_STATUS as any),
       isFetchingStock: false,
       isFetchingOrderInfo: false,
-      invoicingFacility: {} as any
+      invoicingFacility: {} as any,
+      additionalDetailItemExt: "" as any
     }
   },
   computed: {
@@ -333,12 +336,16 @@ export default defineComponent({
       getShipmentMethodDesc: "util/getShipmentMethodDesc",
       getPaymentMethodDesc: 'util/getPaymentMethodDesc',
       userProfile: 'user/getUserProfile',
+      getPartyName: 'util/getPartyName',
+      instanceUrl: "user/getInstanceUrl"
     })
   },
   async ionViewWillEnter() {
     this.isFetchingOrderInfo = true
     await this.store.dispatch("orderLookup/getOrderDetails", this.orderId)
     await this.fetchOrderInvoicingFacility()
+    const instance = this.instanceUrl.split("-")[0]
+    this.additionalDetailItemExt = await useDynamicImport({ scope: "fulfillment_extensions", module: `${instance}_AdditionalDetailItem`})
     this.isFetchingOrderInfo = false
   },
   methods: {

--- a/src/views/OrderLookupDetail.vue
+++ b/src/views/OrderLookupDetail.vue
@@ -344,7 +344,7 @@ export default defineComponent({
     await this.store.dispatch("orderLookup/getOrderDetails", this.orderId)
     await this.fetchOrderInvoicingFacility()
     const instance = this.instanceUrl.split("-")[0]
-    this.additionalDetailItemExt = await useDynamicImport({ scope: "fulfillment_extensions", module: `${instance}_AdditionalDetailItem`})
+    this.additionalDetailItemExt = await useDynamicImport({ scope: "fulfillment_extensions", module: `${instance}_OrderLookupAdditionalDetailItem`})
     this.isFetchingOrderInfo = false
   },
   methods: {

--- a/src/views/OrderLookupDetail.vue
+++ b/src/views/OrderLookupDetail.vue
@@ -336,7 +336,6 @@ export default defineComponent({
       getShipmentMethodDesc: "util/getShipmentMethodDesc",
       getPaymentMethodDesc: 'util/getPaymentMethodDesc',
       userProfile: 'user/getUserProfile',
-      getPartyName: 'util/getPartyName',
       instanceUrl: "user/getInstanceUrl"
     })
   },


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added support to display custom items in the additional details card, by fetching those from the remote app.

Currently, the remote component includes carrier and cod info.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)