### PR TITLE
1394/create popup for ship later

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -24,7 +24,8 @@ const actions: ActionTree<UserState, RootState> = {
  */
   async login ({ commit, dispatch }, payload) {
     try {
-      const {token, oms, omsRedirectionUrl} = payload;
+      const {token, oms} = payload;
+      const omsRedirectionUrl = "hacktoberfest-maarg"
       dispatch("setUserInstanceUrl", oms);
 
       // Getting the permissions list from server

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -24,8 +24,7 @@ const actions: ActionTree<UserState, RootState> = {
  */
   async login ({ commit, dispatch }, payload) {
     try {
-      const {token, oms} = payload;
-      const omsRedirectionUrl = "hacktoberfest-maarg"
+      const {token, oms, omsRedirectionUrl} = payload;
       dispatch("setUserInstanceUrl", oms);
 
       // Getting the permissions list from server

--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -734,13 +734,11 @@ async function shiplater() {
         text: translate("CONTINUE"),
         cssClass: 'primary',
         handler: async () => {
-          try {
-            const success = await approveOrder(currentOrder.value.orderId);    
-            if(success) {
-              router.replace({ path: '/transfer-orders' })
-            }
-          } catch (err) {
-            logger.error('Failed to approve the transfer order to ship later', err);
+          const success = await approveOrder(currentOrder.value.orderId);    
+          if(success) {
+            router.replace({ path: '/transfer-orders' })
+          } else {
+            showToast(translate("Failed to approve the transfer order"));
           }
         }
       }

--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -719,16 +719,34 @@ async function approveOrder(orderId: string) {
   }
 }
 
-// Approves the current transfer order and redirects to the transfer orders page.
+// Shows confirmation popup and approves the current transfer order to ship later.
 async function shiplater() {
-  try {
-    const success = await approveOrder(currentOrder.value.orderId);    
-    if(success) {
-      router.replace({ path: '/transfer-orders' })
-    }
-  } catch (err) {
-    logger.error('Failed to approve the transfer order to ship later', err);
-  }
+  const alert = await alertController.create({
+    header: translate("Ship Later"),
+    message: translate("Save this order without tracking details to ship later."),
+    buttons: [
+      {
+        text: translate("GO BACK"),
+        role: 'cancel',
+        cssClass: 'secondary'
+      },
+      {
+        text: translate("CONTINUE"),
+        cssClass: 'primary',
+        handler: async () => {
+          try {
+            const success = await approveOrder(currentOrder.value.orderId);    
+            if(success) {
+              router.replace({ path: '/transfer-orders' })
+            }
+          } catch (err) {
+            logger.error('Failed to approve the transfer order to ship later', err);
+          }
+        }
+      }
+    ]
+  });
+  await alert.present();
 }
 
 // Packs and ships the order by approving it, grouping items into packages, and creating an outbound transfer shipment.


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1394 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

Added confirmation popup for "Ship Later" functionality in CreateTransferOrder view. When users click the "Ship Later" button, they now see a confirmation dialog asking them to confirm saving the order without tracking details. This improves user experience by preventing accidental order approval and provides clear feedback about the action being performed.

**Key Changes:**
- Added confirmation popup with "Ship Later" title and descriptive message
- Implemented proper error handling with user feedback via toast messages
- Maintained existing functionality while adding confirmation step
- Improved UX by preventing silent failures and providing clear action outcomes

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

**Before:** Ship Later button directly approved the order without confirmation (No Image Possible)
**After:** Ship Later button shows confirmation popup with "GO BACK" and "CONTINUE" options
<img width="1440" height="787" alt="Screenshot 2025-10-11 at 1 04 09 PM" src="https://github.com/user-attachments/assets/90be690e-2788-48f0-805c-62c83ed76f9e" />



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)