### PR TITLE
Fixed: Refreshed selected carrier/methods filter on completed page correctly when shipment method is changed from order detail and goes back to list page (#1271).

### DIFF
--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -314,7 +314,13 @@ export default defineComponent({
   },
   async ionViewWillEnter() {
     this.isScrollingEnabled = false;
-    await Promise.all([this.initialiseOrderQuery(), this.fetchShipmentFacets()]);
+    await this.fetchShipmentFacets()
+    //Remove the selected shipment methods and carriers that are no longer valid after editing the order detail page.
+    this.selectedShipmentMethods = this.selectedShipmentMethods?.filter((shipmentMethod: any) => this.shipmentMethods.includes(shipmentMethod));
+    const selectedCarrier = this.carrierPartyIds?.find((carrierPartyId: any) => carrierPartyId === this.selectedCarrierPartyId)
+    this.selectedCarrierPartyId = selectedCarrier ? selectedCarrier : ""
+
+    await this.initialiseOrderQuery()
     emitter.on('updateOrderQuery', this.updateOrderQuery)
     this.completedOrdersList = JSON.parse(JSON.stringify(this?.completedOrders.list)).slice(0, (this.completedOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
   },


### PR DESCRIPTION


### Related Issues
#1271 

#

### Short Description and Why It's Useful
Fixed: Refreshed selected carrier/methods filter on completed page correctly when shipment method is changed from order detail and goes back to list page (#1271).


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)