### PR TITLE
Fixed: updated item filtering logic in TransferOrderDetail to include only pending fulfill items in Open tab. (#1162)

### DIFF
--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -242,7 +242,7 @@ export default defineComponent({
       if (orderType === 'completed') {
         return this.currentOrder?.items?.filter((item: any) => item.statusId === 'ITEM_COMPLETED')
       } else {
-        return this.currentOrder?.items?.filter((item: any) => item.statusId !== 'ITEM_COMPLETED' && item.statusId !== 'ITEM_CANCELLED' && item.statusId !== 'ITEM_REJECTED')
+        return this.currentOrder?.items?.filter((item: any) => item.statusId === 'ITEM_PENDING_FULFILL')
       }
     },
     async createShipment() {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1162 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Updated item filtering logic in TransferOrderDetail to include only pending fulfill items in Open tab.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 26-05-25 04:12:58 PM IST.webm](https://github.com/user-attachments/assets/ba3d8e51-8a06-48bc-929a-e0d859630998)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)