### PR TITLE
Fixed: shipGroup information is not being displayed for all orders(#886)

### DIFF
--- a/src/store/modules/orderLookup/actions.ts
+++ b/src/store/modules/orderLookup/actions.ts
@@ -106,7 +106,7 @@ const actions: ActionTree<OrderLookupState, RootState> = {
       })
 
       if(!hasError(resp)) {
-        resp.data.docs.map((doc: any) => {
+        resp.data.docs?.map((doc: any) => {
           systemProperties[doc.systemResourceId.toUpperCase()] = doc.systemPropertyValue
         })
       } else {
@@ -337,7 +337,7 @@ const actions: ActionTree<OrderLookupState, RootState> = {
       const productIds: Array<string> = []
       const shipmentMethodIds: Array<string> = []
 
-      const orderRouteSegmentInfo = orderRouteSegment.status === "fulfilled" && orderRouteSegment.value.data.docs.length > 0 ? orderRouteSegment.value.data.docs.reduce((orderSegmentInfo: any, routeSegment: any) => {
+      const orderRouteSegmentInfo = orderRouteSegment.status === "fulfilled" && orderRouteSegment.value.data.docs?.length > 0 ? orderRouteSegment.value.data.docs.reduce((orderSegmentInfo: any, routeSegment: any) => {
         if(orderSegmentInfo[routeSegment.shipGroupSeqId]) orderSegmentInfo[routeSegment.shipGroupSeqId].push(routeSegment)
         else orderSegmentInfo[routeSegment.shipGroupSeqId] = [routeSegment]
         return orderSegmentInfo
@@ -374,7 +374,7 @@ const actions: ActionTree<OrderLookupState, RootState> = {
       const carrierPartyIds = [] as any;
 
       if(orderShipGroups.status === "fulfilled" && !hasError(orderShipGroups.value) && orderShipGroups.value.data.count > 0) {
-        shipGroups = orderShipGroups.value.data.docs.reduce((shipGroups: any, shipGroup: any) => {
+        shipGroups = orderShipGroups.value.data.docs?.reduce((shipGroups: any, shipGroup: any) => {
           productIds.push(shipGroup.productId)
           shipGroup.shipmentMethodTypeId && shipmentMethodIds.includes(shipGroup.shipmentMethodTypeId) ? '' : shipmentMethodIds.push(shipGroup.shipmentMethodTypeId)
           shipGroup.shipGroupSeqId && shipGroupSeqIds.includes(shipGroup.shipGroupSeqId) ? '' : shipGroupSeqIds.push(shipGroup.shipGroupSeqId)


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#886 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
For orders other than completed status the shipGroup information is missing, as the shipment information is not available for those orders, so added a null check before processing the shipment information for orders(#886)

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)