### PR TITLE
Improved: Picker list now always visible to allow adding without removing other pickers (#952)

### DIFF
--- a/src/components/EditPickersModal.vue
+++ b/src/components/EditPickersModal.vue
@@ -111,7 +111,7 @@ export default defineComponent({
     }
   },
   async mounted() {
-    await this.findPickers(this.selectedPicklist.pickerIds)
+    await this.findPickers()
     this.selectAlreadyAssociatedPickers()
   },
   props: ['selectedPicklist'],


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#952 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Fixed issue where list of pickers was not shown unconditionally; now allows adding pickers without removing existing ones.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/3ff99b69-7d3f-4af3-b746-b8e1c2e3d5f9)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)