### PR TITLE
Improved: Allow fetching shipment methods by product store (#1299)

### DIFF
--- a/src/components/GenerateTrackingCodeModal.vue
+++ b/src/components/GenerateTrackingCodeModal.vue
@@ -206,7 +206,10 @@ export default defineComponent({
   },
   props: ["order", "updateCarrierShipmentDetails", "executePackOrder", "rejectEntireOrder", "updateParameter", "documentOptions", "packingError", "isDetailPage"],
   async mounted() {
-    await Promise.all([this.store.dispatch('carrier/fetchFacilityCarriers'), this.store.dispatch('carrier/fetchProductStoreShipmentMeths')])
+    await Promise.all([
+      this.store.dispatch('carrier/fetchFacilityCarriers'),
+      this.store.dispatch('carrier/fetchProductStoreShipmentMeths', this.order.productStoreId)
+    ])
     this.isTrackingRequired = this.isTrackingRequiredForAnyShipmentPackage()
     if (this.facilityCarriers) {
       this.carrierPartyId = this.order?.carrierPartyId ? this.order?.carrierPartyId : this.facilityCarriers[0].partyId;

--- a/src/store/modules/carrier/actions.ts
+++ b/src/store/modules/carrier/actions.ts
@@ -393,7 +393,10 @@ const actions: ActionTree<CarrierState, RootState> = {
     }
     commit(types.CARRIER_FACILITY_CARRIERS_UPDATED, facilityCarriers)
   },
-  async fetchProductStoreShipmentMeths({ state, commit }) {
+  async fetchProductStoreShipmentMeths({ commit }, productStoreId?: string) {
+    if (!productStoreId) {
+      productStoreId = getProductStoreId();
+    }
     let productStoreShipmentMethods  = [] as any;
     let viewIndex = 0, resp;
     
@@ -402,7 +405,7 @@ const actions: ActionTree<CarrierState, RootState> = {
         const params = {
           customParametersMap:{
             "roleTypeId": "CARRIER",
-            "productStoreId": getProductStoreId(),
+            "productStoreId": productStoreId,
             "shipmentMethodTypeId": "STOREPICKUP",
             "shipmentMethodTypeId_op": "equals",
             "shipmentMethodTypeId_not": "Y",

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -557,7 +557,12 @@ export default defineComponent({
     : this.category === 'in-progress'
     ? await this.store.dispatch('order/getInProgressOrder', { orderId: this.orderId, shipmentId: this.shipmentId })
     : await this.store.dispatch('order/getCompletedOrder', { orderId: this.orderId, shipmentId: this.shipmentId })
-    await Promise.all([this.store.dispatch('util/fetchCarrierShipmentBoxTypes'), this.store.dispatch('carrier/fetchFacilityCarriers'), this.store.dispatch('carrier/fetchProductStoreShipmentMeths'), this.fetchOrderInvoicingStatus()]);
+    await Promise.all([
+      this.store.dispatch('util/fetchCarrierShipmentBoxTypes'),
+      this.store.dispatch('carrier/fetchFacilityCarriers'),
+      this.store.dispatch('carrier/fetchProductStoreShipmentMeths', this.order.productStoreId),
+      this.fetchOrderInvoicingStatus()
+    ]);
     if (this.facilityCarriers) {
       const shipmentPackageRouteSegDetail = this.order.shipmentPackageRouteSegDetails?.[0];
       this.carrierPartyId = shipmentPackageRouteSegDetail?.carrierPartyId ? shipmentPackageRouteSegDetail?.carrierPartyId : this.facilityCarriers[0].partyId;


### PR DESCRIPTION
### Related Issues
#1299 

### Short Description and Why It's Useful
Improved: Allow fetching shipment methods by product store so that product store shipment method can be fetched based on the order's product store.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)