### PR TITLE
Fixed : False Success Toast On Packing Order Using Bulk Pack (#1349)

### DIFF
--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -697,11 +697,13 @@ export default defineComponent({
                 const resp = await OrderService.packOrders({
                   shipments
                 });
-                if (hasError(resp)) {
+
+                //Generate documents only for successfully packed shipments, not for those where packing failed.
+                const packedShipmentIds = resp.data?.packedShipmentIds ? resp.data.packedShipmentIds : [];
+
+                if (hasError(resp) || !packedShipmentIds.length) {
                   throw resp.data
                 }
-                //Generate documents only for successfully packed shipments, not for those where packing failed.
-                const packedShipmentIds = resp.data?.packedShipmentIds ? resp.data?.packedShipmentIds : [];
 
                 if (data.length) {
                   // additional parameters for dismiss button and manual dismiss ability

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -703,7 +703,7 @@ export default defineComponent({
                 }
 
                 //Generate documents only for successfully packed shipments, not for those where packing failed.
-                const packedShipmentIds = resp.data?.packedShipmentIds ? resp.data.packedShipmentIds : [];
+                const packedShipmentIds = resp.data?.packedShipmentIds ?? [];
 
                 if (!packedShipmentIds.length) {
                   throw resp.data

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -698,10 +698,14 @@ export default defineComponent({
                   shipments
                 });
 
+                if (hasError(resp)) {
+                  throw resp.data
+                }
+
                 //Generate documents only for successfully packed shipments, not for those where packing failed.
                 const packedShipmentIds = resp.data?.packedShipmentIds ? resp.data.packedShipmentIds : [];
 
-                if (hasError(resp) || !packedShipmentIds.length) {
+                if (!packedShipmentIds.length) {
                   throw resp.data
                 }
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1349

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- fixed the issue of False success toast is displayed when user packs orders using bulk pack order.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)