### PR TITLE
Improved: create transfer order UI, shipping UX and added validations(#1302)

### DIFF
--- a/src/components/AddProductModal.vue
+++ b/src/components/AddProductModal.vue
@@ -19,7 +19,7 @@
           <DxpShopifyImg :src="product.mainImageUrl" />
         </ion-avatar>
         <ion-label>
-          <h2>{{ getProductIdentificationValue(productIdentificationStore.getProductIdentificationPref.primaryId, product) }}</h2>
+          <h2>{{ getProductIdentificationValue(productIdentificationStore.getProductIdentificationPref.primaryId, product) ? getProductIdentificationValue(productIdentificationStore.getProductIdentificationPref.primaryId, product) : product?.internalName }}</h2>
           <p>{{ getProductIdentificationValue(productIdentificationStore.getProductIdentificationPref.secondaryId, product) }}</p>
         </ion-label>
 

--- a/src/components/CreateTransferOrderModal.vue
+++ b/src/components/CreateTransferOrderModal.vue
@@ -156,6 +156,8 @@ async function createTransferOrder() {
     shipGroups: [{
       facilityId: originFacilityId,
       orderFacilityId: selectedDestinationFacilityId.value,
+      carrierPartyId: '_NA_',
+      shipmentMethodTypeId: 'STANDARD'
     }],
   };
   

--- a/src/components/TransferOrderItem.vue
+++ b/src/components/TransferOrderItem.vue
@@ -27,7 +27,7 @@
         <ion-button v-if="item.orderedQuantity" @click="pickAll(item)" slot="start" size="small" fill="outline" :disabled="isForceScanEnabled">
           {{ translate("Pick All") }}
         </ion-button>
-        <ion-button data-testid="book-qoh-btn" v-else :disabled="!item.qoh || item.pickedQuantity === item.qoh" slot="start" size="small" fill="outline" @click="bookQoh(item)">
+        <ion-button data-testid="book-qoh-btn" v-else :disabled="!item.qoh || item.qoh <= 0 || item.pickedQuantity === item.qoh" slot="start" size="small" fill="outline" @click="bookQoh(item)">
           {{ translate("Book qoh") }}
         </ion-button>
       </div>
@@ -64,7 +64,7 @@
       </div>
 
       <ion-item v-else class="qty-ordered" lines="none">
-        <ion-label>{{ item.qoh }} {{ translate("Qoh") }}</ion-label>
+        <ion-label>{{ item.qoh >= 0 ? item.qoh : '-' }} {{ translate("Qoh") }}</ion-label>
         <ion-icon data-testid="remove-item-btn" slot="end" color="danger" :icon="removeCircleOutline" @click="removeOrderItem(item)" />
       </ion-item>
     </div>
@@ -231,6 +231,11 @@ export default defineComponent({
       }
     },
     async updateItemQuantity(item: any) {
+      if(item.pickedQuantity < 0) {
+        showToast(translate("Quantity cannot be negative"));
+        return;
+      }
+
       try {
         const resp = await TransferOrderService.updateOrderItem({
           orderId: this.currentOrder.orderId,

--- a/src/store/modules/transferorder/actions.ts
+++ b/src/store/modules/transferorder/actions.ts
@@ -107,7 +107,7 @@ const actions: ActionTree<TransferOrderState, RootState> = {
             ...item,
             orderedQuantity: item.quantity,
             shippedQuantity: item.totalIssuedQuantity || 0,
-            pickedQuantity: 0
+            pickedQuantity: item.quantity
           }));
         }
 

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -744,8 +744,10 @@ const actions: ActionTree<UtilState, RootState> = {
           const { partyId, shipmentMethodTypeId, description } = storeCarrierAndMethod;
 
           if(!shipmentMethodsByCarrier[partyId]) shipmentMethodsByCarrier[partyId] = []
-          shipmentMethodsByCarrier[partyId].push({ shipmentMethodTypeId, description })
-
+          // only push this shipment method if not already added
+          if(!shipmentMethodsByCarrier[partyId].some((method: any) => method.shipmentMethodTypeId === shipmentMethodTypeId)) {
+            shipmentMethodsByCarrier[partyId].push({ shipmentMethodTypeId, description });
+          }
           return shipmentMethodsByCarrier
         }, {})
       } else {

--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -36,8 +36,8 @@
 
         <!-- adding product card -->
         <ion-card class="add-items">
-          <div class="search-type ion-margin-start">
-            <h4>{{ translate("Add items") }}</h4>
+          <div class="search-type">
+            <h5 class="ion-margin-horizontal">{{ translate("Add items") }}</h5>
             <ion-segment v-model="mode" @ionChange="segmentChange($event.target.value)">
               <ion-segment-button value="scan" content-id="scan">
                 <ion-icon :icon="barcodeOutline"/>
@@ -60,7 +60,7 @@
               </ion-thumbnail>
               <ion-label>
                 {{ getProductIdentificationValue(barcodeIdentifier, getProduct(searchedProduct.productId)) }}
-                <p>{{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(searchedProduct.productId)) }}</p>
+                <p>{{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(searchedProduct.productId)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(searchedProduct.productId)) : getProduct(searchedProduct.productId)?.internalName }}</p>
                 <p>{{ getProductIdentificationValue(productIdentificationPref.secondaryId, getProduct(searchedProduct.productId)) }}</p>
               </ion-label>
               <ion-icon :icon="checkmarkDoneOutline" color="success" slot="end"/>
@@ -126,7 +126,7 @@
                   <DxpShopifyImg :product="searchedProduct" />
                 </ion-thumbnail>
                 <ion-label>
-                  {{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(searchedProduct.productId)) }}
+                  {{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(searchedProduct.productId)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(searchedProduct.productId)) : getProduct(searchedProduct.productId)?.internalName }}
                   <p>{{ getProductIdentificationValue(productIdentificationPref.secondaryId, getProduct(searchedProduct.productId)) }}</p>
                 </ion-label>
                 <template v-if="!isItemAlreadyInOrder(searchedProduct.productId)">
@@ -309,7 +309,7 @@ async function fetchOrderItems(orderId: string) {
         return {
           ...item,
           pickedQuantity: item.pickedQuantity ?? item.quantity,
-          qoh: stock?.qoh ?? 0
+          qoh: stock?.qoh
         };
       })
     );
@@ -585,7 +585,7 @@ async function addTransferOrderItem(product: any, scannedId?: string) {
 
   // Fetch available stock
   const stock = product.productId ? await fetchStock(product.productId) : null;
-  if(stock) newItem.qoh = stock.qoh ?? 0;
+  newItem.qoh = stock?.qoh;
   searchedProduct.value = { ...newItem };
 
   try {
@@ -769,6 +769,11 @@ async function packAndShipOrder() {
   align-items: start;
   gap: var(--spacer-base);
   padding: var(--spacer-base);
+}
+
+ion-segment {
+  grid-auto-columns: minmax(auto, 150px);
+  width: auto;
 }
 
 .transfer-order > * {

--- a/src/views/ShipTransferOrder.vue
+++ b/src/views/ShipTransferOrder.vue
@@ -196,7 +196,7 @@ onIonViewWillEnter(async() => {
 
 function updateShipmentMethodsForCarrier(carrierPartyId: string) {
   shipmentMethods.value = shipmentMethodsByCarrier.value[carrierPartyId] || [];
-  selectedShippingMethod.value = shipmentMethods.value[0].shipmentMethodTypeId;
+  selectedShippingMethod.value = shipmentMethods.value[0]?.shipmentMethodTypeId || '';
 }
 
 async function fetchShipmentOrderDetail(shipmentId: string) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1302 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Enhanced product identification fallback to internal name
- Improved handling of shipping rates loading and empty states
- Clarified carrier/method selection in ShipTransferOrder
- Added validation to prevent negative picked quantities
- Updated Quantity on Hand (QOH) display logic
- Ensured correct initialization of pickedQuantity in transfer order actions
- Improved shipment method deduplication
- Enhanced UI consistency in CreateTransferOrder

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)