### PR TITLE
Fixed: Added an alert box when navigating away from the Ship Transfer Order page (#1366)

### DIFF
--- a/src/views/ShipTransferOrder.vue
+++ b/src/views/ShipTransferOrder.vue
@@ -224,8 +224,9 @@ onBeforeRouteLeave(async () => {
             } else {
               throw resp.data;
             }
-          } catch {
+          } catch (err) {
             showToast(translate('Failed to cancel transfer order shipment'));
+            logger.error('Failed to cancel transfer order shipment', err);
             canLeave = false;
           }
         },


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1366 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- This issue occurs when a user creates a transfer order from the Create Transfer Order page, navigates to the Ship Transfer Order page, and then—without completing the shipment—clicks on any tab or navigates to another route (other than Ship Later or the back button). This leaves the shipment in a limbo state.
- In this state, the item has the `ITEM_PENDING_FULFILL` status, and a shipment exists for that order without any shipped quantity, causing the rejection chip to appear on the Transfer Order Details page.
- However, as the API indicates, you cannot reject an item once fulfillment has started, so the user is unable to reject the item.
- Fixed this issue by adding the same alert box when the user attempts to navigate to another route, showing a message that continuing will cancel the shipment and prevent this issue from occurring.



### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)