### PR TITLE
Fixed: added checks to show a toast when the delivery days input is 0 (#1379)

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -152,7 +152,8 @@ const sortItems = (items: any, sortByField: any) => {
 
 const isValidDeliveryDays = (deliveryDays : any) => {
   // Regular expression pattern for a valid delivery days
-  const delieveryDaysPattern = /^(\d*\.?\d+)?$/;
+  // Allow only positive integers (no decimals, no zero, no negative, leading zeros)
+  const delieveryDaysPattern = /^(0*[1-9]\d*)$/;
   return delieveryDaysPattern.test(deliveryDays);
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -152,7 +152,7 @@ const sortItems = (items: any, sortByField: any) => {
 
 const isValidDeliveryDays = (deliveryDays : any) => {
   // Regular expression pattern for a valid delivery days
-  // Allow only positive integers (no decimals, no zero, no negative, leading zeros)
+  // Allow only positive integers (no decimals, no zero, no negative)
   const delieveryDaysPattern = /^(0*[1-9]\d*)$/;
   return delieveryDaysPattern.test(deliveryDays);
 }


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1379 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
* Added strict validation to allow only positive integers and block zero, negatives, decimals, and leading zeros for the Delivery Days field.
* Implemented a toast notification for invalid inputs such as **0** to improve user feedback.
* Enhanced overall form reliability by preventing incorrect delivery day values.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)