### PR TITLE
Fixed:add the condition to handle carrier name when not present showing partyid(#1353)

### DIFF
--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -705,7 +705,7 @@ const actions: ActionTree<UtilState, RootState> = {
 
       if (!hasError(resp)) {
         resp.data.map((carrier: any) => {
-          carrierDesc[carrier.partyId] = carrier.partyTypeId === "PERSON" ? `${carrier.firstName} ${carrier.lastName}` : carrier.groupName
+          carrierDesc[carrier.partyId] = carrier.partyTypeId === "PERSON" ? (carrier.firstName?(carrier.lastName?`${carrier.firstName}${carrier.lastName}`:`${carrier.firstName}`):(carrier.lastName?`${carrier.lastName}`:carrier.partyId)) : (carrier.groupName?carrier.groupName:carrier.partyId);
         })
       } else {
         throw resp.data;

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -705,7 +705,8 @@ const actions: ActionTree<UtilState, RootState> = {
 
       if (!hasError(resp)) {
         resp.data.map((carrier: any) => {
-          carrierDesc[carrier.partyId] = carrier.partyTypeId === "PERSON" ? (carrier.firstName?(carrier.lastName?`${carrier.firstName}${carrier.lastName}`:`${carrier.firstName}`):(carrier.lastName?`${carrier.lastName}`:carrier.partyId)) : (carrier.groupName?carrier.groupName:carrier.partyId);
+          const personName = [carrier.firstName, carrier.lastName].filter(Boolean).join(' ');
+          carrierDesc[carrier.partyId] = carrier.partyTypeId === "PERSON"? (personName || carrier.partyId): (carrier.groupName || carrier.partyId);
         })
       } else {
         throw resp.data;


### PR DESCRIPTION
…ng partyid(#1353)

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1353 
Fixed :when the carrier name are undefined in that case checking (first, last name) if any of name are not availabel showing partyid otherwise their groupname.

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)