### PR TITLE
Fixed: resolve progress bar reactivity issue for newly added items(#1396)

### DIFF
--- a/src/components/TransferOrderItem.vue
+++ b/src/components/TransferOrderItem.vue
@@ -175,6 +175,8 @@ export default defineComponent({
       if (selectedItem) {
         selectedItem.pickedQuantity = event.detail.value ? parseInt(event.detail.value) : 0;
         selectedItem.progress = parseInt(selectedItem.pickedQuantity);
+        item.pickedQuantity = selectedItem.pickedQuantity;
+        item.progress = selectedItem.progress;
       }
       await this.store.dispatch('transferorder/updateCurrentTransferOrder', this.currentOrder)
     },


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1396 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Synchronize local component item state with store state in updatePickedQuantity method.
- Update local item.pickedQuantity and item.progress when modifying store values.
- Fix progress bar not updating dynamically when changing picked quantity for newly added items.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)