### PR TITLE
Fixed: Simplified shipOrder validation and payload logic by removing redundant label checks (#1392)

### DIFF
--- a/src/views/ShipTransferOrder.vue
+++ b/src/views/ShipTransferOrder.vue
@@ -413,11 +413,9 @@ async function shipLater() {
 async function shipOrder() {
   const shipment = shipmentDetails.value;
   if(!shipment) return;
-
-  const isLabelAlreadyGenerated = shipment.trackingIdNumber ? true : false;
-
-  // Only validate carrier/method/trackingCode if label not already generated
-  if(!isLabelAlreadyGenerated) {
+ 
+  // Validate required fields based on selected shipping method
+  if(selectedSegment.value === "manual") {
     if(!selectedCarrier.value) {
       showToast(translate('Please select a carrier'))
       return;
@@ -430,13 +428,15 @@ async function shipOrder() {
       showToast(translate('Please enter a tracking number'));
       return;
     }
+  } else if(selectedSegment.value === "purchase" && !shipment.trackingIdNumber) {
+    showToast(translate('Please purchase a shipping label'))
+    return;
   }
 
   try {
-    // Build payload dynamically based on whether label exists
     const payload: any = { shipmentId: shipment.shipmentId }
 
-    if(!isLabelAlreadyGenerated) {
+    if(selectedSegment.value === "manual") {
       payload.trackingIdNumber = trackingCode.value
       payload.shipmentRouteSegmentId = shipment.shipmentRouteSegmentId
       payload.carrierPartyId = selectedCarrier.value


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1392

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Removed unnecessary isLabelAlreadyGenerated condition.
- Simplified validation to directly check carrier, method, and tracking number based on selected segment.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)