### PR TITLE
Fixed: Updated keys for response of getInventoryAvailableByFacility endpoint. (#1196)

### DIFF
--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -362,8 +362,8 @@ async function findProductFromIdentifier(payload: any) {
             sku: product.sku,
             quantity: quantityField ? (Number(uploadedItemsByIdValue[idValue][quantityField]) || 0) : 0,
             isChecked: false,
-            qoh: stock.quantityOnHandTotal || 0,
-            atp: stock.availableToPromiseTotal || 0
+            qoh: stock.qoh || 0,
+            atp: stock.atp || 0
           })
         }
       })
@@ -400,8 +400,8 @@ async function addProductToOrder(scannedId?: any, product?: any) {
   } as any;
 
   const stock = await fetchStock(newProduct.productId);
-  if(stock?.quantityOnHandTotal || stock?.quantityOnHandTotal === 0) {
-    newProduct = { ...newProduct, qoh: stock.quantityOnHandTotal, atp: stock.availableToPromiseTotal }
+  if(stock?.qoh || stock?.qoh === 0) {
+    newProduct = { ...newProduct, qoh: stock.qoh, atp: stock.atp }
   }
   
   if(product) {
@@ -890,3 +890,6 @@ function openDateTimeModal(type: any) {
   }
 }
 </style>
+
+
+


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1196

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Currently the QOH and ATP are fetched by the maarg endpoint but when user clicks the book qoh or book atp buttons it does not update the field, also the qoh chip in the product card item does not reflect current QOH, all because the current code was written
to consume keys "quantityOnHandTotal" and "availableToPromiseTotal" but the api response contains "qoh" and "atp" keys, i updated the code to adhere with new keys.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 03-06-25 11:21:18 AM IST.webm](https://github.com/user-attachments/assets/97818077-d471-4a50-97a8-fff8da4fac2c)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)