### PR TITLE
Added a check condition that only shows "view more products" if searc…

### DIFF
--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -138,7 +138,7 @@
                   <ion-icon slot="end" :icon="checkmarkCircle" color="success" />
                 </template>
               </ion-item>
-              <ion-item data-testid="view-more-results" detail @click="openAddProductModal">
+              <ion-item v-if="productSearchCount > 1" data-testid="view-more-results" detail @click="openAddProductModal">
                 {{ translate("View more results", { count: productSearchCount - 1 }) }}
               </ion-item>
             </ion-list>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1386 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

Fixed the "View more results" item in CreateTransferOrder.vue to only display when there are actually more results to view (productSearchCount > 1). Previously, when only one product was found by search, it would show "View 0 more results" and still open the modal unnecessarily. Now it only appears when there are multiple results.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
**Before**:
<img width="810" height="243" alt="Screenshot 2025-10-11 at 3 20 42 PM" src="https://github.com/user-attachments/assets/ed77b51b-5a6e-4e9b-b077-32ac9afeba74" />

**After**:
<img width="810" height="243" alt="Screenshot 2025-10-11 at 3 22 45 PM" src="https://github.com/user-attachments/assets/c697f22c-6324-4f6a-9b9c-f16cfcb82ef2" />

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)