### PR TITLE
Improved: Used oms-api's apiClient method instead of client method in order to use oms token instead of api_key for the moqui authentication (#1266).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@hotwax/app-version-info": "^1.0.0",
         "@hotwax/apps-theme": "^1.2.9",
         "@hotwax/dxp-components": "^1.22.1",
-        "@hotwax/oms-api": "^1.21.0",
+        "@hotwax/oms-api": "^1.22.0",
         "@ionic/core": "^7.6.0",
         "@ionic/vue": "^7.6.0",
         "@ionic/vue-router": "^7.6.0",
@@ -2959,9 +2959,9 @@
       }
     },
     "node_modules/@hotwax/oms-api": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@hotwax/oms-api/-/oms-api-1.21.0.tgz",
-      "integrity": "sha512-zloHBu9Fb6oI2Fk9btezZIqA4NTlYpCZoh9nbtW0HNatssYiSDJeeBCh0Dh/6/mOyPBpvZO1d4JWUk/kGtQxyA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@hotwax/oms-api/-/oms-api-1.22.0.tgz",
+      "integrity": "sha512-GwR/T+rdwNLtc7+PizEHIKluHH5VAzZ+dmKbto6hPNXcd51lSJqlUQJVAy6lvwZvIKcMLUusHPCC8NSCMofMdA==",
       "dependencies": {
         "@types/node-json-transform": "^1.0.0",
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@hotwax/app-version-info": "^1.0.0",
     "@hotwax/apps-theme": "^1.2.9",
     "@hotwax/dxp-components": "^1.22.1",
-    "@hotwax/oms-api": "^1.21.0",
+    "@hotwax/oms-api": "^1.22.0",
     "@ionic/core": "^7.6.0",
     "@ionic/vue": "^7.6.0",
     "@ionic/vue-router": "^7.6.0",

--- a/src/adapter/index.ts
+++ b/src/adapter/index.ts
@@ -1,10 +1,10 @@
   
-import { api, client, getConfig, getNotificationEnumIds, getNotificationUserPrefTypeIds, getProductIdentificationPref, fetchGoodIdentificationTypes, getUserFacilities, getUserPreference,  hasError, initialise, logout, removeClientRegistrationToken, resetConfig, setProductIdentificationPref, setUserLocale, storeClientRegistrationToken,
+import { api, apiClient, client, getConfig, getNotificationEnumIds, getNotificationUserPrefTypeIds, getProductIdentificationPref, fetchGoodIdentificationTypes, getUserFacilities, getUserPreference,  hasError, initialise, logout, removeClientRegistrationToken, resetConfig, setProductIdentificationPref, setUserLocale, storeClientRegistrationToken,
   subscribeTopic, unsubscribeTopic, updateInstanceUrl, updateToken, setUserTimeZone, setUserPreference, getAvailableTimeZones, getEComStoresByFacility } from '@hotwax/oms-api'
 
 export {
   api,
-  client,
+  apiClient,
   getConfig,
   getNotificationEnumIds,
   getNotificationUserPrefTypeIds,

--- a/src/services/CarrierService.ts
+++ b/src/services/CarrierService.ts
@@ -1,32 +1,32 @@
-import { client } from '@/adapter';
+import { apiClient } from '@/adapter';
 import store from '@/store';
   
 
 const fetchCarriers = async (params: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/shippingGateways/carrierShipmentMethods/counts`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params
   });
 }
 const fetchCarrierShipmentMethods = async (params: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     url: `/oms/shippingGateways/carrierShipmentMethods`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params
@@ -34,105 +34,105 @@ const fetchCarrierShipmentMethods = async (params: any): Promise<any> => {
 }
 
 const fetchShipmentMethodTypes = async (params: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     url: `/oms/shippingGateways/shipmentMethodTypes`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params
   });
 }
 const fetchProductStoreShipmentMethodsByCarrier = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     url: `/oms/entityData`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const  fetchProductStoreShipmentMethods = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     url: `/oms/entityData`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const removeCarrierShipmentMethod = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/shippingGateways/carrierShipmentMethods`,
     method: "DELETE",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const addCarrierShipmentMethod = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/shippingGateways/carrierShipmentMethods`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const updateShipmentMethodType = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/shippingGateways/shipmentMethodTypes/${payload.shipmentMethodTypeId}`,
     method: "PUT",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const updateCarrierShipmentMethod = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/shippingGateways/carrierShipmentMethods`,
     method: "PUT",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -140,120 +140,120 @@ const updateCarrierShipmentMethod = async (payload: any): Promise<any> => {
 }
 
 const createProductStoreShipmentMethod = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/shipmentMethods`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const updateProductStoreShipmentMethod = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/shipmentMethods`,
     method: "PUT",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const removeProductStoreShipmentMethod = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/shipmentMethods`,
     method: "PUT",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const addCarrierToFacility = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/facilities/${payload.facilityId}/parties`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const removeCarrierFromFacility = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/facilities/${payload.facilityId}/parties`,
     method: "PUT",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const fetchCarrierFacilities = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/entityData`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const fetchFacilityCarriers = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/entityData`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const createShipmentMethod = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/shippingGateways/shipmentMethodTypes`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -261,15 +261,15 @@ const createShipmentMethod = async (payload: any): Promise<any> => {
 }
 
 const createCarrier = async (payload: any): Promise <any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/shippingGateways/carrierParties`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -277,15 +277,15 @@ const createCarrier = async (payload: any): Promise <any> => {
 }
 
 const updateCarrier = async (payload: any): Promise <any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/admin/organizations/${payload.partyId}`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -293,15 +293,15 @@ const updateCarrier = async (payload: any): Promise <any> => {
 }
 
 const fetchCarrierTrackingUrls = async (params: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     url: `/admin/systemProperties`, //should handle the update of OISG, SRG, SPRG if needed
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params
@@ -309,15 +309,15 @@ const fetchCarrierTrackingUrls = async (params: any): Promise<any> => {
 }
 
 const fetchShipmentGatewayConfigs = async (params: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/shippingGateways/config`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params

--- a/src/services/OrderLookupService.ts
+++ b/src/services/OrderLookupService.ts
@@ -1,4 +1,4 @@
-import { api, client, hasError } from "@/adapter"
+import { api, apiClient, hasError } from "@/adapter"
 import store from '@/store';
 import logger from '@/logger';
 import { showToast } from '@/utils';
@@ -15,30 +15,30 @@ const findOrder = async (payload: any): Promise<any> => {
 }
 
 const fetchOrderDetail = async (orderId: string): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     url: `/oms/orders/${orderId}`, //should handle the update of OISG, SRG, SPRG if needed
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
   });
 }
 
 const fetchCarrierTrackingUrls = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     url: `/admin/systemProperties`, //should handle the update of OISG, SRG, SPRG if needed
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -46,15 +46,15 @@ const fetchCarrierTrackingUrls = async (payload: any): Promise<any> => {
 }
 
 const fetchPartyInformation = async (payload: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/parties`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -62,15 +62,15 @@ const fetchPartyInformation = async (payload: any): Promise <any>  => {
 }
 
 const fetchOrderFacilityChange = async (payload: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/orders/${payload.orderId}/facilityChange`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -78,15 +78,15 @@ const fetchOrderFacilityChange = async (payload: any): Promise <any>  => {
 }
 
 const fetchOrderItems = async (payload: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/orders/${payload.orderId}/items`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -94,7 +94,7 @@ const fetchOrderItems = async (payload: any): Promise <any>  => {
 }
 
 const findShipments = async (orderId: string): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
   const params = {
@@ -106,12 +106,12 @@ const findShipments = async (orderId: string): Promise <any>  => {
     shipmentTypeId: 'SALES_SHIPMENT', 
   } as any
 
-  return await client({
+  return await apiClient({
     url: `/poorti/shipments`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params
@@ -119,15 +119,15 @@ const findShipments = async (orderId: string): Promise <any>  => {
 }
 
 const fetchFacilities = async (payload: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/facilities`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -145,7 +145,7 @@ const findOrderInvoicingInfo = async (query: any): Promise<any> => {
 const printShippingLabel = async (shipmentIds: Array<string>, shippingLabelPdfUrls?: Array<string>, shipmentPackages?: Array<any>, imageType?: string): Promise<any> => {
   try {
     const baseURL = store.getters['user/getMaargBaseUrl'];
-    const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+    const omstoken = store.getters['user/getUserToken'];
 
     let pdfUrls = shippingLabelPdfUrls?.filter((pdfUrl: any) => pdfUrl);
     if (!pdfUrls || pdfUrls.length == 0) {
@@ -164,12 +164,12 @@ const printShippingLabel = async (shipmentIds: Array<string>, shippingLabelPdfUr
         return;
       }
       // Get packing slip from the server
-      const resp = await client({
+      const resp = await apiClient({
         url: "/poorti/Label.pdf",
         method: "GET",
         baseURL,
         headers: {
-          "api_key": omsRedirectionInfo.token,
+          "Authorization": "Bearer " + omstoken,
           "Content-Type": "application/json"
         },
         params: {

--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -1,4 +1,4 @@
-import { api, client, hasError } from '@/adapter';
+import { api, apiClient, hasError } from '@/adapter';
 import store from '@/store';
 import { getProductIdentificationValue, translate, useUserStore } from '@hotwax/dxp-components';
 import logger from '@/logger'
@@ -102,15 +102,15 @@ const findOpenOrders = async (payload: any): Promise<any> => {
 }
 
 const createPicklist = async (payload: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/createOrderFulfillmentWave`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -119,7 +119,7 @@ const createPicklist = async (payload: any): Promise <any>  => {
 
 const printPicklist = async (picklistId: string): Promise <any>  => {
   const maargUrl = store.getters['user/getMaargUrl'];
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
 
   try {
     const isPicklistDownloadEnabled = store.getters["util/isPicklistDownloadEnabled"]
@@ -128,12 +128,12 @@ const printPicklist = async (picklistId: string): Promise <any>  => {
       return;
     }
 
-    const resp = await client({
+    const resp = await apiClient({
       url: "/fop/apps/pdf/PrintPicklist",
       method: "GET",
       baseURL: maargUrl,
       headers: {
-        "api_key": omsRedirectionInfo.token,
+        "Authorization": "Bearer " + omstoken,
         "Content-Type": "application/json"
       },
       responseType: "blob",
@@ -162,15 +162,15 @@ const printPicklist = async (picklistId: string): Promise <any>  => {
 const printPackingSlip = async (shipmentIds: Array<string>): Promise<any> => {
   try {
     const maargUrl = store.getters['user/getMaargUrl'];
-    const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+    const omstoken = store.getters['user/getUserToken'];
 
     // Get packing slip from the server
-    const resp = await client({
+    const resp = await apiClient({
       url: "/fop/apps/pdf/PrintPackingSlip",
       method: "GET",
       baseURL: maargUrl,
       headers: {
-        "api_key": omsRedirectionInfo.token,
+        "Authorization": "Bearer " + omstoken,
         "Content-Type": "application/json"
       },
       params: {
@@ -203,7 +203,7 @@ const printPackingSlip = async (shipmentIds: Array<string>): Promise<any> => {
 const printShippingLabel = async (shipmentIds: Array<string>, shippingLabelPdfUrls?: Array<string>, shipmentPackages?: Array<any>, imageType?: string): Promise<any> => {
   try {
     const maargUrl = store.getters['user/getMaargUrl'];
-    const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+    const omstoken = store.getters['user/getUserToken'];
 
     let pdfUrls = shippingLabelPdfUrls;
     if (!pdfUrls || pdfUrls.length == 0) {
@@ -222,12 +222,12 @@ const printShippingLabel = async (shipmentIds: Array<string>, shippingLabelPdfUr
         return;
       }
       // Get packing slip from the server
-      const resp = await client({
+      const resp = await apiClient({
         url: "/fop/apps/pdf/PrintLabel",
         method: "GET",
         baseURL: maargUrl,
         headers: {
-          "api_key": omsRedirectionInfo.token,
+          "Authorization": "Bearer " + omstoken,
           "Content-Type": "application/json"
         },
         params: {
@@ -293,15 +293,15 @@ const printShippingLabelAndPackingSlip = async (shipmentIds: Array<string>, ship
 
   try {
     const maargUrl = store.getters['user/getMaargUrl'];
-    const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+    const omstoken = store.getters['user/getUserToken'];
 
     // Get packing slip from the server
-    const resp = await client({
+    const resp = await apiClient({
       url: "/fop/apps/pdf/PrintPackingSlipAndLabel",
       method: "GET",
       baseURL: maargUrl,
       headers: {
-        "api_key": omsRedirectionInfo.token,
+        "Authorization": "Bearer " + omstoken,
         "Content-Type": "application/json"
       },
       params: {
@@ -331,15 +331,15 @@ const printShippingLabelAndPackingSlip = async (shipmentIds: Array<string>, ship
 }
 
 const downloadPicklist = async (picklistId: string): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  const resp = await client({
+  const resp = await apiClient({
     url: `/poorti/Picklist.csv`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: { picklistId },
@@ -350,15 +350,15 @@ const downloadPicklist = async (picklistId: string): Promise<any> => {
 
 const recycleOutstandingOrders = async(payload: any): Promise<any> => {
 
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/rejectOutstandingOrders`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -366,7 +366,7 @@ const recycleOutstandingOrders = async(payload: any): Promise<any> => {
 }
 
 const findShipments = async (query: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
   const productStoreShipmentMethCount = store.getters['util/getProductStoreShipmentMethCount'];
   
@@ -422,12 +422,12 @@ const findShipments = async (query: any): Promise <any>  => {
       params.shipmentMethodTypeIds = query.selectedShipmentMethods
     }
 
-    const resp = await client({
+    const resp = await apiClient({
       url: `/poorti/shipments`,
       method: "GET",
       baseURL,
       headers: {
-        "api_key": omsRedirectionInfo.token,
+        "Authorization": "Bearer " + omstoken,
         "Content-Type": "application/json"
       },
       params,
@@ -473,15 +473,15 @@ const findShipments = async (query: any): Promise <any>  => {
 }
 
 const fetchShipmentFacets = async (params: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/shipmentFacets`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params
@@ -489,15 +489,15 @@ const fetchShipmentFacets = async (params: any): Promise <any>  => {
 }
 
 const fetchPicklists = async (payload: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/shipmentPicklists`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -506,15 +506,15 @@ const fetchPicklists = async (payload: any): Promise <any>  => {
 
 const recycleInProgressOrders = async(payload: any): Promise<any> => {
 
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/rejectInProgressOrders`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -523,15 +523,15 @@ const recycleInProgressOrders = async(payload: any): Promise<any> => {
 }
 
 const packOrder = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     url: `/poorti/shipments/${payload.shipmentId}/pack`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -539,15 +539,15 @@ const packOrder = async (payload: any): Promise<any> => {
 }
 
 const packOrders = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/shipments/bulkPack`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -555,15 +555,15 @@ const packOrders = async (payload: any): Promise<any> => {
 }
 
 const resetPicker = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/picklists/${payload.picklistId}`,
     method: "PUT",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -571,45 +571,45 @@ const resetPicker = async (payload: any): Promise<any> => {
 }
 
 const addShipmentBox = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/shipments/${payload.shipmentId}/shipmentPackages`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
   });
 }
 const shipOrder = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/shipments/${payload.shipmentId}/ship`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
   });
 }
 const bulkShipOrders = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/shipments/bulkShip`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -617,15 +617,15 @@ const bulkShipOrders = async (payload: any): Promise<any> => {
 }
 
 const unpackOrder = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/shipments/${payload.shipmentId}/unpack`,
     method: "post",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -633,16 +633,16 @@ const unpackOrder = async (payload: any): Promise<any> => {
 }
 
 const retryShippingLabel = async (shipmentId: string): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
   try {
-    const resp = await client({
+    const resp = await apiClient({
       url: `/poorti/shipments/retryShippingLabel`,
       method: "post",
       baseURL,
       headers: {
-        "api_key": omsRedirectionInfo.token,
+        "Authorization": "Bearer " + omstoken,
         "Content-Type": "application/json"
       },
       data: { shipmentIds: [shipmentId]}
@@ -656,7 +656,7 @@ const retryShippingLabel = async (shipmentId: string): Promise<any> => {
 }
 
 const fetchShipmentLabelError = async (shipmentId: string): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
   let shipmentLabelError = []
 
@@ -669,12 +669,12 @@ const fetchShipmentLabelError = async (shipmentId: string): Promise<any> => {
 
     }
 
-    const resp = await client({
+    const resp = await apiClient({
       url: `/poorti/shipmentPackageRouteSegDetails`,
       method: "GET",
       baseURL,
       headers: {
-        "api_key": omsRedirectionInfo.token,
+        "Authorization": "Bearer " + omstoken,
         "Content-Type": "application/json"
       },
       params: payload,
@@ -694,15 +694,15 @@ const fetchShipmentLabelError = async (shipmentId: string): Promise<any> => {
 }
 
 const fetchShipmentPackageRouteSegDetails = async (params: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     url: `/poorti/shipmentPackageRouteSegDetails`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params,
@@ -710,15 +710,15 @@ const fetchShipmentPackageRouteSegDetails = async (params: any): Promise<any> =>
 }
 
 const voidShipmentLabel = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     url: `/poorti/shipments/${payload.shipmentId}/shippingLabels/void`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -726,15 +726,15 @@ const voidShipmentLabel = async (payload: any): Promise<any> => {
 }
 
 const updateShipmentCarrierAndMethod = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     url: `/poorti/updateShipmentCarrierAndMethod`, //should handle the update of OISG, SRG, SPRG if needed
     method: "PUT",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -749,30 +749,30 @@ const findOrderInvoicingInfo = async (query: any): Promise<any> => {
 }
 
 const fetchOrderDetail = async (orderId: string): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     url: `/oms/orders/${orderId}`, //should handle the update of OISG, SRG, SPRG if needed
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
   });
 }
 
 const addTrackingCode = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     url: `/poorti/updateShipmentTracking`,
     method: "PUT",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -780,7 +780,7 @@ const addTrackingCode = async (payload: any): Promise<any> => {
 }
 
 const fetchGiftCardItemPriceInfo = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
   const currentOrder = store.getters['order/getCurrent'];
   
@@ -799,12 +799,12 @@ const fetchGiftCardItemPriceInfo = async (payload: any): Promise<any> => {
       }
     }
 
-    resp = await client({
+    resp = await apiClient({
       url: `/oms/orders/${payload.orderId}/items/${payload.orderItemSeqId}`,
       method: "GET",
       baseURL,
       headers: {
-        "api_key": omsRedirectionInfo.token,
+        "Authorization": "Bearer " + omstoken,
         "Content-Type": "application/json"
       },
       params: {fieldsToSelect: ["unitPrice"]}
@@ -822,15 +822,15 @@ const fetchGiftCardItemPriceInfo = async (payload: any): Promise<any> => {
 }
 
 const activateGiftCard = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/giftCardFulfillments`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -838,15 +838,15 @@ const activateGiftCard = async (payload: any): Promise<any> => {
 }
 
 const fetchOrderItems = async (payload: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/orders/${payload.orderId}/items`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -854,15 +854,15 @@ const fetchOrderItems = async (payload: any): Promise <any>  => {
 }
 
 const createCommunicationEvent = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: "/oms/communicationEvents",
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,

--- a/src/services/ProductService.ts
+++ b/src/services/ProductService.ts
@@ -1,4 +1,4 @@
-import { api, client } from '@/adapter';
+import { api, apiClient } from '@/adapter';
 import store from '@/store';
 
 
@@ -13,15 +13,15 @@ const fetchProducts = async (query: any): Promise <any>  => {
 }
 
 const fetchProductComponents = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/entityData`,
     method: "post",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -29,15 +29,15 @@ const fetchProductComponents = async (payload: any): Promise<any> => {
 }
 
 const fetchSampleProducts = async (params: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/products`,
     method: "get",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params,
@@ -45,7 +45,7 @@ const fetchSampleProducts = async (params: any): Promise<any> => {
 }
 
 const fetchProductsAverageCost = async (productIds: any, facilityId: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
   
   if(!productIds.length) return []
@@ -69,12 +69,12 @@ const fetchProductsAverageCost = async (productIds: any, facilityId: any): Promi
     requests.push(params)
   }
 
-  const productAverageCostResps = await Promise.allSettled(requests.map((payload) => client({
+  const productAverageCostResps = await Promise.allSettled(requests.map((payload) => apiClient({
     url: `/oms/entityData`,
     method: "post",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,

--- a/src/services/StockService.ts
+++ b/src/services/StockService.ts
@@ -1,16 +1,16 @@
-import { client } from '@/adapter';
+import { apiClient } from '@/adapter';
 import store from '@/store';
 
 const getInventoryAvailableByFacility = async (query: any): Promise <any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/getInventoryAvailableByFacility`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: query,

--- a/src/services/TransferOrderService.ts
+++ b/src/services/TransferOrderService.ts
@@ -1,4 +1,4 @@
-import { api, hasError, client } from "@/adapter";
+import { apiClient, hasError } from "@/adapter";
 import logger from "@/logger";
 import store from "@/store";
 import { translate } from "@hotwax/dxp-components";
@@ -7,78 +7,78 @@ import { cogOutline } from "ionicons/icons";
 import { ZebraPrinterService } from './ZebraPrinterService';
 
 const fetchTransferOrders = async (params: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: "oms/transferOrders/",
     method: "get",
     baseURL,
     params,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     }
   });
 }
 
 const fetchTransferOrderDetail = async (orderId: string): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/transferOrders/${orderId}`,
     method: "get",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     }
   });
 };
 
 const fetchShippedTransferShipments = async (params: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: "poorti/transferShipments",
     method: "get",
     baseURL,
     params,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     }
   });
 };
 
 const fetchTransferShipmentDetails = async (params: Record<string, any>): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: "poorti/transferShipments",
     method: "get",
     baseURL,
     params,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     }
   });
 };
 
 const fetchRejectReasons = async(query: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/admin/enums`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: query,
@@ -86,15 +86,15 @@ const fetchRejectReasons = async(query: any): Promise<any> => {
 }
 
 const fetchFulfillmentRejectReasons = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/admin/enumGroups/${payload.enumerationGroupId}/members`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload,
@@ -102,15 +102,15 @@ const fetchFulfillmentRejectReasons = async (payload: any): Promise<any> => {
 }
 
 const cancelTransferOrderShipment = async (shipmentId: string): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `poorti/shipments/${shipmentId}`,
     method: "put",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: {
@@ -120,15 +120,15 @@ const cancelTransferOrderShipment = async (shipmentId: string): Promise<any> => 
 };
 
 const shipTransferOrderShipment = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `poorti/transferShipments/${payload.shipmentId}/ship`,
     method: "post",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -137,17 +137,17 @@ const shipTransferOrderShipment = async (payload: any): Promise<any> => {
 
 const printTransferOrderPicklist = async (orderId: string): Promise<any> => {
   try {
-    const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+    const omstoken = store.getters['user/getUserToken'];
     const baseURL = store.getters['user/getMaargBaseUrl'];
 
     // Get packing slip from the server
-    const resp: any = await client({
+    const resp: any = await apiClient({
       method: "get",
       url: `poorti/transferOrders/${orderId}/printPicklist`,
       responseType: "blob",
       baseURL,
       headers: {
-        "api_key": omsRedirectionInfo.token,
+        "Authorization": "Bearer " + omstoken,
       }
     })
 
@@ -175,16 +175,16 @@ const printTransferOrderPicklist = async (orderId: string): Promise<any> => {
 };
 
 const createOutboundTransferShipment = async (query: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     method: "post",
     url: "poorti/transferShipments",
     baseURL,
     data: query,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     }
   })
@@ -193,7 +193,7 @@ const createOutboundTransferShipment = async (query: any): Promise<any> => {
 const printShippingLabel = async (shipmentIds: Array<string>, shippingLabelPdfUrls?: Array<string>, shipmentPackages?: Array<any>, imageType?: string): Promise<any> => {
   try {
     const maargUrl = store.getters['user/getMaargUrl'];
-    const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+    const omstoken = store.getters['user/getUserToken'];
 
     let pdfUrls = shippingLabelPdfUrls?.filter((pdfUrl: any) => pdfUrl);
     if (!pdfUrls || pdfUrls.length == 0) {
@@ -213,7 +213,7 @@ const printShippingLabel = async (shipmentIds: Array<string>, shippingLabelPdfUr
       }
 
       // Get packing slip from the server
-      const resp: any = await client({
+      const resp: any = await apiClient({
         method: "get",
         url: "/fop/apps/pdf/PrintLabel",
         params: {
@@ -222,7 +222,7 @@ const printShippingLabel = async (shipmentIds: Array<string>, shippingLabelPdfUr
         responseType: "blob",
         baseURL: maargUrl,
         headers: {
-          "api_key": omsRedirectionInfo.token,
+          "Authorization": "Bearer " + omstoken,
         }
       });
 
@@ -254,15 +254,15 @@ const printShippingLabel = async (shipmentIds: Array<string>, shippingLabelPdfUr
 };
 
 const rejectOrderItems = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `poorti/transferOrders/${payload.orderId}/reject`,
     method: "post",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -270,15 +270,15 @@ const rejectOrderItems = async (payload: any): Promise<any> => {
 };
 
 const closeOrderItems = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `poorti/transferOrders/${payload.orderId}/closeFulfillment`,
     method: "post",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -286,15 +286,15 @@ const closeOrderItems = async (payload: any): Promise<any> => {
 };
 
 const createTransferOrder = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return await client({
+  return await apiClient({
     url: 'oms/transferOrders',
     method: "post",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -302,15 +302,15 @@ const createTransferOrder = async (payload: any): Promise<any> => {
 };
 
 const approveTransferOrder = async (orderId: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `oms/transferOrders/${orderId}/approve`,
     method: "post",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     }
   });

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,4 +1,4 @@
-import { api, client, hasError } from '@/adapter';
+import { api, apiClient, hasError } from '@/adapter';
 import store from '@/store';
 import logger from '@/logger'
 
@@ -17,7 +17,7 @@ const moquiLogin = async (omsRedirectionUrl: string, token: string): Promise <an
   let api_key = ""
 
   try {
-    const resp = await client({
+    const resp = await apiClient({
       url: "login",
       method: "post",
       baseURL,
@@ -42,15 +42,15 @@ const moquiLogin = async (omsRedirectionUrl: string, token: string): Promise <an
 }
 
 const getFacilityDetails = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/facilities/${payload.facilityId}`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -58,15 +58,15 @@ const getFacilityDetails = async (payload: any): Promise<any> => {
 }
 
 const getFacilityOrderCount = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/facilities/facilityOrderCounts`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -74,15 +74,15 @@ const getFacilityOrderCount = async (payload: any): Promise<any> => {
 }
 
 const updateFacility = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/facilities/${payload.facilityId}`,
     method: "PUT",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -90,15 +90,15 @@ const updateFacility = async (payload: any): Promise<any> => {
 }
 
 const updateFacilityToGroup = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/facilities/${payload.facilityId}/groups`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -106,15 +106,15 @@ const updateFacilityToGroup = async (payload: any): Promise<any> => {
 }
 
 const addFacilityToGroup = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/facilities/${payload.facilityId}/groups`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -122,15 +122,15 @@ const addFacilityToGroup = async (payload: any): Promise<any> => {
 }
 
 const getFacilityGroupDetails = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/facilityGroups/${payload.facilityGroupId}`,
     method: "get",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     param: payload
@@ -138,15 +138,15 @@ const getFacilityGroupDetails = async (payload: any): Promise<any> => {
 }
 
 const getFacilityGroupAndMemberDetails = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/entityData`,
     method: "post",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -157,7 +157,7 @@ const getPreferredStore = async (token: any): Promise<any> => {
   const baseURL = store.getters['user/getBaseUrl'];
   try {
     const baseURL = store.getters['user/getMaargBaseUrl'];
-    const resp = await client({
+    const resp = await apiClient({
       url: `/oms/userPreferences`,
       method: "GET",
       baseURL,
@@ -198,7 +198,7 @@ const getUserPermissions = async (payload: any, token: any): Promise<any> => {
       viewSize,
       permissionIds: payload.permissionIds
     }
-    resp = await client({
+    resp = await apiClient({
       url: "getPermissions",
       method: "post",
       baseURL,
@@ -216,7 +216,7 @@ const getUserPermissions = async (payload: any, token: any): Promise<any> => {
         // We need to get all the remaining permissions
         const apiCallsNeeded = Math.floor(remainingPermissions / viewSize) + (remainingPermissions % viewSize != 0 ? 1 : 0);
         const responses = await Promise.all([...Array(apiCallsNeeded).keys()].map(async (index: any) => {
-          const response = await client({
+          const response = await apiClient({
             url: "getPermissions",
             method: "post",
             baseURL,
@@ -270,7 +270,7 @@ const getUserPermissions = async (payload: any, token: any): Promise<any> => {
 const getUserProfile = async (token: any): Promise<any> => {
   const baseURL = store.getters['user/getBaseUrl'];
   try {
-    const resp = await client({
+    const resp = await apiClient({
       url: "user-profile",
       method: "get",
       baseURL,
@@ -287,15 +287,15 @@ const getUserProfile = async (token: any): Promise<any> => {
 }
 
 const setUserPreference = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/userPreferences`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -303,15 +303,15 @@ const setUserPreference = async (payload: any): Promise<any> => {
 }
 
 const getPartialOrderRejectionConfig = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -319,15 +319,15 @@ const getPartialOrderRejectionConfig = async (payload: any): Promise<any> => {
 }
 
 const createEnumeration = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/admin/enums`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -336,15 +336,15 @@ const createEnumeration = async (payload: any): Promise<any> => {
 
 const isEnumExists = async (enumId: string): Promise<any> => {
   try {
-    const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+    const omstoken = store.getters['user/getUserToken'];
     const baseURL = store.getters['user/getMaargBaseUrl'];
 
-    const resp = await client({
+    const resp = await apiClient({
       url: `/admin/enums`,
       method: "GET",
       baseURL,
       headers: {
-        "api_key": omsRedirectionInfo.token,
+        "Authorization": "Bearer " + omstoken,
         "Content-Type": "application/json"
       },
       params: { enumId }
@@ -359,15 +359,15 @@ const isEnumExists = async (enumId: string): Promise<any> => {
 }
 
 const getReservationFacilityIdFieldConfig = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -375,15 +375,15 @@ const getReservationFacilityIdFieldConfig = async (payload: any): Promise<any> =
 }
 
 const getDisableShipNowConfig = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -391,15 +391,15 @@ const getDisableShipNowConfig = async (payload: any): Promise<any> => {
 }
 
 const getDisableUnpackConfig = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -407,15 +407,15 @@ const getDisableUnpackConfig = async (payload: any): Promise<any> => {
 }
 
 const createPartialOrderRejectionConfig = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -423,15 +423,15 @@ const createPartialOrderRejectionConfig = async (payload: any): Promise<any> => 
 }
 
 const updatePartialOrderRejectionConfig = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -439,90 +439,90 @@ const updatePartialOrderRejectionConfig = async (payload: any): Promise<any> => 
 }
 
 const getCollateralRejectionConfig = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
   });
 }
 const createCollateralRejectionConfig = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const updateCollateralRejectionConfig = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const getAffectQohConfig = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
   });
 }
 const createAffectQohConfig = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
   });
 }
 const updateAffectQohConfig = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload

--- a/src/services/UtilService.ts
+++ b/src/services/UtilService.ts
@@ -1,4 +1,4 @@
-import { api, client, hasError } from '@/adapter';
+import { api, apiClient, hasError } from '@/adapter';
 import store from '@/store';
 import logger from '@/logger'
 
@@ -11,15 +11,15 @@ const fetchShipmentMethods = async (query: any): Promise <any>  => {
 }
 
 const fetchCarrierShipmentBoxTypes = async(params: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: "/oms/shippingGateways/carrierShipmentBoxTypes",
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params
@@ -27,15 +27,15 @@ const fetchCarrierShipmentBoxTypes = async(params: any): Promise<any> => {
 }
 
 const fetchDefaultShipmentBox = async(query: any) : Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/admin/systemProperties`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: query,
@@ -43,15 +43,15 @@ const fetchDefaultShipmentBox = async(query: any) : Promise<any> => {
 }
 
 const fetchRejectReasons = async(query: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/admin/enums`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: query,
@@ -59,15 +59,15 @@ const fetchRejectReasons = async(query: any): Promise<any> => {
 }
 
 const fetchRejectReasonEnumTypes = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/entityData`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -83,15 +83,15 @@ const getAvailablePickers = async (query: any): Promise <any> => {
 }
 
 const fetchConfiguredCarrierService = async(payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/entityData`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -99,15 +99,15 @@ const fetchConfiguredCarrierService = async(payload: any): Promise<any> => {
 }
 
 const generateManifest = async(payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/generateManifest`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -115,15 +115,15 @@ const generateManifest = async(payload: any): Promise<any> => {
 }
 
 const downloadCarrierManifest = async(params: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/Manifest.pdf`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params
@@ -131,15 +131,15 @@ const downloadCarrierManifest = async(params: any): Promise<any> => {
 }
 
 const fetchPartyInformation = async (payload: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/parties`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload,
@@ -147,15 +147,15 @@ const fetchPartyInformation = async (payload: any): Promise <any>  => {
 }
 
 const fetchShipmentMethodTypeDesc = async (payload: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/shippingGateways/shipmentMethodTypes`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload,
@@ -163,15 +163,15 @@ const fetchShipmentMethodTypeDesc = async (payload: any): Promise <any>  => {
 }
 
 const fetchShipmentBoxType = async (query: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/shippingGateways/shipmentBoxTypes`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: query,
@@ -179,15 +179,15 @@ const fetchShipmentBoxType = async (query: any): Promise <any>  => {
 }
 
 const fetchFacilityTypeInformation = async (query: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/facilities`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: query,
@@ -195,15 +195,15 @@ const fetchFacilityTypeInformation = async (query: any): Promise <any>  => {
 }
 
 const fetchPaymentMethodTypeDesc = async (payload: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/paymentMethodTypes`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -211,15 +211,15 @@ const fetchPaymentMethodTypeDesc = async (payload: any): Promise <any>  => {
 }
 
 const fetchStatusDesc = async (payload: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/statuses`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -227,15 +227,15 @@ const fetchStatusDesc = async (payload: any): Promise <any>  => {
 }
 
 const findProductStoreShipmentMethCount = async (query: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/shipmentMethods/counts`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: query
@@ -243,15 +243,15 @@ const findProductStoreShipmentMethCount = async (query: any): Promise<any> => {
 }
 
 const createEnumeration = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/admin/enums`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -259,15 +259,15 @@ const createEnumeration = async (payload: any): Promise<any> => {
 }
 
 const updateEnumeration = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/admin/enums/${payload.enumId}`,
     method: "PUT",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -275,30 +275,30 @@ const updateEnumeration = async (payload: any): Promise<any> => {
 }
 
 const deleteEnumeration = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/admin/enums/${payload.enumId}`,
     method: "DELETE",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
   });
 }
 
 const fetchEnumeration = async (payload: any): Promise <any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/admin/enums`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -306,15 +306,15 @@ const fetchEnumeration = async (payload: any): Promise <any> => {
 }
 
 const fetchProductStores = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -322,15 +322,15 @@ const fetchProductStores = async (payload: any): Promise<any> => {
 }
 
 const fetchFacilities = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: "/oms/facilities",
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload
@@ -338,15 +338,15 @@ const fetchFacilities = async (payload: any): Promise<any> => {
 }
 
 const fetchProductStoreFacilities = async (params: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${params.productStoreId}/facilities`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params
@@ -354,15 +354,15 @@ const fetchProductStoreFacilities = async (params: any): Promise<any> => {
 }
 
 const updateForceScanSetting = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -370,15 +370,15 @@ const updateForceScanSetting = async (payload: any): Promise<any> => {
 }
 
 const createForceScanSetting = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -386,15 +386,15 @@ const createForceScanSetting = async (payload: any): Promise<any> => {
 }
 
 const updateBarcodeIdentificationPref = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -402,15 +402,15 @@ const updateBarcodeIdentificationPref = async (payload: any): Promise<any> => {
 }
 
 const createBarcodeIdentificationPref = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${payload.productStoreId}/settings`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload
@@ -418,15 +418,15 @@ const createBarcodeIdentificationPref = async (payload: any): Promise<any> => {
 }
 
 const getProductStoreSetting = async (params: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/productStores/${params.productStoreId}/settings`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params
@@ -434,15 +434,15 @@ const getProductStoreSetting = async (params: any): Promise<any> => {
 }
 
 const fetchGiftCardFulfillmentInfo = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/poorti/giftCardFulfillments`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload,
@@ -450,15 +450,15 @@ const fetchGiftCardFulfillmentInfo = async (payload: any): Promise<any> => {
 }
 
 const fetchFulfillmentRejectReasons = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/admin/enumGroups/${payload.enumerationGroupId}/members`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload,
@@ -466,15 +466,15 @@ const fetchFulfillmentRejectReasons = async (payload: any): Promise<any> => {
 }
 
 const createEnumerationGroupMember = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/admin/enumGroups/${payload.enumerationGroupId}/members`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -482,15 +482,15 @@ const createEnumerationGroupMember = async (payload: any): Promise<any> => {
 }
 
 const updateEnumerationGroupMember = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/admin/enumGroups/${payload.enumerationGroupId}/members`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -499,15 +499,15 @@ const updateEnumerationGroupMember = async (payload: any): Promise<any> => {
 
 const isEnumExists = async (enumId: string): Promise<any> => {
   try {
-    const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+    const omstoken = store.getters['user/getUserToken'];
     const baseURL = store.getters['user/getMaargBaseUrl'];
   
-    const resp = client({
+    const resp = apiClient({
       url: `/admin/enums`,
       method: "GET",
       baseURL,
       headers: {
-        "api_key": omsRedirectionInfo.token,
+        "Authorization": "Bearer " + omstoken,
         "Content-Type": "application/json"
       },
       params: { enumId }
@@ -523,15 +523,15 @@ const isEnumExists = async (enumId: string): Promise<any> => {
 }
 
 const fetchAdjustmentTypeDescription = async(payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/orderAdjustmentTypes`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: payload,
@@ -539,15 +539,15 @@ const fetchAdjustmentTypeDescription = async(payload: any): Promise<any> => {
 }
 
 const fetchCarriers = async (params: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/shippingGateways/carrierParties`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params,
@@ -555,15 +555,15 @@ const fetchCarriers = async (params: any): Promise <any>  => {
 }
 
 const fetchStoreCarrierAndMethods = async (payload: any): Promise <any>  => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/entityData`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -571,15 +571,15 @@ const fetchStoreCarrierAndMethods = async (payload: any): Promise <any>  => {
 }
 
 const fetchFacilityAddresses = async (payload: any): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/oms/entityData`,
     method: "POST",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     data: payload,
@@ -601,15 +601,15 @@ const fetchFacilityZPLGroupInfo = async (facilityId: string): Promise<any> => {
 
   try {
 
-    const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+    const omstoken = store.getters['user/getUserToken'];
     const baseURL = store.getters['user/getMaargBaseUrl'];
 
-    const resp = await client({
+    const resp = await apiClient({
       url: `/oms/entityData`,
       method: "POST",
       baseURL,
       headers: {
-        "api_key": omsRedirectionInfo.token,
+        "Authorization": "Bearer " + omstoken,
         "Content-Type": "application/json"
       },
       data: payload
@@ -627,15 +627,15 @@ const fetchFacilityZPLGroupInfo = async (facilityId: string): Promise<any> => {
 }
 
 const fetchLabelImageType = async (carrierId : string): Promise<any> => {
-  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const omstoken = store.getters['user/getUserToken'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
-  return client({
+  return apiClient({
     url: `/admin/systemProperties`,
     method: "GET",
     baseURL,
     headers: {
-      "api_key": omsRedirectionInfo.token,
+      "Authorization": "Bearer " + omstoken,
       "Content-Type": "application/json"
     },
     params: {"systemResourceId": carrierId, "systemPropertyId": "shipment.carrier.labelImageType", "pageSize": 1}


### PR DESCRIPTION
### Related Issues
#1266 

#

### Short Description and Why It's Useful
Improved: Used oms-api's apiClient method instead of client method in order to use oms token instead of api_key for the moqui authentication.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)