### PR TITLE
Fixed: Resolved infinite scroll issue in the completed orders page (#1039)

### DIFF
--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -18,7 +18,7 @@
     
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="view-size-selector">
       <ion-searchbar class="searchbar" :value="completedOrders.query.queryString" :placeholder="translate('Search orders')" @keyup.enter="updateQueryString($event.target.value)" />
-      <ion-radio-group v-model="selectedCarrierPartyId" @ionChange="updateSelectedCarrierPartyIds($event.target.value)">
+      <ion-radio-group v-model="selectedCarrierPartyId">
         <ion-row class="filters">
           <ion-item lines="none" v-for="carrierPartyId in carrierPartyIds" :key="carrierPartyId.val">
             <ion-radio label-placement="end" :value="carrierPartyId.id">
@@ -618,9 +618,17 @@ export default defineComponent({
     async updateSelectedCarrierPartyIds (carrierPartyId: string) {
       const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
 
+      const selectedCarrierPartyIds = completedOrdersQuery.selectedCarrierPartyIds
+      const index = selectedCarrierPartyIds.indexOf(carrierPartyId)
+      if (index < 0) {
+        selectedCarrierPartyIds.push(carrierPartyId)
+      } else {
+        selectedCarrierPartyIds.splice(index, 1)
+      }
+
       // making view size default when changing the shipment method to correctly fetch orders
       completedOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE
-      completedOrdersQuery.selectedCarrierPartyIds = [carrierPartyId]
+      completedOrdersQuery.selectedCarrierPartyIds = selectedCarrierPartyIds
 
       this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery })
     },

--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -18,7 +18,7 @@
     
     <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="view-size-selector">
       <ion-searchbar class="searchbar" :value="completedOrders.query.queryString" :placeholder="translate('Search orders')" @keyup.enter="updateQueryString($event.target.value)" />
-      <ion-radio-group v-model="selectedCarrierPartyId">
+      <ion-radio-group v-model="selectedCarrierPartyId" @ionChange="updateSelectedCarrierPartyIds($event.target.value)">
         <ion-row class="filters">
           <ion-item lines="none" v-for="carrierPartyId in carrierPartyIds" :key="carrierPartyId.val">
             <ion-radio label-placement="end" :value="carrierPartyId.id">
@@ -357,6 +357,7 @@ export default defineComponent({
       const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
       completedOrdersQuery.viewIndex++;
       await this.store.dispatch('order/updateCompletedOrderIndex', { ...completedOrdersQuery })
+      this.completedOrdersList = JSON.parse(JSON.stringify(this?.completedOrders.list)).slice(0, (this.completedOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
       event.target.complete();
     },
     isCompletedOrderScrollable() {
@@ -617,17 +618,9 @@ export default defineComponent({
     async updateSelectedCarrierPartyIds (carrierPartyId: string) {
       const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
 
-      const selectedCarrierPartyIds = completedOrdersQuery.selectedCarrierPartyIds
-      const index = selectedCarrierPartyIds.indexOf(carrierPartyId)
-      if (index < 0) {
-        selectedCarrierPartyIds.push(carrierPartyId)
-      } else {
-        selectedCarrierPartyIds.splice(index, 1)
-      }
-
       // making view size default when changing the shipment method to correctly fetch orders
       completedOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE
-      completedOrdersQuery.selectedCarrierPartyIds = selectedCarrierPartyIds
+      completedOrdersQuery.selectedCarrierPartyIds = [carrierPartyId]
 
       this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery })
     },


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1039 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Infinite scroll was not working on the Completed Orders page after applying the result size filter.  
- Added logic to update the Completed Orders list after setting the result size, which was preventing infinite scroll from triggering.  


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)