### PR TITLE
Fixed: spinner not displayed when generating shipping label for transfer shipment(#901)

### DIFF
--- a/src/views/TransferShipmentReview.vue
+++ b/src/views/TransferShipmentReview.vue
@@ -21,8 +21,9 @@
               <ion-item>
                 <ion-label>{{ currentShipment.totalQuantityPicked }} {{ translate("items picked") }}</ion-label>
                 <ion-button expand="block" fill="outline" @click="generateShippingLabel(currentShipment)">
-                  <ion-icon slot="start" :icon="documentTextOutline" />{{ currentShipment.trackingCode ? translate("Regenerate Shipping Label") : translate("Generate shipping label") }}
-                  <ion-spinner color="primary" slot="start" v-if="currentShipment.isGeneratingShippingLabel" name="crescent" />
+                  <ion-icon slot="start" :icon="documentTextOutline" />
+                  {{ currentShipment.trackingCode ? translate("Regenerate Shipping Label") : translate("Generate shipping label") }}
+                  <ion-spinner color="primary" slot="end" v-if="isGeneratingShippingLabel" name="crescent" />
                 </ion-button>
               </ion-item>
               <ion-item>
@@ -159,7 +160,8 @@
         isShipped: false,
         trackingCode: '',
         shipmentItems: [] as any,
-        showLabelError: false
+        showLabelError: false,
+        isGeneratingShippingLabel: false
       }
     },
     computed: {
@@ -197,12 +199,12 @@
 
         // if the request to print shipping label is not yet completed, then clicking multiple times on the button
         // should not do anything
-        if (currentShipment.isGeneratingShippingLabel) {
+        if (this.isGeneratingShippingLabel) {
           return;
         }
 
         await this.store.dispatch('transferorder/fetchTransferShipmentDetail', { shipmentId: this.$route.params.shipmentId })
-        currentShipment.isGeneratingShippingLabel = true;
+        this.isGeneratingShippingLabel = true;
         let shippingLabelPdfUrls = this.currentShipment.shipmentPackages
           ?.filter((shipmentPackage: any) => shipmentPackage.labelPdfUrl)
           .map((shipmentPackage: any) => shipmentPackage.labelPdfUrl);
@@ -232,7 +234,7 @@
           await OrderService.printShippingLabel([this.currentShipment.shipmentId], shippingLabelPdfUrls)
         }
 
-        currentShipment.isGeneratingShippingLabel = false;
+        this.isGeneratingShippingLabel = false;
       },
       async transferShipmentActionsPopover(ev: Event) {
         const popover = await popoverController.create({


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#901 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Used local variable to maintain state for generating shipping label, instead of using order level variable

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)