### PR TITLE
Fix CSV parsing error handling

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -231,7 +231,7 @@ const parseCsv = async (file: File, options?: any) => {
       skipEmptyLines: true,
       complete: function (results: any) {
         if (results.errors.length) {
-          reject(results.error)
+          reject(results.errors)
         } else {
           resolve(results.data)
         }


### PR DESCRIPTION
## Summary
- handle `Papa.parse` errors correctly in utils

## Testing
- `npm run test:unit` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_b_6839b6dbc65c8321a2768c1760fae3a0