### PR TITLE
Fixed: issue of partyId being displayed in other shipments section on order details page(#1492)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -283,7 +283,7 @@ const actions: ActionTree<OrderState, RootState> = {
     const facilityTypeIds = otherShipments.map((shipment: any) => shipment.facilityTypeId)
     this.dispatch('util/fetchFacilityTypeInformation', facilityTypeIds)
 
-    const carrierPartyIds = otherShipments.map((shipment: any) => shipment.carrierPartyId)
+    const carrierPartyIds = otherShipments.map((shipment: any) => shipment.carrierPartyId).filter((id: any) => id);
     this.dispatch('util/fetchPartyInformation', [...new Set(carrierPartyIds)])
 
     currentOrder.otherShipGroups = otherShipments

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -283,6 +283,9 @@ const actions: ActionTree<OrderState, RootState> = {
     const facilityTypeIds = otherShipments.map((shipment: any) => shipment.facilityTypeId)
     this.dispatch('util/fetchFacilityTypeInformation', facilityTypeIds)
 
+    const carrierPartyIds = otherShipments.map((shipment: any) => shipment.carrierPartyId)
+    this.dispatch('util/fetchPartyInformation', [...new Set(carrierPartyIds)])
+
     currentOrder.otherShipGroups = otherShipments
     commit(types.ORDER_CURRENT_UPDATED, currentOrder)
   },


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1492 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fetched the carrier party information for all the hip groups

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
After:

<img width="2476" height="1024" alt="image" src="https://github.com/user-attachments/assets/dfefe334-cd03-4ab3-8950-9e29670192ce" />


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)