### PR TITLE
Fixed: scan gift card activation code visible in case of activated code (#986)

### DIFF
--- a/src/components/GiftCardActivationModal.vue
+++ b/src/components/GiftCardActivationModal.vue
@@ -35,7 +35,7 @@
         <ion-label slot="end">{{ formatCurrency(itemPriceInfo.unitPrice, itemPriceInfo.currencyUom) }}</ion-label>
       </ion-item>
 
-      <div class="ion-margin">
+      <div class="ion-margin" v-if="!item.isGCActivated">
         <ion-button expand="block" fill="outline" @click="isCameraEnabled ? stopScan() : scan()">
           <ion-icon slot="start" :icon="isCameraEnabled ? stopOutline : cameraOutline" />
           {{ translate(isCameraEnabled ? "Stop" : "Scan") }}


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#986

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added check to hide the scan button in case of already activated gift card item.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)