### PR TITLE
Fixed: checkbox only changes its current state when api call completes. (#707)

### DIFF
--- a/src/components/ShipmentMethods.vue
+++ b/src/components/ShipmentMethods.vue
@@ -176,7 +176,8 @@
       },
             
       async updateCarrierShipmentMethodAssociation(event: any, shipmentMethod: any) {
-        event.stopPropagation();
+        event.preventDefault();
+        event.stopImmediatePropagation();
 
         let resp = {} as any;
         const payload = {

--- a/src/views/CarrierDetail.vue
+++ b/src/views/CarrierDetail.vue
@@ -270,7 +270,8 @@
         return createShipmentMethodModal.present();
       },
       async updateCarrierFacility(event: any, facility: any) {
-        event.stopPropagation();
+        event.preventDefault();
+        event.stopImmediatePropagation();
 
         try {
           const payload = {
@@ -378,7 +379,8 @@
       },
       
       async updateProductStoreShipmentMethodAssociation(event: any, shipmentMethod: any, productStore: any) {
-        event.stopPropagation();
+        event.preventDefault();
+        event.stopImmediatePropagation();
 
         let resp = {} as any;
         const payload = {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#707 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
performed error handling for checkbox in the carrier and a shipment method section, 
the checkboxes change their current state only if api call completes, (state changes if api call success, if api call fails then error message is shown).

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 04-04-25 04:58:41 PM IST.webm](https://github.com/user-attachments/assets/e9d6f13b-9a66-4895-99fa-77f568e4b4f3)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)