### PR TITLE
Fixed: Modal remained blank and open when camera access is denied during product scanning.

### DIFF
--- a/src/components/ScanOrderItemModal.vue
+++ b/src/components/ScanOrderItemModal.vue
@@ -74,7 +74,7 @@ import { computed, defineComponent } from "vue";
 import { cameraOutline, closeOutline, copyOutline, saveOutline } from "ionicons/icons";
 import { getProductIdentificationValue, DxpShopifyImg, translate, useProductIdentificationStore } from '@hotwax/dxp-components';
 import { mapGetters } from 'vuex';
-import { getFeature, showToast } from "@/utils"
+import { getFeature, showToast, hasWebcamAccess } from "@/utils"
 import Scanner from "@/components/Scanner.vue"
 import { isKit } from '@/utils/order'
 
@@ -119,6 +119,10 @@ export default defineComponent({
       modalController.dismiss({ dismissed: true, ...payload });
     },
     async scan() {
+      if (!(await hasWebcamAccess())) {
+        showToast(translate("Camera access not allowed, please check permissons."));
+        return;
+      } 
       const modal = await modalController.create({
         component: Scanner,
       });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -52,6 +52,7 @@
   "Browser TimeZone": "Browser TimeZone",
   "Browser time zone": "Browser time zone",
   "Built: ": "Built: {builtDateTime}",
+  "Camera access not allowed, please check permissons.": "Camera access not allowed, please check permissons.",
   "Cancel": "Cancel",
   "Cancelled": "Cancelled",
   "Carrier": "Carrier",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -51,6 +51,7 @@
   "Brokered by": "Brokered by",
   "Browser TimeZone": "Navegador de ZonaHoraria",
   "Browser time zone": "Navegador de zona horaria",
+  "Camera access not allowed, please check permissons.": "Camera access not allowed, please check permissons.",
   "Cancel": "Cancelar",
   "Cancelled": "Cancelado",
   "Carrier": "Transportadora",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -52,6 +52,7 @@
   "Browser TimeZone": "ブラウザのタイムゾーン",
   "Browser time zone": "ブラウザのタイムゾーン",
   "Built: ": "ビルド日時: {builtDateTime}",
+  "Camera access not allowed, please check permissons.": "Camera access not allowed, please check permissons.",
   "Cancel": "キャンセル",
   "Cancelled": "キャンセル済み",
   "Carrier": "配送者",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -217,4 +217,13 @@ function getDateWithOrdinalSuffix(time: any) {
   return `${dateTime.day}${suffix} ${dateTime.toFormat("MMM yyyy")}`;
 }
 
-export { copyToClipboard, formatCurrency, formatDate, formatPhoneNumber, formatUtcDate, generateInternalId, getCurrentFacilityId, getProductStoreId, getColorByDesc, getDateWithOrdinalSuffix, getFeature, getIdentificationId, handleDateTimeInput, isValidDeliveryDays, isValidCarrierCode, isPdf, showToast, sortItems, hasError, jsonToCsv }
+const hasWebcamAccess = async () => {
+  try {
+    await navigator.mediaDevices.getUserMedia({ video: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export { copyToClipboard, formatCurrency, formatDate, formatPhoneNumber, formatUtcDate, generateInternalId, getCurrentFacilityId, getProductStoreId, getColorByDesc, getDateWithOrdinalSuffix, getFeature, getIdentificationId, handleDateTimeInput, isValidDeliveryDays, isValidCarrierCode, isPdf, showToast, sortItems, hasError, jsonToCsv, hasWebcamAccess }

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -172,7 +172,7 @@
   import Scanner from "@/components/Scanner.vue";
   import { Actions, hasPermission } from '@/authorization'
   import { DateTime } from 'luxon';
-  import { getFeature, showToast } from '@/utils';
+  import { getFeature, showToast, hasWebcamAccess } from '@/utils';
   import { hasError } from '@/adapter';
   import { OrderService } from '@/services/OrderService'
   import TransferOrderItem from '@/components/TransferOrderItem.vue'
@@ -340,6 +340,10 @@
       },
       
       async scanCode () {
+        if (!(await hasWebcamAccess())) {
+          showToast(translate("Camera access not allowed, please check permissons."));
+          return;
+        } 
         const modal = await modalController
           .create({
             component: Scanner,

--- a/src/views/TransferShipmentReview.vue
+++ b/src/views/TransferShipmentReview.vue
@@ -84,7 +84,7 @@
   import { useRouter } from 'vue-router';
   import Scanner from "@/components/Scanner.vue";
   import { Actions, hasPermission } from '@/authorization'
-  import { getFeature, showToast } from '@/utils';
+  import { getFeature, showToast, hasWebcamAccess } from '@/utils';
   import { hasError } from '@/adapter'
   import { OrderService } from '@/services/OrderService'
   import TransferShipmentActionsPopover from '@/components/TransferShipmentActionsPopover.vue'
@@ -304,6 +304,10 @@
         this.store.dispatch('transferorder/updateOrderProductCount', payload)
       },
       async scanCode () {
+        if (!(await hasWebcamAccess())) {
+          showToast(translate("Camera access not allowed, please check permissons."));
+          return;
+        } 
         const modal = await modalController
           .create({
             component: Scanner,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

https://github.com/hotwax/dxp-components/issues/329

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed the issue of modal remaining blank and open when camera access is denied during product scanning by implementing a utility function to check for permission, consumed the utility function in parent component and shown relative toast message.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 12-03-25 11:01:43 AM IST.webm](https://github.com/user-attachments/assets/768fd06e-a333-4d5a-8a25-3bc83aaf2703)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)