### PR TITLE
Fixed: Refreshed picklists filters correctly when packing order from order detail page and goes back to in progress orders page (#1271).

### DIFF
--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -896,7 +896,7 @@ export default defineComponent({
 
           if (!hasError(resp)) {
             resp.data?.forEach((shipment: any) => {
-              if (shipment?.order?.statusId === "ORDER_APPROVED") {
+              if (shipment?.order?.statusId === "ORDER_APPROVED" && shipment?.order?.productStoreId === this.currentEComStore.productStoreId) {
                 shipment?.picklistShipment?.forEach((picklistShipment: any) => {
                   if (!picklistInfo[picklistShipment.picklistId]) {
                     const picklistRoles = picklistShipment?.picklist?.roles.filter((role: any) => !role.thruDate)
@@ -1251,9 +1251,15 @@ export default defineComponent({
   },
   async ionViewWillEnter() {
     this.isScrollingEnabled = false;
+    await this.fetchPickersInformation()
+    //Cross checking if the selected picklist is still valid, as user can pack the order from order detail page
+    if (this.selectedPicklistId) {
+      const selectedPicklist = this.picklists.find((picklist: any) => picklist.id === this.selectedPicklistId)
+      this.selectedPicklistId = selectedPicklist ? selectedPicklist.id : ""
+    }
+
     await Promise.all([
       this.store.dispatch('util/fetchRejectReasonOptions'),
-      this.fetchPickersInformation(),
       this.initialiseOrderQuery()
     ]);
     emitter.on('updateOrderQuery', this.updateOrderQuery)


### PR DESCRIPTION


### Related Issues
#1272 

#

### Short Description and Why It's Useful
Fixed: Refreshed picklists filters correctly when packing order from order detail page and goes back to in progress orders page.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)