### PR TITLE
Fixed: added support to show a toast when the shipping label API fails to generate

### DIFF
--- a/src/views/ShipTransferOrder.vue
+++ b/src/views/ShipTransferOrder.vue
@@ -356,31 +356,27 @@ function generateRateName(carrierPartyId: string, shipmentMethodTypeId: string) 
 // Purchases a new shipping label by updating carrier/method, retrying label generation, refreshing shipment details, and printing the label.
 async function purchaseShippingLabel() {
   const shipment = shipmentDetails.value;
-
-  try {
-    await OrderService.retryShippingLabel(shipment.shipmentId);
-    await fetchShipmentOrderDetail(shipment.shipmentId)
-    await printShippingLabel();
-  } catch (error) {
-    logger.error("Failed to purchase shipping label", error);
-    showToast(translate("Failed to purchase shipping label"));
+  await OrderService.retryShippingLabel(shipment.shipmentId);
+  await fetchShipmentOrderDetail(shipment.shipmentId)
+  if(shipmentDetails.value?.carrierServiceStatusId !== 'SHRSCS_ACCEPTED') {
+    showToast(translate("Failed to generate shipping label"))
+    return;
   }
+  await printShippingLabel();
 }
 
 // Prints the shipping label if available by collecting unique label URLs and calling the print service
 async function printShippingLabel() {
   const shipment = shipmentDetails.value
   try {
-    if(shipment.carrierServiceStatusId === 'SHRSCS_ACCEPTED') {
-      const shippingLabelPdfUrls: string[] = Array.from(
-        new Set(
-          (shipment.packages ?? [])
-            .filter((shipmentPackage: any) => shipmentPackage.labelImageUrl)
-            .map((shipmentPackage: any) => shipmentPackage.labelImageUrl)
-        )
-      );
-      await OrderService.printShippingLabel([shipment.shipmentId], shippingLabelPdfUrls, shipment.packages);
-    }
+    const shippingLabelPdfUrls: string[] = Array.from(
+      new Set(
+        (shipment.packages ?? [])
+          .filter((shipmentPackage: any) => shipmentPackage.labelImageUrl)
+          .map((shipmentPackage: any) => shipmentPackage.labelImageUrl)
+      )
+    );
+    await OrderService.printShippingLabel([shipment.shipmentId], shippingLabelPdfUrls, shipment.packages);
   } catch (error) {
     logger.error(error)
   }


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added support to show a toast when the shipping label API fails to generate.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)