### PR TITLE
Fixed: Filter orders with shipment packages before cloning inProgress Orders list (#1038)

### DIFF
--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -572,7 +572,7 @@ export default defineComponent({
             role: 'confirm',
             handler: async (data) => {
               emitter.emit('presentLoader');
-              let orderList = JSON.parse(JSON.stringify(this.inProgressOrders.list))
+              let orderList = JSON.parse(JSON.stringify(this.inProgressOrders.list.filter((order: any) => order.shipmentPackages?.length)))
               // fetch related shipmentIds when missing
               if (this.isInProgressOrderScrollable()) {
                 const remainingOrderIndex = (this.inProgressOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any);


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1038 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Updated the logic to clone only those orders that have shipmentPackages. This avoids processing orders without any shipment data.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)