### PR TITLE
Fixed: passed legacy flag when using category filter in legacy app

### DIFF
--- a/src/views/OpenOrders.vue
+++ b/src/views/OpenOrders.vue
@@ -34,7 +34,7 @@
           </ion-checkbox>
         </ion-item>
       </div>
-      <Component :is="productCategoryFilterExt" :orderQuery="openOrders.query" :currentFacility="currentFacility" :currentEComStore="currentEComStore" @updateOpenQuery="updateOpenQuery" />
+      <Component :is="productCategoryFilterExt" :orderQuery="openOrders.query" :currentFacility="currentFacility" :currentEComStore="currentEComStore" @updateOpenQuery="updateOpenQuery" :isLegacyApp="true"/>
       <div v-if="openOrders.total">
 
         <div class="results">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Passed `isLegacyApp` flag to true when displaying category filters in legacy app

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)