### PR TITLE
Fixed: Pass productStoreId to fetchFacilities action on create transfer order page(#1384)

### DIFF
--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -404,10 +404,11 @@ const actions: ActionTree<UtilState, RootState> = {
     commit(types.UTIL_REJECT_REASONS_UPDATED, payload)
   },
 
-  async fetchFacilities({ commit }) {
+  async fetchFacilities({ commit }, productStoreId?: string) {
     let facilities  = [];
     try {
       const payload = {
+        productStoreId: productStoreId,
         "parentTypeId": "VIRTUAL_FACILITY",
         "parentTypeId_op": "equals",
         "parentTypeId_not": "Y",

--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -221,7 +221,7 @@ import { ProductService } from '@/services/ProductService';
 import { StockService } from '@/services/StockService';
 import { hasError } from '@/adapter';
 import logger from '@/logger';
-import { getCurrentFacilityId, showToast } from '@/utils';
+import { getCurrentFacilityId, getProductStoreId, showToast } from '@/utils';
 import { TransferOrderService } from '@/services/TransferOrderService';
 import { OrderService } from '@/services/OrderService';
 import TransferOrderItem from '@/components/TransferOrderItem.vue'
@@ -271,7 +271,7 @@ onIonViewWillEnter(async () => {
   emitter.emit('presentLoader');
   await fetchTransferOrderDetail(route?.params?.orderId as string);
   await fetchProductInformation();
-  await store.dispatch('util/fetchFacilities')
+  await store.dispatch('util/fetchFacilities', getProductStoreId())
   emitter.emit('dismissLoader');
 });
 


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1384

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
* Added support to fetch facilities based on the product store on the Create Transfer Order page.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)