### PR TITLE
Fixed: issue of filters not being reset when coming to lookup list page from any other page(#783)

### DIFF
--- a/src/views/OrderLookup.vue
+++ b/src/views/OrderLookup.vue
@@ -209,8 +209,9 @@ export default defineComponent ({
       isScrollingEnabled: false
     }
   },
-  ionViewWillEnter() {
+  async ionViewWillEnter() {
     this.isScrollingEnabled = false;
+    await this.getOrders();
   },
   beforeRouteEnter(_, from) {
     // Clearing the orderLookup filters only when coming from any page other than detail page
@@ -266,9 +267,6 @@ export default defineComponent ({
         this.isScrollingEnabled = true;
       }
     },
-  },
-  async mounted() {
-    await this.getOrders();
   },
   setup() {
     const router = useRouter();

--- a/src/views/OrderLookup.vue
+++ b/src/views/OrderLookup.vue
@@ -160,6 +160,7 @@ import { useRouter } from 'vue-router';
 import OrderLookupFilters from '@/components/OrderLookupFilters.vue'
 import { translate } from '@hotwax/dxp-components';
 import Image from '@/components/Image.vue'
+import store from "@/store"
 
 export default defineComponent ({
   name: 'OrderLookup',
@@ -211,10 +212,10 @@ export default defineComponent ({
   ionViewWillEnter() {
     this.isScrollingEnabled = false;
   },
-  beforeRouteLeave(to) {
-    // Clearing the orderLookup filters only when moving to a page other than detail page
-    if(to.name !== "OrderLookupDetail") {
-      this.store.dispatch("orderLookup/clearOrderLookup")
+  beforeRouteEnter(_, from) {
+    // Clearing the orderLookup filters only when coming from any page other than detail page
+    if(from.name !== "OrderLookupDetail") {
+      store.dispatch("orderLookup/clearOrderLookup")
     }
   },
   methods: {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#783 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Changed the beforeRouteLeave to beforeRouteEnter hook and checked from router path

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)