### PR TITLE
Fixed: After updating the facility, navigating to the list page now updates the orders list (#1008)

### DIFF
--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -272,11 +272,6 @@ export default defineComponent({
       isUnpackDisabled: 'user/isUnpackDisabled'
     })
   },
-  async mounted() {
-    await Promise.all([this.initialiseOrderQuery(), this.fetchShipmentMethods(), this.fetchCarrierPartyIds()]);
-    emitter.on('updateOrderQuery', this.updateOrderQuery)
-    this.completedOrdersList = JSON.parse(JSON.stringify(this?.completedOrders.list)).slice(0, (this.completedOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
-  },
   unmounted() {
     this.store.dispatch('order/clearCompletedOrders')
     emitter.off('updateOrderQuery', this.updateOrderQuery)
@@ -289,6 +284,9 @@ export default defineComponent({
     }
   },
   async ionViewWillEnter() {
+    await Promise.all([this.initialiseOrderQuery(), this.fetchShipmentMethods(), this.fetchCarrierPartyIds()]);
+    emitter.on('updateOrderQuery', this.updateOrderQuery)
+    this.completedOrdersList = JSON.parse(JSON.stringify(this?.completedOrders.list)).slice(0, (this.completedOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
     this.isScrollingEnabled = false;
   },
   methods: {

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -385,6 +385,9 @@ export default defineComponent({
   },
   async ionViewWillEnter() {
     this.isScrollingEnabled = false;
+    this.store.dispatch('util/fetchRejectReasonOptions')
+    await Promise.all([this.fetchPickersInformation(), this.initialiseOrderQuery()])
+    emitter.on('updateOrderQuery', this.updateOrderQuery)
     await Promise.all([this.store.dispatch('carrier/fetchFacilityCarriers'), this.store.dispatch('carrier/fetchProductStoreShipmentMeths')]);
   },
   methods: {
@@ -1316,11 +1319,6 @@ export default defineComponent({
 
       modal.present();
     }
-  },
-  async mounted () {
-    this.store.dispatch('util/fetchRejectReasonOptions')
-    await Promise.all([this.fetchPickersInformation(), this.initialiseOrderQuery()])
-    emitter.on('updateOrderQuery', this.updateOrderQuery)
   },
   unmounted() {
     this.store.dispatch('order/clearInProgressOrders')

--- a/src/views/OpenOrders.vue
+++ b/src/views/OpenOrders.vue
@@ -241,6 +241,10 @@ export default defineComponent({
     }
   },
   async ionViewWillEnter() {
+    emitter.on('updateOrderQuery', this.updateOrderQuery)
+    await Promise.all([this.initialiseOrderQuery(), this.fetchShipmentMethods()]);
+    const instance = this.instanceUrl.split("-")[0].replace(new RegExp("^(https|http)://"), "")
+    this.productCategoryFilterExt = await useDynamicImport({ scope: "fulfillment_extensions", module: `${instance}_ProductCategoryFilter`})
     this.isScrollingEnabled = false;
   },
   methods: {
@@ -428,12 +432,6 @@ export default defineComponent({
     fetchProductStock(productId: string) {
       this.store.dispatch('stock/fetchStock', { productId })
     }
-  },
-  async mounted () {
-    emitter.on('updateOrderQuery', this.updateOrderQuery)
-    await Promise.all([this.initialiseOrderQuery(), this.fetchShipmentMethods()]);
-    const instance = this.instanceUrl.split("-")[0].replace(new RegExp("^(https|http)://"), "")
-    this.productCategoryFilterExt = await useDynamicImport({ scope: "fulfillment_extensions", module: `${instance}_ProductCategoryFilter`})
   },
   unmounted() {
     this.store.dispatch('order/clearOpenOrders');


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1008 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, when navigating from the orders details page to a different section using the menu tab, and then changing the facility before going back to the orders list page, the updated orders were not fetched for the changed facility. This was because the `mounted` hook did not fire, preventing the API calls.
- Moved the API calls to a different hook, and now the orders list always updates.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)