### PR TITLE
Improved: the code to display picker list when editing picker in the In Progress Tab.(#952)

### DIFF
--- a/src/components/EditPickersModal.vue
+++ b/src/components/EditPickersModal.vue
@@ -128,8 +128,9 @@ export default defineComponent({
         this.selectedPickers.push(this.pickers.find((picker: any) => picker.id == id))
       }
 
+      // If all the selected pickers are removed, retrieve and display the original picker list.
       if (!this.selectedPickers.length) {
-       await this.findPickers();
+        await this.findPickers();
       }
     },
     async findPickers(pickerIds?: Array<any>) {

--- a/src/components/EditPickersModal.vue
+++ b/src/components/EditPickersModal.vue
@@ -128,7 +128,7 @@ export default defineComponent({
         this.selectedPickers.push(this.pickers.find((picker: any) => picker.id == id))
       }
 
-      if(!this.selectedPickers.length){
+      if (!this.selectedPickers.length) {
        await this.findPickers();
       }
     },
@@ -154,7 +154,7 @@ export default defineComponent({
             "qf": "firstName lastName groupName partyId externalId",
             "sort": "firstName asc"
           },
-          "filter": ["docType:EMPLOYEE", "WAREHOUSE_PICKER_role:true"]
+          "filter": ["docType:EMPLOYEE", "WAREHOUSE_PICKER_role:true", partyIdsFilter.length ? `partyId:(${partyIdsFilter})` : ""]
         }
       }
 

--- a/src/components/EditPickersModal.vue
+++ b/src/components/EditPickersModal.vue
@@ -119,13 +119,17 @@ export default defineComponent({
     isPickerSelected(id: string) {
       return this.selectedPickers.some((picker: any) => picker.id == id)
     },
-    updateSelectedPickers(id: string) {
+    async updateSelectedPickers(id: string) {
       const picker = this.isPickerSelected(id)
       if (picker) {
         // if picker is already selected then removing that picker from the list on click
         this.selectedPickers = this.selectedPickers.filter((picker: any) => picker.id != id)
       } else {
         this.selectedPickers.push(this.pickers.find((picker: any) => picker.id == id))
+      }
+
+      if(!this.selectedPickers.length){
+       await this.findPickers();
       }
     },
     async findPickers(pickerIds?: Array<any>) {

--- a/src/components/EditPickersModal.vue
+++ b/src/components/EditPickersModal.vue
@@ -150,7 +150,7 @@ export default defineComponent({
             "qf": "firstName lastName groupName partyId externalId",
             "sort": "firstName asc"
           },
-          "filter": ["docType:EMPLOYEE", "WAREHOUSE_PICKER_role:true", partyIdsFilter.length ? `partyId:(${partyIdsFilter})` : ""]
+          "filter": ["docType:EMPLOYEE", "WAREHOUSE_PICKER_role:true"]
         }
       }
 

--- a/src/components/EditPickersModal.vue
+++ b/src/components/EditPickersModal.vue
@@ -119,7 +119,7 @@ export default defineComponent({
     isPickerSelected(id: string) {
       return this.selectedPickers.some((picker: any) => picker.id == id)
     },
-    async updateSelectedPickers(id: string) {
+    updateSelectedPickers(id: string) {
       const picker = this.isPickerSelected(id)
       if (picker) {
         // if picker is already selected then removing that picker from the list on click
@@ -130,7 +130,7 @@ export default defineComponent({
 
       // If all the selected pickers are removed, retrieve and display the original picker list.
       if (!this.selectedPickers.length) {
-        await this.findPickers();
+        this.findPickers();
       }
     },
     async findPickers(pickerIds?: Array<any>) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#952 
#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
If all selected pickers are removed, the original picker list is retrieved and displayed, when editing picker in the In Progress Tab.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)