### PR TITLE
Fixed: If the shipment has labelImageUrl set then always open it in new tab (#873).

### DIFF
--- a/src/components/OrderLookupLabelActionsPopover.vue
+++ b/src/components/OrderLookupLabelActionsPopover.vue
@@ -28,7 +28,6 @@ import { documentOutline, openOutline } from "ionicons/icons";
 import { translate } from "@hotwax/dxp-components";
 import { mapGetters, useStore } from "vuex";
 import { OrderService } from '@/services/OrderService';
-import { isPdf } from '@/utils'
 
 export default defineComponent({
   name: "OrderLookupLabelActionsPopover",
@@ -53,7 +52,7 @@ export default defineComponent({
 
       shipmentPackages.map((shipmentPackage: any) => {
         shipmentIds.push(shipmentPackage.shipmentId)
-        this.isPdf(shipmentPackage.labelImageUrl) && shippingLabelPdfUrls.push(shipmentPackage.labelImageUrl)
+        shippingLabelPdfUrls.push(shipmentPackage.labelImageUrl)
       })
 
       await OrderService.printShippingLabel(shipmentIds, shippingLabelPdfUrls)
@@ -72,7 +71,6 @@ export default defineComponent({
 
     return {
       documentOutline,
-      isPdf,
       openOutline,
       store,
       translate

--- a/src/services/UtilService.ts
+++ b/src/services/UtilService.ts
@@ -1,7 +1,7 @@
 import { api, hasError } from '@/adapter';
 import logger from '@/logger';
 import store from '@/store';
-import { isPdf, getCurrentFacilityId } from '@/utils';
+import { getCurrentFacilityId } from '@/utils';
 
 const fetchShipmentMethods = async (query: any): Promise <any>  => {
   return api({
@@ -106,7 +106,7 @@ const findShipmentPackages = async(shipmentIds: Array<string>): Promise<any> => 
             shipmentPackage.labelImageUrl = ""
             shipmentPackage.internationalInvoiceUrl = ""
         }
-        if (shipmentPackage.labelImageUrl && isPdf(shipmentPackage.labelImageUrl)) {
+        if (shipmentPackage.labelImageUrl) {
           shipmentPackage.labelPdfUrl = shipmentPackage.labelImageUrl;
         }
         if(shipmentForOrders[key]) {


### PR DESCRIPTION


### Related Issues
#873 
#

### Short Description and Why It's Useful
Fixed: If the shipment has labelImageUrl set then always open it in new tab.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)