### PR TITLE
Improved: added check to avoid fetching order additional information in case of order fetching issue (#780)/

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -882,7 +882,7 @@ const actions: ActionTree<OrderState, RootState> = {
       logger.error('Something went wrong', err)
     }
 
-    await dispatch('fetchInProgressOrderAdditionalInformation', order);
+    if(order?.orderId) await dispatch('fetchInProgressOrderAdditionalInformation', order);
 
     emitter.emit('dismissLoader');
   },
@@ -952,7 +952,7 @@ const actions: ActionTree<OrderState, RootState> = {
       logger.error('No completed orders found', err)
     }
 
-    await dispatch('fetchCompletedOrderAdditionalInformation', order);
+    if(order?.orderId) await dispatch('fetchCompletedOrderAdditionalInformation', order);
     emitter.emit('dismissLoader');
   },
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#780

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Here in following issue, the blank screen comes since we try to fetch the additional information of the order in case order is not fetched from the SOLR due to some problem or late update. Resulting currentOrder getting set as null and showing blank screen.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)