### PR TITLE
Fixed: On confirming a shipment transfer order, show the order items under the Completed tab(#1364)

### DIFF
--- a/src/views/TransferShipmentReview.vue
+++ b/src/views/TransferShipmentReview.vue
@@ -263,7 +263,7 @@ export default defineComponent({
         
         this.isShipped = true;
         showToast(translate('Shipment shipped successfully.'));
-        this.router.replace({ path: `/transfer-order-details/${this.currentShipment.orderId}/open` })
+        this.router.replace({ path: `/transfer-order-details/${this.currentShipment.orderId}/completed` })
       } catch (err) {
         logger.error('Failed to ship the shipment.', err);
         showToast(translate('Something went wrong, could not ship the shipment'))


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1364

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- On confirming a shipment transfer order, show the order items under the Completed tab instead of landing on the Open tab.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)