### PR TITLE
Fixed: ensure picked quantity is parsed as number before updating order item(#1400)

### DIFF
--- a/src/components/TransferOrderItem.vue
+++ b/src/components/TransferOrderItem.vue
@@ -254,7 +254,7 @@ export default defineComponent({
       if(this.currentOrder.statusId !== 'ORDER_CREATED') return;
 
       const currentItem = this.currentOrder.items.find((orderItem: any) => orderItem.orderItemSeqId === item.orderItemSeqId);
-      const itemQuantity = parseInt((this.$refs.pickedQuantity as any).$el.value)
+      const itemQuantity = parseInt((this.$refs.pickedQuantity as any).$el.value) || 0
 
       // Skip if picked quantity is same as current or invalid (equal to or less than 0)
       if(currentItem && itemQuantity === currentItem.quantity) return;

--- a/src/components/TransferOrderItem.vue
+++ b/src/components/TransferOrderItem.vue
@@ -254,7 +254,7 @@ export default defineComponent({
       if(this.currentOrder.statusId !== 'ORDER_CREATED') return;
 
       const currentItem = this.currentOrder.items.find((orderItem: any) => orderItem.orderItemSeqId === item.orderItemSeqId);
-      const itemQuantity = (this.$refs.pickedQuantity as any).$el.value
+      const itemQuantity = parseInt((this.$refs.pickedQuantity as any).$el.value)
 
       // Skip if picked quantity is same as current or invalid (equal to or less than 0)
       if(currentItem && itemQuantity === currentItem.quantity) return;
@@ -267,7 +267,7 @@ export default defineComponent({
           quantity: itemQuantity
         });
         if(!hasError(resp)) {
-          item.quantity = itemQuantity;
+          currentItem.quantity = itemQuantity;
           await this.store.dispatch('transferorder/updateCurrentTransferOrder', this.currentOrder)
         } else {
           throw resp.data;


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1400


### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, item quantity was read as a string, which could cause incorrect comparison or API payload issues.
Now the value is explicitly parsed to an Number before update to ensure correct behavior.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)