### PR TITLE
Fix filter imports

### DIFF
--- a/src/components/CompletedFilters.vue
+++ b/src/components/CompletedFilters.vue
@@ -65,8 +65,8 @@ import {
   IonToolbar,
   menuController
 } from '@ionic/vue';
-import { computed, defineComponent } from 'vue';
-import { useStore } from 'vuex';
+import { defineComponent } from 'vue';
+import { mapGetters, useStore } from 'vuex';
 import { translate } from '@hotwax/dxp-components';
 
 export default defineComponent({
@@ -95,15 +95,11 @@ export default defineComponent({
     }
   },
   computed: {
-    completedOrders() {
-      return this.store.getters['order/getCompletedOrders']
-    },
-    getPartyName() {
-      return this.store.getters['util/getPartyName']
-    },
-    getShipmentMethodDesc() {
-      return this.store.getters['util/getShipmentMethodDesc']
-    }
+    ...mapGetters({
+      completedOrders: 'order/getCompletedOrders',
+      getPartyName: 'util/getPartyName',
+      getShipmentMethodDesc: 'util/getShipmentMethodDesc'
+    })
   },
   methods: {
     prepareViewSizeOptions () {
@@ -129,15 +125,15 @@ export default defineComponent({
       }
       completedOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE
       completedOrdersQuery.selectedShipmentMethods = selectedShipmentMethods
-      this.$emit("update-shipment-methods", selectedShipmentMethods)
       await this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery })
+      await menuController.close()
     },
     async updateSelectedCarrierPartyIds(carrierPartyId: string) {
       const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
       completedOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE
       completedOrdersQuery.selectedCarrierPartyId = carrierPartyId
-      this.$emit("update-carrier", carrierPartyId)
       await this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery })
+      await menuController.close()
     }
   },
   setup() {

--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -172,7 +172,6 @@ import {
   IonButton,
   IonButtons,
   IonCard,
-  IonCheckbox,
   IonChip,
   IonContent,
   IonFab,
@@ -187,9 +186,6 @@ import {
   IonMenuButton,
   IonNote,
   IonPage,
-  IonRadio,
-  IonRadioGroup,
-  IonRow,
   IonSearchbar,
   IonSkeletonText,
   IonSpinner,
@@ -230,7 +226,6 @@ export default defineComponent({
     IonButton,
     IonButtons,
     IonCard,
-    IonCheckbox,
     IonChip,
     IonContent,
     IonFab,
@@ -245,9 +240,6 @@ export default defineComponent({
     IonMenuButton,
     IonNote,
     IonPage,
-    IonRadio,
-    IonRadioGroup,
-    IonRow,
     IonSearchbar,
     IonSkeletonText,
     IonSpinner,
@@ -585,7 +577,6 @@ export default defineComponent({
       completedOrdersQuery.queryString = queryString
       await this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery })
       this.searchedQuery = queryString;
-    },
     },
     async unpackOrder(order: any) {
       const unpackOrderAlert = await alertController


### PR DESCRIPTION
## Summary
- cleanup imports for filter sidebar
- remove unused variable imports
- revert query update logic to remove side effects

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840433e579083288e9293918d197b40