### PR TITLE
Implemented : show all order payment preferences on order detail page (#946)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -498,6 +498,7 @@ const actions: ActionTree<OrderState, RootState> = {
           ...order,
           shipGroups: resp.data.shipGroups,
           paymentPreferences: resp.data.paymentPreferences,
+          currencyUom:resp.data.currencyUom,
           adjustments: resp.data.adjustments,
           attributes: resp.data.attributes,
           shippingAddress: resp.data.contactMechs?.find((contactMech:any) => contactMech.contactMechPurposeTypeId === "SHIPPING_LOCATION")?.postalAddress,

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -250,7 +250,7 @@
                   </ion-label>
                   <div slot="end" class="ion-text-end">
                     <ion-badge v-if="order.paymentPreferences.length > 1 && index === 0" color="dark">{{ translate("Latest") }}</ion-badge>
-                    <ion-label slot="end">{{ formatCurrency(orderPayment.presentmentAmount, orderPayment.presentmentCurrencyUom) }}</ion-label>
+                    <ion-label slot="end">{{ formatCurrency(orderPayment.maxAmount, order.currencyUom) }}</ion-label>
                   </div>
                 </ion-item>
               </ion-list>

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -241,7 +241,7 @@
               <ion-card-title>{{ translate("Payment") }}</ion-card-title>
             </ion-card-header>
             <div v-if="order.paymentPreferences?.length">
-              <ion-list v-for="(orderPayment, index) in order.paymentPreferences" :key="index">
+              <ion-list v-for="(orderPayment, index) in order.paymentPreferences" :key="orderPayment.paymentMethodTypeId">
                 <ion-item lines="none">
                   <ion-label class="ion-text-wrap">
                     <p class="overline">{{ orderPayment.paymentMethodTypeId }}</p>

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -241,7 +241,7 @@
               <ion-card-title>{{ translate("Payment") }}</ion-card-title>
             </ion-card-header>
             <div v-if="order.paymentPreferences?.length">
-              <ion-list v-for="(orderPayment, index) in order.paymentPreferences" :key="orderPayment.paymentMethodTypeId">
+              <ion-list v-for="(orderPayment, index) in order.paymentPreferences" :key="`${order.orderId}-${orderPayment.orderPaymentPreferenceId}`">
                 <ion-item lines="none">
                   <ion-label class="ion-text-wrap">
                     <p class="overline">{{ orderPayment.paymentMethodTypeId }}</p>

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -236,6 +236,30 @@
             </ion-item>
           </ion-card>
 
+          <ion-card>
+            <ion-card-header>
+              <ion-card-title>{{ translate("Payment") }}</ion-card-title>
+            </ion-card-header>
+            <div v-if="order.paymentPreferences?.length">
+              <ion-list v-for="(orderPayment, index) in order.paymentPreferences" :key="index">
+                <ion-item lines="none">
+                  <ion-label class="ion-text-wrap">
+                    <p class="overline">{{ orderPayment.paymentMethodTypeId }}</p>
+                    <ion-label>{{ translate(getPaymentMethodDesc(orderPayment.paymentMethodTypeId)) || orderPayment.paymentMethodTypeId }}</ion-label>
+                    <ion-note :color="getColorByDesc(getStatusDesc(orderPayment.statusId))">{{ translate(getStatusDesc(orderPayment.statusId)) }}</ion-note>
+                  </ion-label>
+                  <div slot="end" class="ion-text-end">
+                    <ion-badge v-if="order.paymentPreferences.length > 1 && index === 0" color="dark">{{ translate("Latest") }}</ion-badge>
+                    <ion-label slot="end">{{ formatCurrency(orderPayment.presentmentAmount, orderPayment.presentmentCurrencyUom) }}</ion-label>
+                  </div>
+                </ion-item>
+              </ion-list>
+            </div>
+            <p v-else class="empty-state">
+              {{ translate("No payments found") }}
+            </p>
+          </ion-card>
+
           <ion-card v-if="['in-progress', 'completed'].includes(order.category)">
             <ion-card-header>
               <ion-card-title>
@@ -428,7 +452,7 @@ import {
   checkmarkCircleOutline
 } from 'ionicons/icons';
 import { getProductIdentificationValue, translate, DxpShopifyImg, useProductIdentificationStore, useUserStore } from '@hotwax/dxp-components';
-import { copyToClipboard, formatUtcDate, getFeatures, getFacilityFilter, showToast } from '@/utils'
+import { copyToClipboard, formatUtcDate, getFeatures, getFacilityFilter, showToast, getColorByDesc, formatCurrency } from '@/utils'
 import { Actions, hasPermission } from '@/authorization'
 import OrderActionsPopover from '@/components/OrderActionsPopover.vue'
 import emitter from '@/event-bus';
@@ -1610,7 +1634,9 @@ export default defineComponent({
       store,
       trashBinOutline,
       translate,
-      ribbonOutline
+      ribbonOutline,
+      getColorByDesc,
+      formatCurrency
     };
   }
 });


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#946

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Added card all order payment preferences on order detail page like we do in BOPIS app

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
<img width="1022" height="849" alt="image" src="https://github.com/user-attachments/assets/62d70766-4161-4f04-9768-c3ee2745de22" />



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)