### PR TITLE
Implemented: Add discard confirmation alert box to transfer order(#1395)

### DIFF
--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -692,19 +692,39 @@ function clearSearch() {
 
 // Discards the current transfer order by calling the cancel API and navigates to the transfer orders list.
 async function discardOrder() {
-  const orderId = currentOrder.value.orderId;
-  try {
-    const resp = await TransferOrderService.cancelTransferOrder(orderId);
-    if(!hasError(resp)) {
-      showToast(translate("Order discarded successfully"));
-      router.replace({ path: '/transfer-orders' });
-    } else {
-      throw resp.data;
-    }
-  } catch (err) {
-    logger.error("Failed to discard order", err);
-    showToast(translate("Failed to discard order"));
-  }
+  const alert = await alertController.create({
+    header: translate('Discard order'),
+    message: translate("Are you sure you want to discard this transfer order?"),
+    buttons: [{
+      text: translate('Cancel'),
+      role: 'cancel',
+      htmlAttributes: { 
+        'data-testid': "discard-order-cancel-btn"
+      }
+    },
+    {
+      text: translate('Discard'),
+      htmlAttributes: { 
+        'data-testid': "discard-order-btn"
+      },
+      handler: async () => {
+        const orderId = currentOrder.value.orderId;
+        try {
+          const resp = await TransferOrderService.cancelTransferOrder(orderId);
+          if(!hasError(resp)) {
+            showToast(translate("Order discarded successfully"));
+            router.replace({ path: '/transfer-orders' });
+          } else {
+            throw resp.data;
+          }
+        } catch (err) {
+          logger.error("Failed to discard order", err);
+          showToast(translate("Failed to discard order"));
+        }
+      }
+    }]
+  });
+  return alert.present();
 }
 
 async function approveOrder(orderId: string) {

--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -705,7 +705,7 @@ async function discardOrder() {
     {
       text: translate('Discard'),
       htmlAttributes: { 
-        'data-testid': "discard-order-btn"
+        'data-testid': "discard-order-discard-btn"
       },
       handler: async () => {
         const orderId = currentOrder.value.orderId;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1395


### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a confirmation alert before discarding a transfer order in CreateTransferOrder.vue to prevent accidental deletions. 

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)