### PR TITLE
Implemented: support to display print shipping button on the details page for in-progress orders(#961)

### DIFF
--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -185,6 +185,7 @@
                   {{ translate("Pack order") }}
                 </ion-button>
                 <ion-button :disabled="order.hasMissingInfo" fill="outline" @click.stop="save(order)">{{ translate("Save") }}</ion-button>
+                <Component :is="printDocumentsExt" :category="category" :order="order" :currentFacility="currentFacility" :hasMissingInfo="order.hasMissingInfo || order.missingLabelImage"/>
               </template>  
               <ion-button v-else-if="category === 'open'" @click="assignPickers">
                 <ion-icon slot="start" :icon="archiveOutline" />
@@ -552,7 +553,8 @@ export default defineComponent({
       orderAdjustments: [],
       orderHeaderAdjustmentTotal: 0,
       adjustmentsByGroup: {} as any,
-      orderAdjustmentShipmentId: ""
+      orderAdjustmentShipmentId: "",
+      printDocumentsExt: "" as any
     }
   },
   async ionViewDidEnter() {
@@ -585,6 +587,7 @@ export default defineComponent({
   },
   async mounted() {
     const instance = this.instanceUrl.split("-")[0]
+    this.printDocumentsExt = await useDynamicImport({ scope: "fulfillment_extensions", module: `${instance}_PrintDocument`})
     this.orderInvoiceExt = await useDynamicImport({ scope: "fulfillment_extensions", module: `${instance}_OrderInvoice`})
   },
   methods: {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#961 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added `Print Shipping Label` button on the details page for in-progress orders
- Currently added the support to only print shipping labels and no other documents.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/2fff7a71-6c5b-4d80-9745-4394d34ea179)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)