### PR TITLE
Fix: Restrict carrier selection and preserve shipment method for ship-to-store orders

### DIFF
--- a/src/components/GenerateTrackingCodeModal.vue
+++ b/src/components/GenerateTrackingCodeModal.vue
@@ -64,7 +64,7 @@
           </ion-item>
           <ion-item>
             <template v-if="carrierMethods && carrierMethods.length > 0">
-              <ion-select :disabled="!order.missingLabelImage" :label="translate('Method')" v-model="shipmentMethodTypeId" interface="popover">
+              <ion-select :disabled="!order.missingLabelImage || shipmentMethodTypeId === 'SHIP_TO_STORE'" :label="translate('Method')" v-model="shipmentMethodTypeId" interface="popover">
                 <ion-select-option v-for="method in carrierMethods" :key="carrierMethods.partyId + method.shipmentMethodTypeId" :value="method.shipmentMethodTypeId">{{ translate(method.description) }}</ion-select-option>
               </ion-select>
             </template>
@@ -98,7 +98,7 @@
           </ion-item>
           <ion-item>
             <template v-if="carrierMethods && carrierMethods.length > 0">
-              <ion-select :disabled="!order.missingLabelImage" :label="translate('Method')" v-model="shipmentMethodTypeId" interface="popover">
+              <ion-select :disabled="!order.missingLabelImage || shipmentMethodTypeId === 'SHIP_TO_STORE'" :label="translate('Method')" v-model="shipmentMethodTypeId" interface="popover">
                 <ion-select-option v-for="method in carrierMethods" :key="carrierMethods.partyId + method.shipmentMethodTypeId" :value="method.shipmentMethodTypeId">{{ translate(method.description) }}</ion-select-option>
               </ion-select>
             </template>

--- a/src/components/GenerateTrackingCodeModal.vue
+++ b/src/components/GenerateTrackingCodeModal.vue
@@ -236,7 +236,8 @@ export default defineComponent({
       return this.order.isTrackingRequired === 'Y'
     },
     async getProductStoreShipmentMethods(carrierPartyId: string) { 
-      return this.productStoreShipmentMethods?.filter((method: any) => method.partyId === carrierPartyId) || [];
+      const shipmentMethodTypeId = this.initialShipmentMethodTypeId ? this.initialShipmentMethodTypeId : this.order?.shipmentMethodTypeId
+      return this.productStoreShipmentMethods?.filter((method: any) => method.partyId === carrierPartyId && (shipmentMethodTypeId === 'SHIP_TO_STORE' || method.shipmentMethodTypeId !== 'SHIP_TO_STORE')) || [];
     },
     getCarrier() {
       const carrier = this.facilityCarriers.find((facilityCarrier: any) => facilityCarrier.partyId === this.carrierPartyId)

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -636,7 +636,7 @@ export default defineComponent({
       window.open('https://docs.hotwax.co/documents/v/system-admins/fulfillment/shipping-methods/carrier-and-shipment-methods', '_blank');
     },
     async getProductStoreShipmentMethods(carrierPartyId: string) { 
-      return this.productStoreShipmentMethods?.filter((method: any) => method.partyId === carrierPartyId) || [];
+      return this.productStoreShipmentMethods?.filter((method: any) => method.partyId === carrierPartyId && (this.initialShipmentMethodTypeId === 'SHIP_TO_STORE' || method.shipmentMethodTypeId !== 'SHIP_TO_STORE')) || [];
     },
     async shippingLabelActionPopover(ev: Event, currentOrder: any) {
       const popover = await popoverController.create({

--- a/src/views/ShipTransferOrder.vue
+++ b/src/views/ShipTransferOrder.vue
@@ -128,7 +128,9 @@
               </ion-item>
               <ion-item>
                 <ion-select data-testid="select-method-dropdown" :disabled="!shipmentMethods.length" :value="selectedShippingMethod" :label="translate('Method')" interface="popover" :placeholder="translate('Select')" @ionChange="updateSelectedShippingMethod($event.detail.value)">
-                  <ion-select-option data-testid="select-method-dropdown-option" v-for="(method, index) in shipmentMethods" :key="index" :value="method.shipmentMethodTypeId">{{ method.description ? method.description : method.shipmentMethodTypeId }}</ion-select-option>
+                  <template v-for="(method, index) in shipmentMethods" :key="index">
+                    <ion-select-option data-testid="select-method-dropdown-option" v-if="method.shipmentMethodTypeId !== 'SHIP_TO_STORE'" :value="method.shipmentMethodTypeId">{{ method.description ? method.description : method.shipmentMethodTypeId }}</ion-select-option>
+                  </template>
                 </ion-select>
               </ion-item>
               <ion-item lines="full">


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Related to [82](https://github.com/hotwax/hotwax-oms/issues/82#issuecomment-3673617640)
Closes [707](https://github.com/hotwax/bopis/issues/707)
#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR improves the carrier selection experience for "Ship to Store" orders.
- **Filtered Carriers**: When an order is set to "Ship to Store", the carrier dropdown now ONLY displays carriers that support the "Ship to Store" shipment method. This prevents users from selecting incompatible carriers.
- **Preserved Selection**: Enhanced the **updateCarrierAndShippingMethod** logic to preserve the current shipment method when switching carriers. If the new carrier supports the current method (e.g., `SHIP_TO_STORE`), it remains selected instead of resetting to a default value like "Standard".


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
N/A

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)