### PR TITLE
Implemented:added feature to disable the segment tab on completed Detail page(#1286)

### DIFF
--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -29,7 +29,7 @@
           </ion-button>
         </div>
 
-        <ion-segment scrollable v-model="selectedSegment">
+        <ion-segment scrollable v-if="isDisabled || $route.params.category === 'open'" v-model="selectedSegment">
           <ion-segment-button value="open">
             <ion-label>{{ translate("Open") }}</ion-label>
           </ion-segment-button>
@@ -232,7 +232,11 @@ export default defineComponent({
     }),
     areItemsEligibleForRejection() {
       return this.currentOrder.items?.some((item: any) => item.rejectReasonId);
-    }
+    },
+    isDisabled() {
+      const openItems:any = this.currentOrder?.items?.filter((item: any) => item.statusId === 'ITEM_PENDING_FULFILL');
+      return (openItems && openItems.length > 0);
+    },
   },
   methods: {
     async printTransferOrderPicklist() {

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -29,7 +29,7 @@
           </ion-button>
         </div>
 
-        <ion-segment scrollable v-if="isDisabled || $route.params.category === 'open'" v-model="selectedSegment">
+        <ion-segment scrollable v-if="hasOpenItems || $route.params.category === 'open'" v-model="selectedSegment">
           <ion-segment-button value="open">
             <ion-label>{{ translate("Open") }}</ion-label>
           </ion-segment-button>
@@ -233,9 +233,9 @@ export default defineComponent({
     areItemsEligibleForRejection() {
       return this.currentOrder.items?.some((item: any) => item.rejectReasonId);
     },
-    isDisabled() {
-      const openItems:any = this.currentOrder?.items?.filter((item: any) => item.statusId === 'ITEM_PENDING_FULFILL');
-      return (openItems && openItems.length > 0);
+    hasOpenItems() {
+      const hasOpenItems:any = this.currentOrder?.items?.some((item: any) => item.statusId === 'ITEM_PENDING_FULFILL');
+      return hasOpenItems;
     },
   },
   methods: {


### PR DESCRIPTION
…ail only showing when open item > 0 (#1286)

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1286 
Implemented : added the feature to show the segement tab on completed detail page when there is  open item othewise showing completed items without showing segment tabs.

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)