### PR TITLE
Implemented: Update PDF Document API Endpoints and Add Getter for Maarg Origin URL (#1215)

### DIFF
--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -118,7 +118,7 @@ const createPicklist = async (payload: any): Promise <any>  => {
 }
 
 const printPicklist = async (picklistId: string): Promise <any>  => {
-  const baseURL = store.getters['user/getMaargBaseUrl'];
+  const maargUrl = store.getters['user/getMaargUrl'];
   const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
 
   try {
@@ -131,7 +131,7 @@ const printPicklist = async (picklistId: string): Promise <any>  => {
     const resp = await client({
       url: "/fop/apps/pdf/PrintPicklist",
       method: "GET",
-      baseURL: new URL(baseURL).origin,
+      baseURL: maargUrl,
       headers: {
         "api_key": omsRedirectionInfo.token,
         "Content-Type": "application/json"
@@ -161,14 +161,14 @@ const printPicklist = async (picklistId: string): Promise <any>  => {
 
 const printPackingSlip = async (shipmentIds: Array<string>): Promise<any> => {
   try {
-    const baseURL = store.getters['user/getMaargBaseUrl'];
+    const maargUrl = store.getters['user/getMaargUrl'];
     const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
 
     // Get packing slip from the server
     const resp = await client({
       url: "/fop/apps/pdf/PrintPackingSlip",
       method: "GET",
-      baseURL: new URL(baseURL).origin,
+      baseURL: maargUrl,
       headers: {
         "api_key": omsRedirectionInfo.token,
         "Content-Type": "application/json"
@@ -202,7 +202,7 @@ const printPackingSlip = async (shipmentIds: Array<string>): Promise<any> => {
 
 const printShippingLabel = async (shipmentIds: Array<string>, shippingLabelPdfUrls?: Array<string>, shipmentPackages?: Array<any>, imageType?: string): Promise<any> => {
   try {
-    const baseURL = store.getters['user/getMaargBaseUrl'];
+    const maargUrl = store.getters['user/getMaargUrl'];
     const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
 
     let pdfUrls = shippingLabelPdfUrls;
@@ -225,7 +225,7 @@ const printShippingLabel = async (shipmentIds: Array<string>, shippingLabelPdfUr
       const resp = await client({
         url: "/fop/apps/pdf/PrintLabel",
         method: "GET",
-        baseURL: new URL(baseURL).origin,
+        baseURL: maargUrl,
         headers: {
           "api_key": omsRedirectionInfo.token,
           "Content-Type": "application/json"
@@ -292,14 +292,14 @@ const printShippingLabelAndPackingSlip = async (shipmentIds: Array<string>, ship
   }
 
   try {
-    const baseURL = store.getters['user/getMaargBaseUrl'];
+    const maargUrl = store.getters['user/getMaargUrl'];
     const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
 
     // Get packing slip from the server
     const resp = await client({
       url: "/fop/apps/pdf/PrintPackingSlipAndLabel",
       method: "GET",
-      baseURL: new URL(baseURL).origin,
+      baseURL: maargUrl,
       headers: {
         "api_key": omsRedirectionInfo.token,
         "Content-Type": "application/json"

--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -129,9 +129,9 @@ const printPicklist = async (picklistId: string): Promise <any>  => {
     }
 
     const resp = await client({
-      url: "/poorti/Picklist.pdf",
+      url: "/fop/apps/pdf/PrintPicklist",
       method: "GET",
-      baseURL,
+      baseURL: new URL(baseURL).origin,
       headers: {
         "api_key": omsRedirectionInfo.token,
         "Content-Type": "application/json"
@@ -166,9 +166,9 @@ const printPackingSlip = async (shipmentIds: Array<string>): Promise<any> => {
 
     // Get packing slip from the server
     const resp = await client({
-      url: "/poorti/PackingSlip.pdf",
+      url: "/fop/apps/pdf/PrintPackingSlip",
       method: "GET",
-      baseURL,
+      baseURL: new URL(baseURL).origin,
       headers: {
         "api_key": omsRedirectionInfo.token,
         "Content-Type": "application/json"
@@ -223,9 +223,9 @@ const printShippingLabel = async (shipmentIds: Array<string>, shippingLabelPdfUr
       }
       // Get packing slip from the server
       const resp = await client({
-        url: "/poorti/Label.pdf",
+        url: "/fop/apps/pdf/PrintLabel",
         method: "GET",
-        baseURL,
+        baseURL: new URL(baseURL).origin,
         headers: {
           "api_key": omsRedirectionInfo.token,
           "Content-Type": "application/json"
@@ -297,9 +297,9 @@ const printShippingLabelAndPackingSlip = async (shipmentIds: Array<string>, ship
 
     // Get packing slip from the server
     const resp = await client({
-      url: "/poorti/PackingSlipAndLabel.pdf",
+      url: "/fop/apps/pdf/PrintPackingSlipAndLabel",
       method: "GET",
-      baseURL,
+      baseURL: new URL(baseURL).origin,
       headers: {
         "api_key": omsRedirectionInfo.token,
         "Content-Type": "application/json"

--- a/src/store/modules/user/getters.ts
+++ b/src/store/modules/user/getters.ts
@@ -34,7 +34,8 @@ const getters: GetterTree <UserState, RootState> = {
         return state.pwaState;
     },
     getMaargUrl (state) {
-        return new URL(state.omsRedirectionInfo.url).origin
+        const url = state.omsRedirectionInfo.url;
+        return url.startsWith('http') ? new URL(url).origin : `https://${url}.hotwax.io`;
     },
     getMaargBaseUrl (state) {
         const url = state.omsRedirectionInfo.url

--- a/src/store/modules/user/getters.ts
+++ b/src/store/modules/user/getters.ts
@@ -33,6 +33,9 @@ const getters: GetterTree <UserState, RootState> = {
     getPwaState(state) {
         return state.pwaState;
     },
+    getMaargUrl (state) {
+        return new URL(state.omsRedirectionInfo.url).origin
+    },
     getMaargBaseUrl (state) {
         const url = state.omsRedirectionInfo.url
         return url.startsWith('http') ? url.includes('/rest/s1') ? url : `${url}/rest/s1/` : `https://${url}.hotwax.io/rest/s1`;


### PR DESCRIPTION
### Related Issues

#1215 

### Short Description and Why It's Useful
This PR introduces a new getter to retrieve the Maarg instance origin URL and updates the API endpoint paths in the order services that request for PDF documents.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)