### PR TITLE
Improved: logic to return order in case of retry shipping label from list page, success toast not shown in case of packing (#1033)

### DIFF
--- a/src/components/GenerateTrackingCodeModal.vue
+++ b/src/components/GenerateTrackingCodeModal.vue
@@ -206,7 +206,7 @@ export default defineComponent({
         return false;
       }
 
-      const response = await this.retryShippingLabel(order);
+      const response = await this.retryShippingLabel(order, false);
       if(response?.isGenerated) {
         return true;
       } else {

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -635,7 +635,7 @@ const actions: ActionTree<OrderState, RootState> = {
   },
 
   async updateShipmentPackageDetail ({ commit, state }, payload) {
-    const currentOrder = JSON.parse(JSON.stringify(state.current));
+    let currentOrder = JSON.parse(JSON.stringify(state.current));
     const completedOrders = JSON.parse(JSON.stringify(state.completed.list));
     const inProgressOrders = JSON.parse(JSON.stringify(state.inProgress.list));
 
@@ -686,6 +686,7 @@ const actions: ActionTree<OrderState, RootState> = {
         const order = completedOrders.find((completedOrder:any) => completedOrder.orderId === payload.orderId);
         if (order) {
           updateShipmentPackages(order);
+          currentOrder = order
           commit(types.ORDER_COMPLETED_UPDATED, { list: completedOrders, total: state.completed.total });
         }
       }
@@ -693,6 +694,7 @@ const actions: ActionTree<OrderState, RootState> = {
         const order = inProgressOrders.find((inProgressOrder:any) => inProgressOrder.orderId === payload.orderId);
         if (order) {
           updateShipmentPackages(order);
+          currentOrder = order
           commit(types.ORDER_INPROGRESS_UPDATED, { orders: inProgressOrders, total: state.inProgress.total });
         }
       }

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -113,7 +113,7 @@ const removeKitComponents = (order: any) => {
   return itemsWithoutKitComponents;
 }
 
-const retryShippingLabel = async (order: any) => {
+const retryShippingLabel = async (order: any, showSuccessToast = true) => {
   let isGenerated = false;
 
   // Getting all the shipmentIds from shipmentPackages for which label is missing
@@ -138,7 +138,7 @@ const retryShippingLabel = async (order: any) => {
   if(order.missingLabelImage) {
     showToast(translate("Failed to generate shipping label"))
   } else {
-    showToast(translate("Shipping Label generated successfully"))
+    if(showSuccessToast) showToast(translate("Shipping Label generated successfully"))
     isGenerated = true;
   }
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1033

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Updated logic to return order in case of retry shipping label from list page, success toast not shown in case of packing

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)