### PR TITLE
Fixed: null going in the list of shipping label pdf url array for print shipping label (#878)

### DIFF
--- a/src/components/OrderLookupLabelActionsPopover.vue
+++ b/src/components/OrderLookupLabelActionsPopover.vue
@@ -52,7 +52,7 @@ export default defineComponent({
 
       shipmentPackages.map((shipmentPackage: any) => {
         shipmentIds.push(shipmentPackage.shipmentId)
-        shippingLabelPdfUrls.push(shipmentPackage.labelImageUrl)
+        shipmentPackage.labelImageUrl && shippingLabelPdfUrls.push(shipmentPackage.labelImageUrl)
       })
 
       await OrderService.printShippingLabel(shipmentIds, shippingLabelPdfUrls)


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#878

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added a check for null label url while creating a list for print shipping label method.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)