### PR TITLE
FIxed: Improve carrier description fallback logic (#1387)

### DIFF
--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -707,7 +707,7 @@ const actions: ActionTree<UtilState, RootState> = {
       if (!hasError(resp)) {
         resp.data.map((carrier: any) => {
           const personName = [carrier.firstName, carrier.lastName].filter(Boolean).join(' ');
-          carrierDesc[carrier.partyId] = carrier.partyTypeId === "PERSON"? (personName || carrier.groupName || carrier.partyId): (carrier.groupName || carrier.partyId);
+          carrierDesc[carrier.partyId] = (carrier.partyTypeId === "PERSON" && personName) || carrier.groupName || carrier.partyId;
         })
       } else {
         throw resp.data;

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -707,7 +707,7 @@ const actions: ActionTree<UtilState, RootState> = {
       if (!hasError(resp)) {
         resp.data.map((carrier: any) => {
           const personName = [carrier.firstName, carrier.lastName].filter(Boolean).join(' ');
-          carrierDesc[carrier.partyId] = carrier.partyTypeId === "PERSON"? (personName || carrier.partyId): (carrier.groupName || carrier.partyId);
+          carrierDesc[carrier.partyId] = carrier.partyTypeId === "PERSON"? (personName || carrier.groupName || carrier.partyId): (carrier.groupName || carrier.partyId);
         })
       } else {
         throw resp.data;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1387 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Updated the logic for assigning carrier descriptions to use groupName as a fallback for personName when partyTypeId is 'PERSON'. This ensures more descriptive values when personName is unavailable.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)