### PR TITLE
Improved: Removed buttons to show completed transfer orders when there is no open orders (#1241).

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -574,7 +574,6 @@
   "Show all pickers": "Show all pickers",
   "Show label error": "Show label error",
   "Show order items": "Show order items",
-  "Show completed transfer orders": "Show completed transfer orders",
   "Single variance": "Single variance",
   "Something went wrong while fetching order details, please check the orderId and try again.": "Something went wrong while fetching order details, please check the orderId and try again.",
   "Something went wrong": "Something went wrong",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -567,7 +567,6 @@
   "Show all pickers": "Show all pickers",
   "Show label error": "Show label error",
   "Show order items": "Mostrar artículos del pedido",
-  "Show completed transfer orders": "Show completed transfer orders",
   "Single variance": "Variante unica",
   "Something went wrong": "Algo salió mal",
   "Something went wrong while getting complete user permissions.": "Algo salió mal al obtener permisos de usuario completos.",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -569,7 +569,6 @@
   "Show all pickers": "Show all pickers",
   "Show label error": "ラベルエラーを表示",
   "Show order items": "注文アイテムを表示",
-  "Show completed transfer orders": "Show completed transfer orders",
   "Single variance": "単一変動",
   "Something went wrong while fetching order details, please check the orderId and try again.": "注文詳細の取得中にエラーが発生しました。注文IDを確認して再試行してください。",
   "Something went wrong": "エラーが発生しました",

--- a/src/views/TransferOrders.vue
+++ b/src/views/TransferOrders.vue
@@ -48,9 +48,6 @@
       </div>
       <div v-else class="empty-state">
         <p v-html="getErrorMessage()"></p>
-        <ion-button v-if="!transferOrders.query.queryString && hasCompletedTransferOrders && selectedSegment === 'open'" size="small" fill="outline" color="medium" @click="showCompletedTransferOrders">
-          <ion-icon slot="end" :icon="checkmarkDoneOutline"/>{{ translate("Show completed transfer orders") }}
-        </ion-button>
       </div>
     </ion-content>
 
@@ -66,7 +63,6 @@
 <script lang="ts">
 import { 
   IonBadge,
-  IonButton,
   IonIcon,
   IonContent, 
   IonFab,
@@ -98,7 +94,6 @@ export default defineComponent({
   name: 'TransferOrders',
   components: {
     IonBadge,
-    IonButton,
     IonIcon,  
     IonContent,
     IonFab,


### PR DESCRIPTION


### Related Issues
#1241 

#

### Short Description and Why It's Useful
Improved: Removed buttons to show completed transfer orders when there is no open orders as the segment to show completed orders is already added (#1241).

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)