### PR TITLE
 Fixed: Set the default value of isTrackingRequired as 'Y' from fetchTransferShipmentDetail action and reverted old ui logic.(#1168)

### DIFF
--- a/src/services/TransferOrderService.ts
+++ b/src/services/TransferOrderService.ts
@@ -53,7 +53,6 @@ const fetchShippedTransferShipments = async (params: any): Promise<any> => {
   });
 };
 
-
 const fetchTransferShipmentDetails = async (params: Record<string, any>): Promise<any> => {
   const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
   const baseURL = store.getters['user/getMaargBaseUrl'];

--- a/src/store/modules/transferorder/actions.ts
+++ b/src/store/modules/transferorder/actions.ts
@@ -160,7 +160,8 @@ const actions: ActionTree<TransferOrderState, RootState> = {
             pickedQuantity: item.quantity,
             shippedQuantity: item.totalIssuedQuantity || 0,
           })),
-          totalQuantityPicked: shipments[0]?.items.reduce((acc: number, curr: any) => acc + curr.quantity, 0)
+          totalQuantityPicked: shipments[0]?.items.reduce((acc: number, curr: any) => acc + curr.quantity, 0),
+          isTrackingRequired: shipments[0]?.isTrackingRequired ?? 'Y' 
         };
 
         commit(types.ORDER_CURRENT_SHIPMENT_UPDATED, shipment);

--- a/src/store/modules/user/index.ts
+++ b/src/store/modules/user/index.ts
@@ -21,8 +21,8 @@ const userModule: Module<UserState, RootState> = {
         registration: null,
       },
       omsRedirectionInfo: {
-         url: "",
-         token: ""
+        url: "",
+        token: ""
       },
       notifications: [],
       notificationPrefs: [],

--- a/src/views/TransferShipmentReview.vue
+++ b/src/views/TransferShipmentReview.vue
@@ -45,8 +45,13 @@
         <TransferOrderItem v-for="item in shipmentItems" :key="item.shipmentItemSeqId" :itemDetail="item" />
       </main>
 
-      <ion-fab vertical="bottom" horizontal="end" slot="fixed">
+      <!-- <ion-fab vertical="bottom" horizontal="end" slot="fixed">    //temporarily disabled the fab button so that the user can not ship the order if tracking code is not present
         <ion-fab-button :disabled="!hasPermission(Actions.APP_TRANSFER_ORDER_UPDATE) || !Object.keys(currentShipment).length || (currentShipment.isTrackingRequired &&  !trackingCode?.trim())" @click="confirmShip()">
+          <ion-icon :icon="sendOutline" />
+        </ion-fab-button>
+      </ion-fab> -->
+      <ion-fab vertical="bottom" horizontal="end" slot="fixed">
+        <ion-fab-button :disabled="!hasPermission(Actions.APP_TRANSFER_ORDER_UPDATE) || !Object.keys(currentShipment).length || !trackingCode?.trim()" @click="confirmShip()">
           <ion-icon :icon="sendOutline" />
         </ion-fab-button>
       </ion-fab>

--- a/src/views/TransferShipmentReview.vue
+++ b/src/views/TransferShipmentReview.vue
@@ -45,13 +45,8 @@
         <TransferOrderItem v-for="item in shipmentItems" :key="item.shipmentItemSeqId" :itemDetail="item" />
       </main>
 
-      <!-- <ion-fab vertical="bottom" horizontal="end" slot="fixed">    //temporarily disabled the fab button so that the user can not ship the order if tracking code is not present
-        <ion-fab-button :disabled="!hasPermission(Actions.APP_TRANSFER_ORDER_UPDATE) || !Object.keys(currentShipment).length || (currentShipment.isTrackingRequired &&  !trackingCode?.trim())" @click="confirmShip()">
-          <ion-icon :icon="sendOutline" />
-        </ion-fab-button>
-      </ion-fab> -->
       <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-        <ion-fab-button :disabled="!hasPermission(Actions.APP_TRANSFER_ORDER_UPDATE) || !Object.keys(currentShipment).length || !trackingCode?.trim()" @click="confirmShip()">
+        <ion-fab-button :disabled="!hasPermission(Actions.APP_TRANSFER_ORDER_UPDATE) || !Object.keys(currentShipment).length || (currentShipment.isTrackingRequired === 'Y' &&  !trackingCode?.trim())" @click="confirmShip()">
           <ion-icon :icon="sendOutline" />
         </ion-fab-button>
       </ion-fab>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#1168

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Set the default value of isTrackingRequired as 'Y' from fetchTransferShipmentDetail action and reverted old ui logic. So the user can not ship the order if tracking code is required and not entered.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

[Screencast from 26-05-25 03:49:25 PM IST.webm](https://github.com/user-attachments/assets/323f2dbe-f3ab-4919-ac0f-b1cff1fefa16)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)