### PR TITLE
Fixed: added default '$' fallback in formatCurrency when currency code is missing

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -174,7 +174,7 @@ const currentSymbol: any = {
 }
 
 const formatCurrency = (amount: any, code: string) => {
-  return `${currentSymbol[code] || code} ${amount || 0}`
+  return `${currentSymbol[code] || code || "$"} ${amount || 0}`
 }
 
 const getColorByDesc = (desc: string) => ({


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a default `$` fallback in the formatCurrency function to ensure a currency symbol is displayed even when the currency code is missing or undefined.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)