### PR TITLE
Fixed: Added orderDate and entryDate fields when creating a transfer order (#1455)

### DIFF
--- a/src/components/CreateTransferOrderModal.vue
+++ b/src/components/CreateTransferOrderModal.vue
@@ -57,6 +57,7 @@ import { TransferOrderService } from '@/services/TransferOrderService';
 import { hasError } from '@/adapter';
 import { useStore } from 'vuex';
 import { getCurrentFacilityId, getProductStoreId, showToast } from '@/utils';
+import { DateTime } from 'luxon';
 import router from '@/router';
 import logger from '@/logger';
 
@@ -143,6 +144,8 @@ async function createTransferOrder() {
     statusId: 'ORDER_CREATED',
     statusFlowId: 'TO_Fulfill_And_Receive',
     currencyUom: currencyUom.value || 'USD',
+    orderDate: DateTime.now().toFormat("yyyy-MM-dd 23:59:59.000"),
+		entryDate: DateTime.now().toFormat("yyyy-MM-dd 23:59:59.000"),
     grandTotal: 0,
     productStoreId,
     originFacilityId,

--- a/src/components/CreateTransferOrderModal.vue
+++ b/src/components/CreateTransferOrderModal.vue
@@ -130,7 +130,8 @@ async function createTransferOrder() {
   
   const productStoreId = getProductStoreId() || '';
   const originFacilityId = getCurrentFacilityId() || '';
-  
+  const orderTimestamp = DateTime.now().toFormat("yyyy-MM-dd 23:59:59.000")
+
   if(originFacilityId === selectedDestinationFacilityId.value) {
     showToast(translate('Origin and destination facility cannot be the same.'));
     return;
@@ -144,8 +145,8 @@ async function createTransferOrder() {
     statusId: 'ORDER_CREATED',
     statusFlowId: 'TO_Fulfill_And_Receive',
     currencyUom: currencyUom.value || 'USD',
-    orderDate: DateTime.now().toFormat("yyyy-MM-dd 23:59:59.000"),
-		entryDate: DateTime.now().toFormat("yyyy-MM-dd 23:59:59.000"),
+    orderDate: orderTimestamp,
+		entryDate: orderTimestamp,
     grandTotal: 0,
     productStoreId,
     originFacilityId,


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1455

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, the orderDate was not being passed while creating the transfer order. Because of this, the date was not set in the order header, resulting in orders not being listed date-wise in the Transfer app.
- Added support to pass the orderDate and entryDate fields while creating a transfer order.



### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)