### PR TITLE
FIxed: Handled undefined shippingRates in ShipTransferOrder(#1390)

### DIFF
--- a/src/views/ShipTransferOrder.vue
+++ b/src/views/ShipTransferOrder.vue
@@ -85,7 +85,7 @@
               </div>
 
               <!-- Rates list -->
-              <ion-list v-else-if="shippingRates?.length">
+              <ion-list v-else-if="shippingRates.length">
                 <ion-item v-for="(shippingRate, index) in shippingRates" :key="index">
                   <ion-avatar slot="start">
                     <Image :src="getCarrierLogo(shippingRate.carrierPartyId)" />
@@ -185,7 +185,7 @@ const shipmentMethods = ref([]) as any;
 const selectedShippingMethod = ref('')
 const trackingCode = ref('')
 const shipmentDetails = ref({}) as any
-const shippingRates = ref({}) as any
+const shippingRates = ref([]) as any
 const isLoadingRates = ref(true)
 
 onIonViewWillEnter(async() => {
@@ -247,12 +247,13 @@ async function fetchShippingRates() {
   try {
     const resp = await CarrierService.fetchShippingRates({ shipmentId: shipmentDetails.value.shipmentId })
     if(!hasError(resp)) {
-      shippingRates.value = resp.data?.shippingRates
+      shippingRates.value = resp.data?.shippingRates || []
     } else { 
       throw resp.data
     }
   } catch (err) {
     logger.error('Failed to fetch shipment details.', err);
+    shippingRates.value = []
   }
   isLoadingRates.value = false
 }

--- a/src/views/ShipTransferOrder.vue
+++ b/src/views/ShipTransferOrder.vue
@@ -85,7 +85,7 @@
               </div>
 
               <!-- Rates list -->
-              <ion-list v-else-if="shippingRates.length">
+              <ion-list v-else-if="shippingRates?.length">
                 <ion-item v-for="(shippingRate, index) in shippingRates" :key="index">
                   <ion-avatar slot="start">
                     <Image :src="getCarrierLogo(shippingRate.carrierPartyId)" />
@@ -247,7 +247,7 @@ async function fetchShippingRates() {
   try {
     const resp = await CarrierService.fetchShippingRates({ shipmentId: shipmentDetails.value.shipmentId })
     if(!hasError(resp)) {
-      shippingRates.value = resp.data.shippingRates
+      shippingRates.value = resp.data?.shippingRates
     } else { 
       throw resp.data
     }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1390 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added optional chaining to prevent errors when shippingRates is undefined in both template rendering and API response assignment.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)