### PR TITLE
Fixed: Used unique key while rendering transfer order item component in order to fix the wrong item detail in case of same orderItemSeqId (#1221).

### DIFF
--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -40,7 +40,7 @@
         <div class="segments" v-if="currentOrder">
           <template v-if="selectedSegment === 'open'">
             <template v-if="getTOItems('open')?.length > 0">
-              <TransferOrderItem v-for="item in getTOItems('open')" :key="item.orderItemSeqId" :itemDetail="item" :class="item.internalName === lastScannedId ? 'scanned-item' : '' " :id="item.internalName" isRejectionSupported="true"/>
+              <TransferOrderItem v-for="item in getTOItems('open')" :key="currentOrder.orderId + item.orderItemSeqId" :itemDetail="item" :class="item.internalName === lastScannedId ? 'scanned-item' : '' " :id="item.internalName" isRejectionSupported="true"/>
             </template>
             <template v-else>
               <div class="empty-state">


### PR DESCRIPTION


### Related Issues
#1221 
#

### Short Description and Why It's Useful
Fixed: Used unique key while rendering transfer order item component in order to fix the wrong item detail in case of same orderItemSeqId (#1221).


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)