### PR TITLE
Fixed: issue of label pdfs not being fetch when having shipping labelImage

### DIFF
--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -552,7 +552,7 @@ const printPackingSlip = async (shipmentIds: Array<string>): Promise<any> => {
 
 const printShippingLabel = async (shipmentIds: Array<string>, shippingLabelPdfUrls?: Array<string>): Promise<any> => {
   try {
-    let pdfUrls = shippingLabelPdfUrls;
+    let pdfUrls = shippingLabelPdfUrls?.filter((pdfUrl: any) => pdfUrl);
     if (!pdfUrls || pdfUrls.length == 0) {
     // Get packing slip from the server
     const resp: any = await api({


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When we are having labelImage we are passing an empty array of undefined values in printShippingLabel service because we have checked for imageUrls which is undefined in case of labelImage, resulting in opening blank tabs, so added a check to filter out undefined values and then check for the rest of the logic.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)