### PR TITLE
Fixed: Prevent user to navigate to create-transfer-order page from shipment TO (#1374)

### DIFF
--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -754,7 +754,7 @@ async function packAndShipOrder() {
     const resp = await TransferOrderService.createOutboundTransferShipment(params)
     if(!hasError(resp)) {
       shipmentId = resp.data.shipmentId;
-      router.push({ path: `/ship-transfer-order/${shipmentId}` })
+      router.replace({ path: `/ship-transfer-order/${shipmentId}` })
     } else {
       throw resp.data;
     }

--- a/src/views/ShipTransferOrder.vue
+++ b/src/views/ShipTransferOrder.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header>
       <ion-toolbar>
-        <ion-back-button data-testid="ship-transfer-orders-back-btn" slot="start" defaultHref="" @click="shipLater" />
+        <ion-back-button data-testid="ship-transfer-orders-back-btn" slot="start" defaultHref="/transfer-orders" @click="shipLater" />
         <ion-title>{{ translate("Ship transfer order") }}</ion-title>
       </ion-toolbar>
     </ion-header>
@@ -375,10 +375,17 @@ async function shipLater() {
           'data-testid': "shiplater-continue-btn"
         },
         handler: async () => {
-          const resp = await TransferOrderService.cancelTransferOrderShipment(shipmentDetails.value.shipmentId)
-          if(!hasError(resp)) {
-            alertController.dismiss()
-            router.replace({ path: '/transfer-orders' })
+          try {
+            const resp = await TransferOrderService.cancelTransferOrderShipment(shipmentDetails.value.shipmentId)
+            if(!hasError(resp)) {
+              alertController.dismiss()
+              router.replace({ path: '/transfer-orders' })
+            } else {
+              throw resp.data
+            }
+          } catch (err) {
+            logger.error('Failed to cancel the shipment.', err);
+            showToast(translate('Failed to cancel transfer order shipment'));
           }
         }
       }

--- a/src/views/ShipTransferOrder.vue
+++ b/src/views/ShipTransferOrder.vue
@@ -378,7 +378,7 @@ async function shipLater() {
           const resp = await TransferOrderService.cancelTransferOrderShipment(shipmentDetails.value.shipmentId)
           if(!hasError(resp)) {
             alertController.dismiss()
-            router.push({ path: '/transfer-orders' })
+            router.replace({ path: '/transfer-orders' })
           }
         }
       }


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1374

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
* Replaced `router.push` with `router.replace` in **CreateTransferOrder** and **ShipTransferOrder** views.
* Prevents navigation history issues after creating or cancelling transfer order shipments.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)