### PR TITLE
Improved: transfer order item validations(#1370)

### DIFF
--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -740,7 +740,7 @@ async function packAndShipOrder() {
     }
     const hasInvalidItem = currentOrder.value.items.some((item: any) => item.pickedQuantity <= 0);
     if(hasInvalidItem) {
-      showToast(translate("Please update a valid items quantity."));
+      showToast(translate("Please enter a valid quantity for all items."));
       return;
     }
 
@@ -749,7 +749,7 @@ async function packAndShipOrder() {
       items: currentOrder.value.items.map((item: any) => ({
         orderItemSeqId: item.orderItemSeqId,
         productId: item.productId,
-        quantity: parseInt(item.quantity),
+        quantity: parseInt(item.pickedQuantity),
         shipGroupSeqId: item.shipGroupSeqId
       }))
     }];

--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -269,7 +269,7 @@ watch(queryString, (value) => {
 
 onIonViewWillEnter(async () => {
   emitter.emit('presentLoader');
-  await fetchTransferOrderDetail(route.params.orderId as string);
+  await fetchTransferOrderDetail(route?.params?.orderId as string);
   await fetchProductInformation();
   await store.dispatch('util/fetchFacilities')
   emitter.emit('dismissLoader');
@@ -459,20 +459,29 @@ function clearQuery() {
 }
 
 // Scanning/Searching helpers
+// Enables scan mode and activates scanning.
 async function enableScan() {
   mode.value = 'scan';
   isScanningEnabled.value = true;
+  setTimeout(() => {
+    scanInput.value?.setFocus?.()
+  }, 0)
 }
 
+// Activates search mode: sets mode, focuses input after DOM update, and disables scanning.
+// Used by the "Search products" button.
 async function enableSearch() {
   mode.value = 'search';
   await nextTick();
   searchInput.value?.$el.setFocus?.()
+  isScanningEnabled.value = false
 }
 
+// Handles segment changes: clears query, switches to search mode or disables scanning.
+// Used by the segment change toggle UI.
 function segmentChange(mode: string) {
   clearQuery();
-  if(mode === 'search') enableSearch()
+  mode === 'search' ? enableSearch() : isScanningEnabled.value = false;
 }
 
 async function openAddProductModal() {
@@ -613,11 +622,13 @@ async function addTransferOrderItem(product: any, scannedId?: string) {
       currentOrder.value.items.push(newItem);
       await store.dispatch('transferorder/updateCurrentTransferOrder', currentOrder.value);
     } else {
+      searchedProduct.value = {};
       throw resp.data;
     }
   } catch (err) {
     logger.error(err);
     showToast(translate("Failed to add product to order"));
+    searchedProduct.value = {};
   }
   queryString.value = '';
 }
@@ -727,15 +738,15 @@ async function packAndShipOrder() {
         return;
       }
     }
-    const eligibleItems = currentOrder.value.items.filter((item: any) => item.quantity > 0);
-    if(!eligibleItems.length) {
-      showToast(translate("Please add at least one quantity to the item to proceed."));
+    const hasInvalidItem = currentOrder.value.items.some((item: any) => item.pickedQuantity <= 0);
+    if(hasInvalidItem) {
+      showToast(translate("Please update a valid items quantity."));
       return;
     }
 
     // Group items into packages — assuming we're sending one package for now
     const packages = [{
-      items: eligibleItems.map((item: any) => ({
+      items: currentOrder.value.items.map((item: any) => ({
         orderItemSeqId: item.orderItemSeqId,
         productId: item.productId,
         quantity: parseInt(item.quantity),

--- a/src/views/ShipTransferOrder.vue
+++ b/src/views/ShipTransferOrder.vue
@@ -189,7 +189,7 @@ const shippingRates = ref({}) as any
 const isLoadingRates = ref(true)
 
 onIonViewWillEnter(async() => {
-  await Promise.allSettled([fetchShipmentOrderDetail(route.params.shipmentId as any), store.dispatch('util/fetchStoreCarrierAndMethods'), store.dispatch("util/fetchCarriersDetail"), store.dispatch('carrier/fetchFacilityCarriers')])
+  await Promise.allSettled([fetchShipmentOrderDetail(route?.params?.shipmentId as any), store.dispatch('util/fetchStoreCarrierAndMethods'), store.dispatch("util/fetchCarriersDetail"), store.dispatch('carrier/fetchFacilityCarriers')])
   await fetchShippingRates();
   if(shipmentDetails.value?.carrierPartyId) updateShipmentMethodsForCarrier(shipmentDetails.value.carrierPartyId)
 });


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1370 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
* Added validation to prevent zero or negative picked quantities during transfer order creation.
* Improved error messaging and input focus handling in scan and search modes.
* Fixed incorrect parameter access in route handling.
* Ensured product search state resets properly on add failures.
* Updated pack and ship logic to validate item quantities before continuing.
* Added support to focus input while scanning.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)