### PR TITLE
Fixed: Pre-filled quantity displayed on Transfer Order Details page (#1376)

### DIFF
--- a/src/store/modules/transferorder/actions.ts
+++ b/src/store/modules/transferorder/actions.ts
@@ -107,7 +107,7 @@ const actions: ActionTree<TransferOrderState, RootState> = {
             ...item,
             orderedQuantity: item.quantity,
             shippedQuantity: item.totalIssuedQuantity || 0,
-            pickedQuantity: item.quantity
+            pickedQuantity: 0
           }));
         }
 


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1376


### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Issue with pre-filled quantity display on the Transfer Order Details page.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)