### PR TITLE
Fixed: Disabling irrelevant options such as 'Generate QR Code', 'Edit Picker' & 'Print Picklist' when no search results for picker. (#655)

### DIFF
--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -215,7 +215,7 @@
       </div>
     </ion-content>
     <!-- only show footer buttons if 'All orders' is not selected -->
-    <ion-footer v-if="selectedPicklistId">
+    <ion-footer v-if="selectedPicklistId && inProgressOrders.total">
       <ion-toolbar>
         <ion-buttons slot="start">
           <ion-button fill="clear" color="primary" @click="openQRCodeModal(selectedPicklistId)">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#655 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Disabling irrelevant options such as 'Generate QR Code', 'Edit Picker' & 'Print Picklist' when no search results found for a selected picker. 
Steps to reproduce are in in the issue.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 07-04-25 02:59:12 PM IST.webm](https://github.com/user-attachments/assets/ec142c8e-5754-48d7-8778-39f99b1cef49)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)