### PR TITLE
Improved: Enable void label for orders in completed tab(#870)

### DIFF
--- a/src/components/ShippingLabelActionPopover.vue
+++ b/src/components/ShippingLabelActionPopover.vue
@@ -6,7 +6,7 @@
           {{ translate("View Label") }}
           <ion-icon slot="end" :icon="documentOutline" />
         </ion-item>
-        <ion-item button lines="none" :disabled="isVoidLabelDisabled" @click="voidShippingLabel(currentOrder)">
+        <ion-item button lines="none" @click="voidShippingLabel(currentOrder)">
           {{ translate("Void Label") }}
           <ion-icon slot="end" :icon="trashOutline" />
         </ion-item>
@@ -41,7 +41,7 @@
       IonList,
       IonListHeader
     },
-    props: ['currentOrder', 'isVoidLabelDisabled'],
+    props: ['currentOrder'],
     computed: {
       ...mapGetters({
         facilityProductStores: 'facility/getFacilityProductStores',

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -573,7 +573,6 @@ export default defineComponent({
         component: ShippingLabelActionPopover,
         componentProps: {
           currentOrder: currentOrder,
-          isVoidLabelDisabled: (this.category === "completed" && !this.hasPackedShipments(currentOrder))
         },
         event: ev,
         showBackdrop: false


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#870

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Removed the check for disabling the void label on orders in the Completed tab.
- Previously, the label was disabled for orders in the Completed category and for orders that did not have any shipments in the SHIPMENT_PACKED status.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/9979be8e-fcb3-41c8-8ae6-2f021317f7b0)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)