### PR TITLE
Fixed: Added route guard to prevent navigation from create transfer order page with discard confirmation (#1468)

### DIFF
--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -295,7 +295,7 @@ onIonViewWillEnter(async () => {
 
 // Discards the current transfer order by calling the cancel API and navigates to the transfer orders list.
 onBeforeRouteLeave(async () => {
-  if(preventLeave.value) return true;
+  if(preventLeave.value || currentOrder.value.statusId !== 'ORDER_CREATED') return true;
 
   let canLeave = false;
   const alert = await alertController.create({


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1468 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Previously, users could navigate away from the *Create Transfer Order* page without confirmation, which could cause incomplete orders.
- Added a routing guard (`onBeforeRouteLeave`) to show a discard confirmation alert before leaving the page, ensuring intentional navigation only.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)