### PR TITLE
Fixed: Added support to show an alert when navigating away from the Review Shipment page to discard an already created shipment (#1366)

### DIFF
--- a/src/views/TransferShipmentReview.vue
+++ b/src/views/TransferShipmentReview.vue
@@ -114,8 +114,9 @@ export default defineComponent({
     this.trackingCode = this.currentShipment?.trackingIdNumber;
     this.shipmentItems = this.currentShipment.items;
   },
-  async beforeRouteLeave(to) {
-    if (to.path !== `/transfer-order-details/${this.currentShipment.orderId}/open`) return;
+  async beforeRouteLeave() {
+    if(this.isShipped) return true;
+
     let canLeave = false;
     const message = translate("Are you sure that you want to discard this shipment?");
     const alert = await alertController.create({


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1366 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Another case occurred when the shipment was left in a limbo state after the user left the Review Shipment page without processing.
- This resulted in the user being unable to reject the item on the details page.
- Added a navigation alert that appears when the user tries to leave the Review Shipment page without proceeding from it.



### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)