### PR TITLE
Fixed: Allow updating item quantity only if the order is in created status(#1448)

### DIFF
--- a/src/components/TransferOrderItem.vue
+++ b/src/components/TransferOrderItem.vue
@@ -248,6 +248,9 @@ export default defineComponent({
       }
     },
     async updateItemQuantity(item: any) {
+      // Allow updating item quantity only if the order is in ORDER_CREATED status
+      if(this.currentOrder.statusId !== 'ORDER_CREATED') return;
+
       const currentItem = this.currentOrder.items.find((orderItem: any) => orderItem.orderItemSeqId === item.orderItemSeqId);
       // Skip if picked quantity is same as current or invalid (equal to or less than 0)
       if(currentItem && item.pickedQuantity === currentItem.quantity) return;


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1448

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Currently, the input field triggers an API call to update the item's ordered quantity on blur.
- Ideally, the user should only be allowed to update the item's ordered quantity if the order is in the "ORDER_CREATED" state. Added a check to enforce this behavior.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)