### PR TITLE
Fixed:added the checks on order to display spinner when it is empty(#689)

### DIFF
--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -364,6 +364,10 @@
           </ion-card>
         </div>
       </div>
+      <div v-else-if="!Object.keys(order).length " class="empty-state">
+        <ion-spinner name="crescent" />
+        <ion-label>{{ translate("Loading...") }}</ion-label>
+      </div>
       <div v-else class="empty-state">
         <p>{{ translate("Unable to fetch the order details. Either the order has been shipped or something went wrong. Please try again after some time.")}}</p>
       </div>

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -7,7 +7,7 @@
       </ion-toolbar>
     </ion-header>
     <ion-content>
-      <div v-if="Object.keys(order).length">
+      <div v-if="order && Object.keys(order).length">
         <div class="order-header">
           <div class="order-primary-info">
             <h3>{{ order.orderName }}</h3>
@@ -364,7 +364,7 @@
           </ion-card>
         </div>
       </div>
-      <div v-else-if="!Object.keys(order).length " class="empty-state">
+      <div v-else-if="order" class="empty-state">
         <ion-spinner name="crescent" />
         <ion-label>{{ translate("Loading...") }}</ion-label>
       </div>


### PR DESCRIPTION
…n mounting(#689)

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#689 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed: added the check on order when the order is empty it will show loading spinner in  mounting phase  ,In case of null or undefined it will fallback to the error displaying check.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)