### PR TITLE
Fix rejection stats facet key

### DIFF
--- a/src/store/modules/rejection/actions.ts
+++ b/src/store/modules/rejection/actions.ts
@@ -37,7 +37,7 @@ const actions: ActionTree<RejectionState, RootState> = {
             "limit":-1,
             "type":"terms",
           },
-          "prodductIdFacet":{
+          "productIdFacet":{
             "field":"productId_s",
             "mincount":1,
             "limit":-1,
@@ -51,7 +51,7 @@ const actions: ActionTree<RejectionState, RootState> = {
         if (!hasError(resp)) {
           total = resp.data.facets.total ? resp.data.facets.total : 0
           const usedReasons = resp.data.facets.rejectionReasonIdFacet.buckets
-          rejectedItems = resp.data.facets.prodductIdFacet.buckets
+          rejectedItems = resp.data.facets.productIdFacet.buckets
           if (rejectedItems) {
             const productIds = rejectedItems.map((rejectedItem: any) => rejectedItem.val)
             await this.dispatch('product/fetchProducts', { productIds })


### PR DESCRIPTION
## Summary
- rename `prodductIdFacet` to `productIdFacet` when preparing rejection stats query
- update facet response handling accordingly

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm test` *(fails: Missing script)*