### PR TITLE
Fixed: Updated oms-api package version to v1.28.2 which has the fix where standard products are not fetched from Solr (#1552).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@hotwax/app-version-info": "^1.0.0",
         "@hotwax/apps-theme": "^1.4.0",
         "@hotwax/dxp-components": "^1.24.2",
-        "@hotwax/oms-api": "^1.28.0",
+        "@hotwax/oms-api": "^1.28.2",
         "@ionic/core": "^7.6.0",
         "@ionic/vue": "^7.6.0",
         "@ionic/vue-router": "^7.6.0",
@@ -2961,10 +2961,9 @@
       }
     },
     "node_modules/@hotwax/oms-api": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@hotwax/oms-api/-/oms-api-1.28.0.tgz",
-      "integrity": "sha512-4P5kBaUU/QJ9ES7D3s3F4akaLs2DXKM2zPP1tg/444/41BosPxaay+OONrSixhqX4GwKqDJnUHc6IrJ5clFdWQ==",
-      "license": "Apache-2.0",
+      "version": "1.28.2",
+      "resolved": "https://registry.npmjs.org/@hotwax/oms-api/-/oms-api-1.28.2.tgz",
+      "integrity": "sha512-kl7iZgxtBPajWBDbcBZuOn44ow3anLaxCpqcsbRc9AGVJwzFbD16WCvTPSkGbEdxwnvkVAIrNhE8qiPuTbF0Xw==",
       "dependencies": {
         "@types/node-json-transform": "^1.0.0",
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@hotwax/app-version-info": "^1.0.0",
     "@hotwax/apps-theme": "^1.4.0",
     "@hotwax/dxp-components": "^1.24.2",
-    "@hotwax/oms-api": "^1.28.0",
+    "@hotwax/oms-api": "^1.28.2",
     "@ionic/core": "^7.6.0",
     "@ionic/vue": "^7.6.0",
     "@ionic/vue-router": "^7.6.0",


### PR DESCRIPTION


### Related Issues
#1552 

#

### Short Description and Why It's Useful
Fixed: Updated oms-api package version to v1.28.2 which has the fix where standard products are not fetched from Solr (#1552).


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)