### PR TITLE
Improved: Change pack action to "Reject" if all items are selected for rejection

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -350,6 +350,7 @@
   "Order Name": "Order Name",
   "Order packed successfully": "Order packed successfully",
   "Order packed successfully. Document generation in process": "Order packed successfully. Document generation in process",
+  "Order rejected successfully": "Order rejected successfully",
   "Other shipments in this order": "Other shipments in this order",
   "Order shipped successfully": "Order shipped successfully",
   "Order Shipment ID": "Order Shipment ID",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -344,6 +344,7 @@
   "Order Name": "ID de pedido",
   "Order packed successfully": "Pedido empacado exitosamente",
   "Order packed successfully. Document generation in process": "Pedido empacado con éxito. Proceso de generación de documentos en curso",
+  "Order rejected successfully": "Pedido rechazados exitosamente",
   "Other shipments in this order": "Otros envíos en este pedido",
   "Order shipped successfully": "Pedido enviado exitosamente",
   "Order Shipment ID": "ID de Envío del Pedido",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -344,6 +344,7 @@
   "Order Name": "注文名",
   "Order packed successfully": "注文が正常に梱包されました",
   "Order packed successfully. Document generation in process": "注文が正常に梱包されました。ドキュメント生成中",
+  "Order rejected successfully": "注文は拒否されました",
   "Other shipments in this order": "この注文の他の出荷",
   "Order shipped successfully": "注文が正常に出荷されました",
   "Order Shipment ID": "注文出荷ID",

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -504,7 +504,6 @@ export default defineComponent({
           facilityId: order.originFacilityId,
           rejectedOrderItems: updatedOrderDetail.rejectedOrderItems
         }
-        console.log(params)
         const resp = await OrderService.packOrder(params);
 
         if (hasError(resp)) {

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -189,7 +189,7 @@
 
             <div class="actions">
               <div>
-                <ion-button :color="order.hasAllRejectedItem ? 'danger' : 'primary'" @click.stop="packOrder(order)">{{ translate(order.hasAllRejectedItem ? "Reject" : "Pack") }}</ion-button>
+                <ion-button :color="order.hasAllRejectedItem ? 'danger' : ''" @click.stop="packOrder(order)">{{ translate(order.hasAllRejectedItem ? "Reject" : "Pack") }}</ion-button>
               </div>
 
               <div class="desktop-only">

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -189,7 +189,7 @@
 
             <div class="actions">
               <div>
-                <ion-button  @click.stop="packOrder(order)">{{ translate("Pack") }}</ion-button>
+                <ion-button :color="order.hasAllRejectedItem ? 'danger' : 'primary'" @click.stop="packOrder(order)">{{ translate(order.hasAllRejectedItem ? "Reject" : "Pack") }}</ion-button>
               </div>
 
               <div class="desktop-only">
@@ -429,6 +429,7 @@ export default defineComponent({
           }
         })
         order.hasRejectedItem = order.items.some((item:any) => item.rejectReason);
+        order.hasAllRejectedItem = this.isEntierOrderRejectionEnabled(order) || order.items.every((item: any) => item.rejectReason)
       this.store.dispatch('order/updateInProgressOrder', order)
     },
 
@@ -483,12 +484,41 @@ export default defineComponent({
         forceScan = !order.items.every((item: any) => item.rejectReason)
       }
 
-      if (order.missingLabelImage && hasPermission(Actions.APP_ORDER_SHIPMENT_METHOD_UPDATE)) {
+      if (order.hasAllRejectedItem) {
+        await this.rejectEntireOrder(order, updateParameter)
+      } else if (order.missingLabelImage && hasPermission(Actions.APP_ORDER_SHIPMENT_METHOD_UPDATE)) {
         await this.generateTrackingCodeForPacking(order, updateParameter, forceScan)
       } else if (forceScan) {
         await this.scanOrder(order, updateParameter)
       } else {
         this.confirmPackOrder(order, updateParameter);
+      }
+    },
+    async rejectEntireOrder(order: any, updateParameter?: string) {
+      emitter.emit('presentLoader');
+      try {
+        const updatedOrderDetail = await this.getUpdatedOrderDetail(order, updateParameter)
+        const params = {
+          shipmentId: order.shipmentId,
+          orderId: order.orderId,
+          facilityId: order.originFacilityId,
+          rejectedOrderItems: updatedOrderDetail.rejectedOrderItems
+        }
+        console.log(params)
+        const resp = await OrderService.packOrder(params);
+
+        if (hasError(resp)) {
+          throw resp.data
+        }
+
+        await Promise.all([this.fetchPickersInformation(), this.updateOrderQuery("", "", true)]);
+        showToast(translate('Order rejected successfully'));
+
+      } catch (err) {
+        logger.error('Failed to reject order', err)
+        showToast(translate('Failed to reject order'))
+      } finally {
+        emitter.emit("dismissLoader");
       }
     },
     async confirmPackOrder(order: any, updateParameter?: string) {
@@ -809,6 +839,7 @@ export default defineComponent({
         }
       })
       order.hasRejectedItem = true
+      order.hasAllRejectedItem = this.isEntierOrderRejectionEnabled(order) || order.items.every((item: any) => item.rejectReason)
       this.store.dispatch('order/updateInProgressOrder', order)
     },
     rejectKitComponent(order: any, item: any, componentProductId: string) {

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -757,7 +757,6 @@ export default defineComponent({
           facilityId: order.originFacilityId,
           rejectedOrderItems: updatedOrderDetail.rejectedOrderItems
         }
-        console.log(params)
         const resp = await OrderService.packOrder(params);
 
         if (hasError(resp)) {

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -179,9 +179,9 @@
             <!-- positive -->
             <div>
               <template v-if="category === 'in-progress'">
-                <ion-button @click="packOrder(order)">
+                <ion-button :color="order.hasAllRejectedItem ? 'danger' : 'primary'" @click="packOrder(order)">
                   <ion-icon slot="start" :icon="personAddOutline" />
-                  {{ translate("Pack order") }}
+                  {{ translate(order.hasAllRejectedItem ? "Reject order" : "Pack order") }}
                 </ion-button>
                 <Component :is="printDocumentsExt" :category="category" :order="order" :currentFacility="currentFacility" :hasMissingInfo="order.missingLabelImage"/>
               </template>  
@@ -737,12 +737,40 @@ export default defineComponent({
         forceScan = !order.items.every((item: any) => item.rejectReason)
       }
 
-      if (order.missingLabelImage && hasPermission(Actions.APP_ORDER_SHIPMENT_METHOD_UPDATE)) {
+      if (order.hasAllRejectedItem) {
+        await this.rejectEntireOrder(order, updateParameter)
+      } else if (order.missingLabelImage && hasPermission(Actions.APP_ORDER_SHIPMENT_METHOD_UPDATE)) {
         await this.generateTrackingCodeForPacking(order, updateParameter, forceScan)
       } else if (forceScan) {
         await this.scanOrder(order, updateParameter)
       } else {
         this.confirmPackOrder(order, updateParameter);
+      }
+    },
+    async rejectEntireOrder(order: any, updateParameter?: string) {
+      emitter.emit('presentLoader');
+      try {
+        const updatedOrderDetail = await this.getUpdatedOrderDetail(order, updateParameter)
+        const params = {
+          shipmentId: order.shipmentId,
+          orderId: order.orderId,
+          facilityId: order.originFacilityId,
+          rejectedOrderItems: updatedOrderDetail.rejectedOrderItems
+        }
+        console.log(params)
+        const resp = await OrderService.packOrder(params);
+
+        if (hasError(resp)) {
+          throw resp.data
+        }
+
+        // await Promise.all([this.fetchPickersInformation(), this.updateOrderQuery("", "", true)]);
+        showToast(translate('Order rejected successfully'));
+      } catch (err) {
+        logger.error('Failed to reject order', err)
+        showToast(translate('Failed to reject order'))
+      } finally {
+        emitter.emit("dismissLoader");
       }
     },
     async confirmPackOrder(order: any, updateParameter?: string) {
@@ -920,7 +948,7 @@ export default defineComponent({
           }
         })
         order.hasRejectedItem = true
-        
+        order.hasAllRejectedItem = this.isEntierOrderRejectionEnabled(order) || order.items.every((item: any) => item.rejectReason)
 
         /*
         Commenting this out to avoid directly updating items. Now user need to click on the save button to save the detail.
@@ -940,6 +968,7 @@ export default defineComponent({
           }
         })
         order.hasRejectedItem = order.items.some((item:any) => item.rejectReason);
+        order.hasAllRejectedItem = this.isEntierOrderRejectionEnabled(order) || order.items.every((item: any) => item.rejectReason)
     },
     rejectKitComponent(order: any, item: any, componentProductId: string) {
       let kitComponents = item.kitComponents ? item.kitComponents : []

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -179,7 +179,7 @@
             <!-- positive -->
             <div>
               <template v-if="category === 'in-progress'">
-                <ion-button :color="order.hasAllRejectedItem ? 'danger' : 'primary'" @click="packOrder(order)">
+                <ion-button :color="order.hasAllRejectedItem ? 'danger' : ''" @click="packOrder(order)">
                   <ion-icon slot="start" :icon="personAddOutline" />
                   {{ translate(order.hasAllRejectedItem ? "Reject order" : "Pack order") }}
                 </ion-button>


### PR DESCRIPTION
### Related Issues

#1140 

### Short Description and Why It's Useful
Update the `In Progress` and `Order Detail` pages to switch the Pack action button to `Reject` with danger color styling when all items are marked for rejection.

The logic of switching the button is based on the partial rejection toggle or the number of units marked for rejection in a particular order.

### Screenshots of Visual Changes before/after (If There Are Any)
#### In Progress Page
##### Before
![image](https://github.com/user-attachments/assets/c3720a93-a5dc-42e8-a94c-9431b0a5fe58)
##### After
![image](https://github.com/user-attachments/assets/fcf45d45-ffd7-466d-b8de-06eae6c789e1)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)