### PR TITLE
Fixed: Show SKU swap message conditionally in scanner UI(#1380)

### DIFF
--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -88,7 +88,7 @@
               <ion-label>
                 {{ translate("Your scanner isn’t focused yet.") }}
                 <p>{{ translate("Scanning is set to") }} {{ (barcodeIdentifier || '').toUpperCase() }}</p>
-                <p>{{ translate("Swap to SKU from the settings page") }}</p>
+                <p v-if="barcodeIdentifier !== 'SKU'">{{ translate("Swap to SKU from the settings page") }}</p>
               </ion-label>
               <ion-button slot="end" color="warning" size="small" @click="enableScan">
                 <ion-icon slot="start" :icon="locateOutline"/>
@@ -104,7 +104,7 @@
               <ion-label>
                 {{ translate("Begin scanning products to add them to this transfer") }}
                 <p>{{ translate("Scanning is set to") }} {{ (barcodeIdentifier || '').toUpperCase() }}</p>
-                <p>{{ translate("Swap to SKU from the settings page") }}</p>
+                <p v-if="barcodeIdentifier !== 'SKU'">{{ translate("Swap to SKU from the settings page") }}</p>
               </ion-label>
               <ion-badge slot="end" color="success">{{ translate("start scanning") }}</ion-badge>
             </ion-item>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1380 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- The 'Swap to SKU from the settings page' message is now only displayed when the barcode identifier is not 'SKU', improving clarity for users scanning products.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)