### PR TITLE
Improved: button label to be shown if label is already generated in completed page (#1065)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -405,6 +405,7 @@
   "Print": "Print",
   "Print Customer Letter": "Print Customer Letter",
   "Print Picklist": "Print Picklist",
+  "Print Shipping Label": "Print Shipping Label",
   "Print supplementary documents with the shipment for package identification.": "Print supplementary documents with the shipment for package identification.",
   "Product identifier": "Product identifier",
   "Product is already received:": "Product is already received: {itemName}",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -398,6 +398,7 @@
   "Primary product ID": "Primary product ID",
   "Print Customer Letter": "Imprimir Carta al Cliente",
   "Print Picklist": "Imprimir Lista de Selección",
+  "Print Shipping Label": "Print Shipping Label",
   "Print supplementary documents with the shipment for package identification.": "Imprime documentos adicionales con el envío para la identificación del paquete.",
   "Product identifier": "Product identifier",
   "Product is already received:": "Producto ya esta recibido: {itemName}",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -399,6 +399,7 @@
   "Primary product ID": "Primary product ID",
   "Print Customer Letter": "顧客の手紙を印刷",
   "Print Picklist": "ピックリストを印刷",
+  "Print Shipping Label": "Print Shipping Label",
   "Print supplementary documents with the shipment for package identification.": "パッケージの識別のために、出荷時に補助書類を印刷します。",
   "Product identifier": "Product identifier",
   "Product is already received:": "製品はすでに受け取られています: {itemName}",

--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -151,7 +151,7 @@
                 <ion-button v-if="!hasPackedShipments(order)" :disabled="true">{{ translate("Shipped") }}</ion-button>
                 <ion-button v-else :disabled="isShipNowDisabled || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || ((isTrackingRequiredForAnyShipmentPackage(order) && !order.trackingCode) && !hasPermission(Actions.APP_FORCE_SHIP_ORDER))" @click.stop="shipOrder(order)">{{ translate("Ship Now") }}</ion-button>
                 <ion-button :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo" fill="outline" @click.stop="regenerateShippingLabel(order)">
-                  {{ translate("Regenerate Shipping Label") }}
+                  {{ translate(order.missingLabelImage ? "Regenerate Shipping Label" : "Print Shipping Label") }}
                   <ion-spinner color="primary" slot="end" v-if="order.isGeneratingShippingLabel" name="crescent" />
                 </ion-button>
                 <ion-button :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo" fill="outline" @click.stop="printPackingSlip(order)">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1065

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Updated the regenerate button text rendering to show Print Shipping Label in case of order with already having label.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2025-04-24 16-56-25](https://github.com/user-attachments/assets/2ca3cd21-1f83-47b5-9ecc-1ce50a77ed8f)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)