### PR TITLE
Fixed: Disable Pick All button when force scan is required (#1235)

### DIFF
--- a/src/components/TransferOrderItem.vue
+++ b/src/components/TransferOrderItem.vue
@@ -24,7 +24,7 @@
     </div>
     <div class="action border-top" v-if="item.orderedQuantity > 0">
       <div class="pick-all-qty" v-if="!item.shipmentId">
-        <ion-button @click="pickAll(item)" slot="start" size="small" fill="outline">
+        <ion-button @click="pickAll(item)" slot="start" size="small" fill="outline" :disabled="isForceScanEnabled">
           {{ translate("Pick All") }}
         </ion-button>
       </div>


### PR DESCRIPTION
### Related Issues
#1235 

### Short Description and Why It's Useful
Disable Pick All button when force scan is required.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)