### PR TITLE
Improved: added background processing toast for bulk item scanning

### DIFF
--- a/src/composables/useProductQueue.ts
+++ b/src/composables/useProductQueue.ts
@@ -100,7 +100,7 @@ export function useProductQueue() {
     }
     
     isProcessing.value = false;
-    if (pendingItemsToast) hidePendingItemsToast();
+    hidePendingItemsToast();
   };
   
   /**

--- a/src/composables/useProductQueue.ts
+++ b/src/composables/useProductQueue.ts
@@ -51,7 +51,7 @@ export function useProductQueue() {
   };
 
   // Hide pending items toast
-  const hidePendingItemsToast = async () => {
+  const hidePendingItemsToast = () => {
     if (pendingItemsToast) {
       pendingItemsToast.dismiss();
       pendingItemsToast = null;
@@ -78,8 +78,8 @@ export function useProductQueue() {
     pendingProductIds.value.add(product.productId);
     addQueue.value.push(itemToAdd);
 
-    // Show toast only when pending items exceed 2
-    if (pendingProductIds.value.size > 2) showPendingItemsToast();
+    // Show toast only when pending items are 2 or more
+    if (pendingProductIds.value.size >= 2) showPendingItemsToast();
     processQueue();
   };
 
@@ -97,14 +97,10 @@ export function useProductQueue() {
 
       await processSingleProduct(itemToAdd);
       addQueue.value.shift();
-
-      // Hide toast when pending items drop to 2 or less
-      if (pendingItemsToast && pendingProductIds.value.size <= 2) {
-        await hidePendingItemsToast();
-      }
     }
     
     isProcessing.value = false;
+    if (pendingItemsToast) hidePendingItemsToast();
   };
   
   /**

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,7 @@
   "Activation code": "Activation code",
   "Add": "Add",
   "Adding...": "Adding...",
+  "Adding items to the order": "Adding items to the order",
   "Add a message" : "Add a message",
   "Adjust the QOH along with ATP on rejection.": "Adjust the QOH along with ATP on rejection.",
   "Affect QOH": "Affect QOH",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -4,6 +4,7 @@
   "Activation code": "Código de Activación",
   "Add": "Agregar",
   "Adding...": "Adding...",
+  "Adding items to the order": "Adding items to the order",
   "Add a message" : "Add a message",
   "Add tracking details" : "Add tracking details",
   "Adjust the QOH along with ATP on rejection.": "Adjust the QOH along with ATP on rejection.",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -4,6 +4,7 @@
   "Activation code": "Activation code",
   "Add": "追加",
   "Adding...": "Adding...",
+  "Adding items to the order": "Adding items to the order",
   "Add a message" : "Add a message",
   "Add tracking details" : "Add tracking details",
   "Adjust the QOH along with ATP on rejection.": "Adjust the QOH along with ATP on rejection.",


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Show "Adding items to the order" toast when scanning 2 or more products
- Toast appears for any background processing with 2+ items
- Toast remains visible until all items in queue are completely processed
- Automatic dismissal only after entire processing session completes

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)