### PR TITLE
Fixed: Used shipGroups data from order details to display the order facility name (#1447)

### DIFF
--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -227,7 +227,7 @@ import { ProductService } from '@/services/ProductService';
 import { StockService } from '@/services/StockService';
 import { hasError } from '@/adapter';
 import logger from '@/logger';
-import { getCurrentFacilityId, showToast } from '@/utils';
+import { showToast } from '@/utils';
 import { TransferOrderService } from '@/services/TransferOrderService';
 import { UtilService } from '@/services/UtilService';
 import { OrderService } from '@/services/OrderService';
@@ -614,7 +614,7 @@ async function addTransferOrderItem(product: any, scannedId?: string) {
     // Fetch product's average cost before committing to order
     const unitPrice = await ProductService.fetchProductAverageCost(
       newItem.productId,
-      currentOrder.value.shipGroups[0].orderFacilityId
+      currentOrder.value.shipGroups[0].facilityId
     );
 
     // Prepare payload and call API to add order item
@@ -652,7 +652,7 @@ async function fetchStock(productId: string) {
   try {
     const resp: any = await StockService.getInventoryAvailableByFacility({
       productId,
-      facilityId: getCurrentFacilityId()
+      facilityId: currentOrder.value.shipGroups[0].facilityId
     });
     if(!hasError(resp)) return resp.data;
   } catch (err) {

--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -23,7 +23,7 @@
               <ion-item>
                 <ion-icon :icon="storefrontOutline" slot="start"/>
                 <!-- currently the facility name is coming in the api -->
-                <ion-label>{{ getFacilityName(currentOrder.orderFacilityId) }}</ion-label>
+                <ion-label>{{ getFacilityName(currentOrder.shipGroups[0].orderFacilityId) }}</ion-label>
                 <ion-button data-testid="store-name-edit-btn" slot="end" color="medium" fill="outline" size="small" @click="openSelectFacilityModal">{{ translate("Edit") }}</ion-button>
               </ion-item>
               <ion-item>
@@ -420,8 +420,8 @@ async function openSelectFacilityModal() {
   const addressModal = await modalController.create({
     component: SelectFacilityModal,
     componentProps: {
-      currentFacilityId: currentOrder.value.facilityId,
-      selectedFacilityId: currentOrder.value.orderFacilityId,
+      currentFacilityId: currentOrder.value.shipGroups[0].facilityId,
+      selectedFacilityId: currentOrder.value.shipGroups[0].orderFacilityId,
       facilities: facilities.value
     }
   });
@@ -440,13 +440,13 @@ async function updateOrderFacility(facilityId: string) {
   const payload = {
     orderId: currentOrder.value.orderId,
     orderFacilityId: facilityId,
-    shipGroupSeqId: currentOrder.value.shipGroupSeqId
+    shipGroupSeqId: currentOrder.value.shipGroups[0].shipGroupSeqId
   }
 
   try {
     const resp = await OrderService.updateOrderFacility(payload)
     if(!hasError(resp)) {
-      currentOrder.value.orderFacilityId = facilityId;
+      currentOrder.value.shipGroups[0].orderFacilityId = facilityId;
       await store.dispatch('transferorder/updateCurrentTransferOrder', currentOrder.value);
       showToast(translate("Store name updated successfully"))
     } else {
@@ -614,7 +614,7 @@ async function addTransferOrderItem(product: any, scannedId?: string) {
     // Fetch product's average cost before committing to order
     const unitPrice = await ProductService.fetchProductAverageCost(
       newItem.productId,
-      currentOrder.value.orderFacilityId
+      currentOrder.value.shipGroups[0].orderFacilityId
     );
 
     // Prepare payload and call API to add order item

--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -23,7 +23,7 @@
               <ion-item>
                 <ion-icon :icon="storefrontOutline" slot="start"/>
                 <!-- currently the facility name is coming in the api -->
-                <ion-label>{{ getFacilityName(currentOrder.shipGroups[0].orderFacilityId) }}</ion-label>
+                <ion-label>{{ getFacilityName(currentOrder.shipGroups?.[0]?.orderFacilityId) }}</ion-label>
                 <ion-button data-testid="store-name-edit-btn" slot="end" color="medium" fill="outline" size="small" @click="openSelectFacilityModal">{{ translate("Edit") }}</ion-button>
               </ion-item>
               <ion-item>
@@ -420,8 +420,8 @@ async function openSelectFacilityModal() {
   const addressModal = await modalController.create({
     component: SelectFacilityModal,
     componentProps: {
-      currentFacilityId: currentOrder.value.shipGroups[0].facilityId,
-      selectedFacilityId: currentOrder.value.shipGroups[0].orderFacilityId,
+      currentFacilityId: currentOrder.value.shipGroups?.[0]?.facilityId,
+      selectedFacilityId: currentOrder.value.shipGroups?.[0]?.orderFacilityId,
       facilities: facilities.value
     }
   });
@@ -437,16 +437,18 @@ async function openSelectFacilityModal() {
 
 // Updates the order facility with the given facility ID.
 async function updateOrderFacility(facilityId: string) {
+  const shipGroup = currentOrder.value?.shipGroups?.[0];
+
   const payload = {
     orderId: currentOrder.value.orderId,
     orderFacilityId: facilityId,
-    shipGroupSeqId: currentOrder.value.shipGroups[0].shipGroupSeqId
+    shipGroupSeqId: shipGroup?.shipGroupSeqId
   }
 
   try {
     const resp = await OrderService.updateOrderFacility(payload)
     if(!hasError(resp)) {
-      currentOrder.value.shipGroups[0].orderFacilityId = facilityId;
+      if(shipGroup) shipGroup.orderFacilityId = facilityId;
       await store.dispatch('transferorder/updateCurrentTransferOrder', currentOrder.value);
       showToast(translate("Store name updated successfully"))
     } else {
@@ -614,7 +616,7 @@ async function addTransferOrderItem(product: any, scannedId?: string) {
     // Fetch product's average cost before committing to order
     const unitPrice = await ProductService.fetchProductAverageCost(
       newItem.productId,
-      currentOrder.value.shipGroups[0].facilityId
+      currentOrder.value.shipGroups?.[0]?.facilityId
     );
 
     // Prepare payload and call API to add order item
@@ -652,7 +654,7 @@ async function fetchStock(productId: string) {
   try {
     const resp: any = await StockService.getInventoryAvailableByFacility({
       productId,
-      facilityId: currentOrder.value.shipGroups[0].facilityId
+      facilityId: currentOrder.value.shipGroups?.[0]?.facilityId
     });
     if(!hasError(resp)) return resp.data;
   } catch (err) {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1447 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
* Previously, the order details had a separate API call that fetched the data from `shipGroups`.
* After changing to a single API for fetching the data, when items are not present in the order, `facilityId` and `orderFacilityId` are not returned at the order level but are instead present in the `shipGroup` object. This change has been fixed.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)