### PR TITLE
Fixed: loader issue on changing the result size filter (#1038)

### DIFF
--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -322,7 +322,7 @@ export default defineComponent({
     emitter.on('updateOrderQuery', this.updateOrderQuery)
     this.completedOrdersList = JSON.parse(JSON.stringify(this?.completedOrders.list)).slice(0, (this.completedOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
   },
-  ionViewWillLeave() {
+  beforeRouteLeave() {
     this.store.dispatch('order/clearCompletedOrders')
     emitter.off('updateOrderQuery', this.updateOrderQuery)
   },

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -1333,7 +1333,7 @@ export default defineComponent({
     ]);
     emitter.on('updateOrderQuery', this.updateOrderQuery)
   },
-  ionViewWillLeave() {
+  beforeRouteLeave() {
     this.store.dispatch('order/clearInProgressOrders')
     emitter.off('updateOrderQuery', this.updateOrderQuery)
   },

--- a/src/views/OpenOrders.vue
+++ b/src/views/OpenOrders.vue
@@ -438,7 +438,7 @@ export default defineComponent({
     this.productCategoryFilterExt = await useDynamicImport({ scope: "fulfillment_extensions", module: `${instance}_ProductCategoryFilter`});
     emitter.on("updateOrderQuery", this.updateOrderQuery);
   },
-  ionViewWillLeave() {
+  beforeRouteLeave() {
     this.store.dispatch('order/clearOpenOrders');
     emitter.off('updateOrderQuery', this.updateOrderQuery)
   },


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1038 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Identified an issue where `ionViewWillLeave` was not triggered when navigating away from the Open Orders page via a side menu, leading to the emitter not being turned off and causing a persistent loader when the result size was changed.
- This occurred when navigating through a sequence like: Open Orders → Order Details → In Progress Order Details → Back → Open Orders → Another Menu Item.
- To address this, added `beforeRouteLeave` in the Open, In Progress, and Completed Orders pages to ensure the emitter is properly turned off when navigating away, thereby resolving the loader issue.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)