### PR TITLE
Enable data-test-id for fulfilment screens (Playwright support)

### DIFF
--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -2,7 +2,10 @@
   <ion-header>
     <ion-toolbar>
       <ion-buttons slot="start">
-        <ion-button @click="closeModal()">
+        <ion-button
+          data-test-id="close-assign-picker-modal"
+          @click="closeModal()"
+        >
           <ion-icon slot="icon-only" :icon="closeOutline" />
         </ion-button>
       </ion-buttons>
@@ -11,16 +14,30 @@
   </ion-header>
 
   <ion-content>
-    <ion-searchbar v-model="queryString" @keyup.enter="queryString = $event.target.value; findPickers()"/>
+    <ion-searchbar
+      data-test-id="picker-search-input"
+      v-model="queryString"
+      @keyup.enter="
+        queryString = $event.target.value;
+        findPickers();
+      "
+    />
     <ion-row>
-      <ion-chip v-for="picker in selectedPickers" :key="picker.id">
+      <ion-chip
+        data-test-id="selected-picker-chip"
+        v-for="picker in selectedPickers"
+        :key="picker.id"
+      >
         <ion-label>{{ picker.name }}</ion-label>
-        <ion-icon :icon="closeCircle" @click="selectPicker(picker.id)" />
+        <ion-icon
+          data-test-id="remove-selected-picker"
+          :icon="closeCircle"
+          @click="selectPicker(picker.id)"
+        />
       </ion-chip>
     </ion-row>
 
     <ion-list>
-
       <ion-list-header>{{ translate("Staff") }}</ion-list-header>
       <!-- TODO: added click event on the item as when using the ionChange event then it's getting
       called every time the v-for loop runs and then removes or adds the currently rendered picker
@@ -29,10 +46,20 @@
         <ion-spinner name="crescent" />
         <ion-label>{{ translate("Fetching pickers") }}</ion-label>
       </div>
-      <div class="empty-state" v-else-if="!pickers.length">{{ "No picker found" }}</div>
+      <div class="empty-state" v-else-if="!pickers.length">
+        {{ "No picker found" }}
+      </div>
       <div v-else>
-        <ion-item v-for="(picker, index) in pickers" :key="index" @click="selectPicker(picker.id)">
-          <ion-checkbox :checked="isPickerSelected(picker.id)">
+        <ion-item
+          data-test-id="picker-list-item"
+          v-for="(picker, index) in pickers"
+          :key="index"
+          @click="selectPicker(picker.id)"
+        >
+          <ion-checkbox
+            data-test-id="picker-checkbox"
+            :checked="isPickerSelected(picker.id)"
+          >
             <ion-label>
               {{ picker.name }}
               <p>{{ picker.externalId ? picker.externalId : picker.id }}</p>
@@ -44,14 +71,17 @@
   </ion-content>
 
   <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-    <ion-fab-button :disabled="!selectedPickers.length" @click="printPicklist()">
+    <ion-fab-button
+      :disabled="!selectedPickers.length"
+      @click="printPicklist()"
+    >
       <ion-icon :icon="saveOutline" />
     </ion-fab-button>
   </ion-fab>
 </template>
 
 <script>
-import { 
+import {
   IonButtons,
   IonButton,
   IonCheckbox,
@@ -70,22 +100,23 @@ import {
   IonSpinner,
   IonTitle,
   IonToolbar,
-  modalController } from "@ionic/vue";
+  modalController,
+} from "@ionic/vue";
 import { defineComponent, computed } from "vue";
 import { closeOutline, closeCircle, saveOutline } from "ionicons/icons";
 import { mapGetters, useStore } from "vuex";
 import { showToast } from "@/utils";
 import { hasError } from "@/adapter";
-import { translate, useUserStore } from '@hotwax/dxp-components'
+import { translate, useUserStore } from "@hotwax/dxp-components";
 import { UtilService } from "@/services/UtilService";
 import emitter from "@/event-bus";
-import logger from "@/logger"
-import { OrderService } from '@/services/OrderService';
-import { Actions, hasPermission } from '@/authorization'
+import logger from "@/logger";
+import { OrderService } from "@/services/OrderService";
+import { Actions, hasPermission } from "@/authorization";
 
 export default defineComponent({
   name: "AssignPickerModal",
-  components: { 
+  components: {
     IonButtons,
     IonButton,
     IonCheckbox,
@@ -107,159 +138,197 @@ export default defineComponent({
   },
   computed: {
     ...mapGetters({
-      openOrders: 'order/getOpenOrders'
-    })
+      openOrders: "order/getOpenOrders",
+    }),
   },
-  data () {
+  data() {
     return {
       selectedPickers: [],
-      queryString: '',
+      queryString: "",
       pickers: [],
       isLoading: false,
-    }
+    };
   },
   props: ["order"], // if we have order in props then create picklist for this single order only
   methods: {
     isPickerSelected(id) {
-      return this.selectedPickers.some((picker) => picker.id == id)
+      return this.selectedPickers.some((picker) => picker.id == id);
     },
     closeModal(responseData) {
       modalController.dismiss({ dismissed: true, value: responseData });
     },
     selectPicker(id) {
-      const picker = this.selectedPickers.some((picker) => picker.id == id)
+      const picker = this.selectedPickers.some((picker) => picker.id == id);
       if (picker) {
         // if picker is already selected then removing that picker from the list on click
-        this.selectedPickers = this.selectedPickers.filter((picker) => picker.id != id)
+        this.selectedPickers = this.selectedPickers.filter(
+          (picker) => picker.id != id
+        );
       } else {
-        this.selectedPickers.push(this.pickers.find((picker) => picker.id == id))
+        this.selectedPickers.push(
+          this.pickers.find((picker) => picker.id == id)
+        );
       }
     },
-    async printPicklist () {
-      emitter.emit("presentLoader")
+    async printPicklist() {
+      emitter.emit("presentLoader");
       let resp;
-      const orderIdsToPick = []
+      const orderIdsToPick = [];
 
       // creating picklist for orders that are currently in the list, means those are currently in the selected viewSize
-      const orderItems = []
+      const orderItems = [];
 
-      if(this.order) {
-        this.order.items.map((item) => orderItems.push(item))
-        orderIdsToPick.push(this.order.orderId)
+      if (this.order) {
+        this.order.items.map((item) => orderItems.push(item));
+        orderIdsToPick.push(this.order.orderId);
       } else {
         this.openOrders.list.map((order) => {
-          order.items.map((item) => orderItems.push(item))
-          orderIdsToPick.push(order.orderId)
+          order.items.map((item) => orderItems.push(item));
+          orderIdsToPick.push(order.orderId);
         });
       }
 
-      
       const payload = {
         packageName: "A", //default package name
         facilityId: this.currentFacility?.facilityId,
         shipmentMethodTypeId: orderItems[0]?.shipmentMethodTypeId,
         statusId: "PICKLIST_ASSIGNED",
-        pickers: this.selectedPickers?.map(selectedPicker => ({
-          partyId: selectedPicker.id,
-          roleTypeId: "WAREHOUSE_PICKER"
-        })) || [],
-        orderItems: orderItems.map(({ orderId, orderItemSeqId, shipGroupSeqId, productId, quantity }) => ({
-          orderId,
-          orderItemSeqId,
-          shipGroupSeqId,
-          productId,
-          quantity
-        }))
+        pickers:
+          this.selectedPickers?.map((selectedPicker) => ({
+            partyId: selectedPicker.id,
+            roleTypeId: "WAREHOUSE_PICKER",
+          })) || [],
+        orderItems: orderItems.map(
+          ({
+            orderId,
+            orderItemSeqId,
+            shipGroupSeqId,
+            productId,
+            quantity,
+          }) => ({
+            orderId,
+            orderItemSeqId,
+            shipGroupSeqId,
+            productId,
+            quantity,
+          })
+        ),
       };
 
       try {
         resp = await OrderService.createPicklist(payload);
         if (resp.status === 200 && !hasError(resp)) {
-          this.closeModal({picklistId: resp.data.picklistId, shipmentIds: resp.data.shipmentIds});
-          showToast(translate('Picklist created successfully'))
+          this.closeModal({
+            picklistId: resp.data.picklistId,
+            shipmentIds: resp.data.shipmentIds,
+          });
+          showToast(translate("Picklist created successfully"));
 
           // generating picklist after creating a new picklist
           if (resp.data.picklistId) {
-            await OrderService.printPicklist(resp.data.picklistId)
+            await OrderService.printPicklist(resp.data.picklistId);
           }
 
-          await this.store.dispatch('order/findOpenOrders')
+          await this.store.dispatch("order/findOpenOrders");
           //Removing orders if the solr doc is not updated after picking
           if (orderIdsToPick.length) {
-            const updatedOpenOrders = this.openOrders?.list.filter(openOrder => !orderIdsToPick.includes(openOrder.orderId))
-            const outdatedOpenOrderCount = this.openOrders.list.reduce((count, openOrder) => 
-              orderIdsToPick.includes(openOrder.orderId) ? count + 1 : count, 0
+            const updatedOpenOrders = this.openOrders?.list.filter(
+              (openOrder) => !orderIdsToPick.includes(openOrder.orderId)
             );
-            await this.store.dispatch('order/updateOpenOrderQuery', {...this.openOrders.query, viewSize: updatedOpenOrders.length})
-            await this.store.dispatch('order/updateOpenOrders', {orders: updatedOpenOrders, total: this.openOrders.total - outdatedOpenOrderCount})
+            const outdatedOpenOrderCount = this.openOrders.list.reduce(
+              (count, openOrder) =>
+                orderIdsToPick.includes(openOrder.orderId) ? count + 1 : count,
+              0
+            );
+            await this.store.dispatch("order/updateOpenOrderQuery", {
+              ...this.openOrders.query,
+              viewSize: updatedOpenOrders.length,
+            });
+            await this.store.dispatch("order/updateOpenOrders", {
+              orders: updatedOpenOrders,
+              total: this.openOrders.total - outdatedOpenOrderCount,
+            });
           }
         } else {
-          throw resp.data
+          throw resp.data;
         }
       } catch (err) {
-        logger.error('Failed to create picklist for orders', err)
-        showToast(translate('Failed to create picklist for orders'))
+        logger.error("Failed to create picklist for orders", err);
+        showToast(translate("Failed to create picklist for orders"));
       }
 
-      emitter.emit("dismissLoader")
+      emitter.emit("dismissLoader");
     },
     async findPickers() {
       this.isLoading = true;
-      let query = {}
-      this.pickers = []
+      let query = {};
+      this.pickers = [];
 
-      if(this.queryString.length > 0) {
-        let keyword = this.queryString.trim().split(' ')
-        query = `(${keyword.map(key => `*${key}*`).join(' OR ')}) OR "${this.queryString}"^100`;
-      }
-      else {
-        query = `*:*`
+      if (this.queryString.length > 0) {
+        let keyword = this.queryString.trim().split(" ");
+        query = `(${keyword.map((key) => `*${key}*`).join(" OR ")}) OR "${
+          this.queryString
+        }"^100`;
+      } else {
+        query = `*:*`;
       }
 
       const facilityFilter = [];
-      if(!hasPermission(Actions.APP_SHOW_ALL_PICKERS)){
-        facilityFilter.push(`facilityIds:${this.currentFacility.facilityId}`)
+      if (!hasPermission(Actions.APP_SHOW_ALL_PICKERS)) {
+        facilityFilter.push(`facilityIds:${this.currentFacility.facilityId}`);
       }
 
       const payload = {
-        "json": {
-          "params": {
-            "rows": "50",
-            "q": query,
-            "defType" : "edismax",
-            "qf": "firstName lastName groupName partyId externalId",
-            "sort": "firstName asc"
+        json: {
+          params: {
+            rows: "50",
+            q: query,
+            defType: "edismax",
+            qf: "firstName lastName groupName partyId externalId",
+            sort: "firstName asc",
           },
-          "filter": ["docType:EMPLOYEE", "statusId:PARTY_ENABLED", "WAREHOUSE_PICKER_role:true", ...facilityFilter]
-        }
-      }
+          filter: [
+            "docType:EMPLOYEE",
+            "statusId:PARTY_ENABLED",
+            "WAREHOUSE_PICKER_role:true",
+            ...facilityFilter,
+          ],
+        },
+      };
 
       try {
         const resp = await UtilService.getAvailablePickers(payload);
         if (resp.status === 200 && !hasError(resp)) {
           this.pickers = resp.data.response.docs.map((picker) => ({
-            name: picker.groupName ? picker.groupName : (picker.firstName || picker.lastName)
-                ? (picker.firstName ? picker.firstName : '') + (picker.lastName ? ' ' + picker.lastName : '') : picker.partyId,           
+            name: picker.groupName
+              ? picker.groupName
+              : picker.firstName || picker.lastName
+              ? (picker.firstName ? picker.firstName : "") +
+                (picker.lastName ? " " + picker.lastName : "")
+              : picker.partyId,
             id: picker.partyId,
-            externalId: picker.externalId
-          }))
+            externalId: picker.externalId,
+          }));
         } else {
-          throw resp.data
+          throw resp.data;
         }
       } catch (err) {
-        logger.error('Failed to fetch the pickers information or there are no pickers available', err)
+        logger.error(
+          "Failed to fetch the pickers information or there are no pickers available",
+          err
+        );
       }
-      this.isLoading = false
-    }
+      this.isLoading = false;
+    },
   },
   async mounted() {
     // getting picker information on initial load
-    await this.findPickers()
+    await this.findPickers();
   },
   setup() {
     const store = useStore();
-    const userStore = useUserStore()
-    let currentFacility = computed(() => userStore.getCurrentFacility) 
+    const userStore = useUserStore();
+    let currentFacility = computed(() => userStore.getCurrentFacility);
 
     return {
       Actions,
@@ -269,7 +338,7 @@ export default defineComponent({
       saveOutline,
       closeCircle,
       store,
-      translate
+      translate,
     };
   },
 });

--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -1,34 +1,67 @@
 <template>
   <ion-page :key="router.currentRoute.value.path">
-    <ViewSizeSelector menu-id="view-size-selector-completed" content-id="view-size-selector" />
+    <ViewSizeSelector
+      menu-id="view-size-selector-completed"
+      content-id="view-size-selector"
+    />
 
     <ion-header :translucent="true">
       <ion-toolbar>
         <ion-menu-button slot="start" />
-        <ion-title v-if="!completedOrders.total">{{ completedOrders.total }} {{ translate('orders') }}</ion-title>
-        <ion-title v-else>{{ completedOrders.query.viewSize }} {{ translate('of') }} {{ completedOrders.total }} {{ completedOrders.total ? translate('order') : translate('orders') }}</ion-title>
+        <ion-title v-if="!completedOrders.total"
+          >{{ completedOrders.total }} {{ translate("orders") }}</ion-title
+        >
+        <ion-title v-else
+          >{{ completedOrders.query.viewSize }} {{ translate("of") }}
+          {{ completedOrders.total }}
+          {{
+            completedOrders.total ? translate("order") : translate("orders")
+          }}</ion-title
+        >
 
         <ion-buttons slot="end">
-          <ion-menu-button menu="view-size-selector-completed" :disabled="!completedOrders.total">
+          <ion-menu-button
+            menu="view-size-selector-completed"
+            :disabled="!completedOrders.total"
+          >
             <ion-icon :icon="optionsOutline" />
           </ion-menu-button>
         </ion-buttons>
       </ion-toolbar>
     </ion-header>
-    
-    <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="view-size-selector">
-      <ion-searchbar class="searchbar" :value="completedOrders.query.queryString" :placeholder="translate('Search orders')" @keyup.enter="updateQueryString($event.target.value)" />
-      <ion-radio-group v-if="carrierPartyIds?.length" v-model="selectedCarrierPartyId" @ionChange="updateSelectedCarrierPartyIds($event.detail.value)">
+
+    <ion-content
+      ref="contentRef"
+      :scroll-events="true"
+      @ionScroll="enableScrolling()"
+      id="view-size-selector"
+    >
+      <ion-searchbar
+        data-test-id="completed-search-input"
+        class="searchbar"
+        :value="completedOrders.query.queryString"
+        :placeholder="translate('Search orders')"
+        @keyup.enter="updateQueryString($event.target.value)"
+      />
+      <ion-radio-group
+        v-if="carrierPartyIds?.length"
+        v-model="selectedCarrierPartyId"
+        @ionChange="updateSelectedCarrierPartyIds($event.detail.value)"
+      >
         <ion-row class="filters">
           <ion-item lines="none">
-              <!-- empty value '' for 'All orders' radio -->
+            <!-- empty value '' for 'All orders' radio -->
             <ion-radio label-placement="end" value="">
               <ion-label class="ion-text-wrap">
                 {{ translate("All") }}
               </ion-label>
             </ion-radio>
           </ion-item>
-          <ion-item lines="none" v-for="carrierPartyId in carrierPartyIds" :key="carrierPartyId">
+          <ion-item
+            lines="none"
+            v-for="carrierPartyId in carrierPartyIds"
+            :key="carrierPartyId"
+          >
             <ion-radio label-placement="end" :value="carrierPartyId">
               <ion-label>
                 {{ getPartyName(carrierPartyId) }}
@@ -39,8 +72,20 @@
       </ion-radio-group>
 
       <div v-if="shipmentMethods?.length" class="filters">
-        <ion-item lines="none" v-for="shipmentMethod in shipmentMethods" :key="shipmentMethod">
-          <ion-checkbox label-placement="end" :checked="completedOrders.query.selectedShipmentMethods.includes(shipmentMethod)" @ionChange="updateSelectedShipmentMethods(shipmentMethod)">
+        <ion-item
+          lines="none"
+          v-for="shipmentMethod in shipmentMethods"
+          :key="shipmentMethod"
+        >
+          <ion-checkbox
+            label-placement="end"
+            :checked="
+              completedOrders.query.selectedShipmentMethods.includes(
+                shipmentMethod
+              )
+            "
+            @ionChange="updateSelectedShipmentMethods(shipmentMethod)"
+          >
             <ion-label>
               {{ getShipmentMethodDesc(shipmentMethod) }}
             </ion-label>
@@ -50,82 +95,248 @@
 
       <div v-if="completedOrders.total">
         <div class="results">
-          <ion-button :disabled="isShipNowDisabled || hasAnyMissingInfo() || (hasAnyShipmentTrackingInfoMissing() && !hasPermission(Actions.APP_FORCE_SHIP_ORDER))" expand="block" class="bulk-action desktop-only" fill="outline" size="large" @click="bulkShipOrders()">{{ translate("Ship") }}</ion-button>
-          <ion-card class="order" v-for="(order, index) in completedOrdersList" :key="index">
+          <ion-button
+            data-test-id="completed-ship-btn"
+            :disabled="
+              isShipNowDisabled ||
+              hasAnyMissingInfo() ||
+              (hasAnyShipmentTrackingInfoMissing() &&
+                !hasPermission(Actions.APP_FORCE_SHIP_ORDER))
+            "
+            expand="block"
+            class="bulk-action desktop-only"
+            fill="outline"
+            size="large"
+            @click="bulkShipOrders()"
+            >{{ translate("Ship") }}</ion-button
+          >
+          <ion-card
+            class="order"
+            v-for="(order, index) in completedOrdersList"
+            :key="index"
+            data-test-id="completed-order-card"
+          >
             <div class="order-header">
               <div class="order-primary-info">
                 <ion-label>
-                  <strong>{{ order.customerName }}</strong>
-                  <p>{{ translate("Ordered") }} {{ getTime(order.orderDate) }}</p>
+                  <strong data-test-id="completed-customer-name">{{
+                    order.customerName
+                  }}</strong>
+                  <p>
+                    {{ translate("Ordered") }} {{ getTime(order.orderDate) }}
+                  </p>
                 </ion-label>
               </div>
 
               <div class="order-tags">
-                <ion-chip @click.stop="orderActionsPopover(order, $event)" outline>
+                <ion-chip
+                  data-test-id="completed-order-actions-chip"
+                  @click.stop="orderActionsPopover(order, $event)"
+                  outline
+                >
                   <ion-icon :icon="pricetagOutline" />
                   <ion-label>{{ order.orderName }}</ion-label>
                   <ion-icon :icon="caretDownOutline" />
                 </ion-chip>
               </div>
 
-              <div class="order-metadata">
+              <div
+                class="order-metadata"
+                data-test-id="completed-order-metadata"
+              >
                 <ion-label>
                   {{ getShipmentMethodDesc(order.shipmentMethodTypeId) }}
-                  <p v-if="order.reservedDatetime">{{ translate("Last brokered") }} {{ getTime(order.reservedDatetime) }}</p>
-                  <p v-if="order.trackingCode">{{ translate("Tracking Code") }} {{ order.trackingCode }}</p>
+                  <p v-if="order.reservedDatetime">
+                    {{ translate("Last brokered") }}
+                    {{ getTime(order.reservedDatetime) }}
+                  </p>
+                  <p v-if="order.trackingCode">
+                    {{ translate("Tracking Code") }} {{ order.trackingCode }}
+                  </p>
                 </ion-label>
               </div>
             </div>
 
-            <div v-for="item in order.items" :key="order.shipmentId + item.shipmentItemSeqId" class="order-line-item">
+            <div
+              v-for="item in order.items"
+              :key="order.shipmentId + item.shipmentItemSeqId"
+              class="order-line-item"
+              data-test-id="completed-order-line-item"
+            >
               <div class="order-item">
                 <div class="product-info">
                   <ion-item lines="none">
-                    <ion-thumbnail slot="start" v-image-preview="getProduct(item.productId)" :key="getProduct(item.productId)?.mainImageUrl">
-                      <DxpShopifyImg :src="getProduct(item.productId).mainImageUrl" :key="getProduct(item.productId).mainImageUrl" size="small"/>
+                    <ion-thumbnail
+                      slot="start"
+                      v-image-preview="getProduct(item.productId)"
+                      :key="getProduct(item.productId)?.mainImageUrl"
+                    >
+                      <DxpShopifyImg
+                        :src="getProduct(item.productId).mainImageUrl"
+                        :key="getProduct(item.productId).mainImageUrl"
+                        size="small"
+                      />
                     </ion-thumbnail>
                     <ion-label>
-                      <p class="overline">{{ getProductIdentificationValue(productIdentificationPref.secondaryId, getProduct(item.productId)) }}</p>
+                      <p class="overline">
+                        {{
+                          getProductIdentificationValue(
+                            productIdentificationPref.secondaryId,
+                            getProduct(item.productId)
+                          )
+                        }}
+                      </p>
                       <div>
-                        {{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) : getProduct(item.productId).productName }}
-                        <ion-badge class="kit-badge" color="dark" v-if="isKit(item)">{{ translate("Kit") }}</ion-badge>
+                        {{
+                          getProductIdentificationValue(
+                            productIdentificationPref.primaryId,
+                            getProduct(item.productId)
+                          )
+                            ? getProductIdentificationValue(
+                                productIdentificationPref.primaryId,
+                                getProduct(item.productId)
+                              )
+                            : getProduct(item.productId).productName
+                        }}
+                        <ion-badge
+                          class="kit-badge"
+                          color="dark"
+                          v-if="isKit(item)"
+                          >{{ translate("Kit") }}</ion-badge
+                        >
                       </div>
-                      <p>{{ getFeatures(getProduct(item.productId).productFeatures)}}</p>
+                      <p>
+                        {{
+                          getFeatures(
+                            getProduct(item.productId).productFeatures
+                          )
+                        }}
+                      </p>
                     </ion-label>
                   </ion-item>
                 </div>
                 <div class="product-metadata">
-                  <ion-button v-if="isKit(item)" fill="clear" size="small" @click.stop="fetchKitComponents(item)">
-                    <ion-icon v-if="item.showKitComponents" color="medium" slot="icon-only" :icon="chevronUpOutline"/>
-                    <ion-icon v-else color="medium" slot="icon-only" :icon="listOutline"/>
+                  <ion-button
+                    v-if="isKit(item)"
+                    fill="clear"
+                    size="small"
+                    @click.stop="fetchKitComponents(item)"
+                  >
+                    <ion-icon
+                      v-if="item.showKitComponents"
+                      color="medium"
+                      slot="icon-only"
+                      :icon="chevronUpOutline"
+                    />
+                    <ion-icon
+                      v-else
+                      color="medium"
+                      slot="icon-only"
+                      :icon="listOutline"
+                    />
                   </ion-button>
-                  <ion-button color="medium" fill="clear" size="small" v-if="item.productTypeId === 'GIFT_CARD'" @click="openGiftCardActivationModal(item)">
-                    <ion-icon slot="icon-only" :icon="item.isGCActivated ? gift : giftOutline"/>
+                  <ion-button
+                    color="medium"
+                    fill="clear"
+                    size="small"
+                    v-if="item.productTypeId === 'GIFT_CARD'"
+                    @click="openGiftCardActivationModal(item)"
+                  >
+                    <ion-icon
+                      slot="icon-only"
+                      :icon="item.isGCActivated ? gift : giftOutline"
+                    />
                   </ion-button>
-                  <ion-note v-if="getProductStock(item.productId).qoh">{{ getProductStock(item.productId).qoh }} {{ translate('pieces in stock') }}</ion-note>
-                  <ion-button fill="clear" v-else size="small" @click.stop="fetchProductStock(item.productId)">
-                    <ion-icon color="medium" slot="icon-only" :icon="cubeOutline"/>
+                  <ion-note v-if="getProductStock(item.productId).qoh"
+                    >{{ getProductStock(item.productId).qoh }}
+                    {{ translate("pieces in stock") }}</ion-note
+                  >
+                  <ion-button
+                    fill="clear"
+                    v-else
+                    size="small"
+                    @click.stop="fetchProductStock(item.productId)"
+                  >
+                    <ion-icon
+                      color="medium"
+                      slot="icon-only"
+                      :icon="cubeOutline"
+                    />
                   </ion-button>
                 </div>
               </div>
-              <div v-if="item.showKitComponents && !getProduct(item.productId)?.productComponents" class="kit-components">
+              <div
+                v-if="
+                  item.showKitComponents &&
+                  !getProduct(item.productId)?.productComponents
+                "
+                class="kit-components"
+              >
                 <ion-item lines="none">
-                  <ion-skeleton-text animated style="height: 80%;"/>
+                  <ion-skeleton-text animated style="height: 80%" />
                 </ion-item>
                 <ion-item lines="none">
-                  <ion-skeleton-text animated style="height: 80%;"/>
+                  <ion-skeleton-text animated style="height: 80%" />
                 </ion-item>
               </div>
-              <div v-else-if="item.showKitComponents && getProduct(item.productId)?.productComponents" class="kit-components">
-                <ion-card v-for="(productComponent, index) in getProduct(item.productId).productComponents" :key="index">
+              <div
+                v-else-if="
+                  item.showKitComponents &&
+                  getProduct(item.productId)?.productComponents
+                "
+                class="kit-components"
+              >
+                <ion-card
+                  v-for="(productComponent, index) in getProduct(item.productId)
+                    .productComponents"
+                  :key="index"
+                >
                   <ion-item lines="none">
-                    <ion-thumbnail slot="start" v-image-preview="getProduct(productComponent.productIdTo)" :key="getProduct(productComponent.productIdTo)?.mainImageUrl">
-                      <DxpShopifyImg :src="getProduct(productComponent.productIdTo).mainImageUrl" :key="getProduct(productComponent.productIdTo).mainImageUrl" size="small"/>
+                    <ion-thumbnail
+                      slot="start"
+                      v-image-preview="getProduct(productComponent.productIdTo)"
+                      :key="
+                        getProduct(productComponent.productIdTo)?.mainImageUrl
+                      "
+                    >
+                      <DxpShopifyImg
+                        :src="
+                          getProduct(productComponent.productIdTo).mainImageUrl
+                        "
+                        :key="
+                          getProduct(productComponent.productIdTo).mainImageUrl
+                        "
+                        size="small"
+                      />
                     </ion-thumbnail>
                     <ion-label>
-                      <p class="overline">{{ getProductIdentificationValue(productIdentificationPref.secondaryId, getProduct(productComponent.productIdTo)) }}</p>
-                      {{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(productComponent.productIdTo)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(productComponent.productIdTo)) : productComponent.productIdTo }}
-                      <p>{{ getFeatures(getProduct(productComponent.productIdTo).productFeatures)}}</p>
+                      <p class="overline">
+                        {{
+                          getProductIdentificationValue(
+                            productIdentificationPref.secondaryId,
+                            getProduct(productComponent.productIdTo)
+                          )
+                        }}
+                      </p>
+                      {{
+                        getProductIdentificationValue(
+                          productIdentificationPref.primaryId,
+                          getProduct(productComponent.productIdTo)
+                        )
+                          ? getProductIdentificationValue(
+                              productIdentificationPref.primaryId,
+                              getProduct(productComponent.productIdTo)
+                            )
+                          : productComponent.productIdTo
+                      }}
+                      <p>
+                        {{
+                          getFeatures(
+                            getProduct(productComponent.productIdTo)
+                              .productFeatures
+                          )
+                        }}
+                      </p>
                     </ion-label>
                   </ion-item>
                 </ion-card>
@@ -135,8 +346,24 @@
             <!-- TODO: implement functionality to mobile view -->
             <div class="mobile-only">
               <ion-item>
-                <ion-button :disabled="isShipNowDisabled || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || ((isTrackingRequiredForAnyShipmentPackage(order) && !order.trackingCode) && !hasPermission(Actions.APP_FORCE_SHIP_ORDER))" fill="clear" >{{ translate("Ship Now") }}</ion-button>
-                <ion-button slot="end" fill="clear" color="medium" @click.stop="shippingPopover">
+                <ion-button
+                  :disabled="
+                    isShipNowDisabled ||
+                    order.hasMissingShipmentInfo ||
+                    order.hasMissingPackageInfo ||
+                    (isTrackingRequiredForAnyShipmentPackage(order) &&
+                      !order.trackingCode &&
+                      !hasPermission(Actions.APP_FORCE_SHIP_ORDER))
+                  "
+                  fill="clear"
+                  >{{ translate("Ship Now") }}</ion-button
+                >
+                <ion-button
+                  slot="end"
+                  fill="clear"
+                  color="medium"
+                  @click.stop="shippingPopover"
+                >
                   <ion-icon slot="icon-only" :icon="ellipsisVerticalOutline" />
                 </ion-button>
               </ion-item>
@@ -145,33 +372,115 @@
             <!-- TODO: make the buttons functional -->
             <div class="actions">
               <div class="desktop-only">
-                <ion-button v-if="!hasPackedShipments(order)" :disabled="true">{{ translate("Shipped") }}</ion-button>
-                <ion-button v-else :disabled="isShipNowDisabled || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || ((isTrackingRequiredForAnyShipmentPackage(order) && !order.trackingCode) && !hasPermission(Actions.APP_FORCE_SHIP_ORDER))" @click.stop="shipOrder(order)">{{ translate("Ship Now") }}</ion-button>
-                <ion-button :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo" fill="outline" @click.stop="regenerateShippingLabel(order)">
-                  {{ translate(order.missingLabelImage ? "Regenerate Shipping Label" : "Print Shipping Label") }}
-                  <ion-spinner color="primary" slot="end" v-if="order.isGeneratingShippingLabel" name="crescent" />
+                <ion-button
+                  v-if="!hasPackedShipments(order)"
+                  :disabled="true"
+                  >{{ translate("Shipped") }}</ion-button
+                >
+                <ion-button
+                  v-else
+                  :disabled="
+                    isShipNowDisabled ||
+                    order.hasMissingShipmentInfo ||
+                    order.hasMissingPackageInfo ||
+                    (isTrackingRequiredForAnyShipmentPackage(order) &&
+                      !order.trackingCode &&
+                      !hasPermission(Actions.APP_FORCE_SHIP_ORDER))
+                  "
+                  @click.stop="shipOrder(order)"
+                  >{{ translate("Ship Now") }}</ion-button
+                >
+                <ion-button
+                  :disabled="
+                    order.hasMissingShipmentInfo || order.hasMissingPackageInfo
+                  "
+                  fill="outline"
+                  @click.stop="regenerateShippingLabel(order)"
+                >
+                  {{
+                    translate(
+                      order.missingLabelImage
+                        ? "Regenerate Shipping Label"
+                        : "Print Shipping Label"
+                    )
+                  }}
+                  <ion-spinner
+                    color="primary"
+                    slot="end"
+                    v-if="order.isGeneratingShippingLabel"
+                    name="crescent"
+                  />
                 </ion-button>
-                <ion-button :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo" fill="outline" @click.stop="printPackingSlip(order)">
+                <ion-button
+                  :disabled="
+                    order.hasMissingShipmentInfo || order.hasMissingPackageInfo
+                  "
+                  fill="outline"
+                  @click.stop="printPackingSlip(order)"
+                >
                   {{ translate("Print Customer Letter") }}
-                  <ion-spinner color="primary" slot="end" v-if="order.isGeneratingPackingSlip" name="crescent" />
+                  <ion-spinner
+                    color="primary"
+                    slot="end"
+                    v-if="order.isGeneratingPackingSlip"
+                    name="crescent"
+                  />
                 </ion-button>
               </div>
               <div class="desktop-only">
-                <ion-button v-if="order.missingLabelImage" fill="outline" @click.stop="showShippingLabelErrorModal(order)">{{ translate("Shipping label error") }}</ion-button>
-                <ion-button :disabled="isUnpackDisabled || !hasPermission(Actions.APP_UNPACK_ORDER) || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || !hasPackedShipments(order)" fill="outline" color="danger" @click.stop="unpackOrder(order)">{{ translate("Unpack") }}</ion-button>
+                <ion-button
+                  v-if="order.missingLabelImage"
+                  fill="outline"
+                  @click.stop="showShippingLabelErrorModal(order)"
+                  >{{ translate("Shipping label error") }}</ion-button
+                >
+                <ion-button
+                  :disabled="
+                    isUnpackDisabled ||
+                    !hasPermission(Actions.APP_UNPACK_ORDER) ||
+                    order.hasMissingShipmentInfo ||
+                    order.hasMissingPackageInfo ||
+                    !hasPackedShipments(order)
+                  "
+                  fill="outline"
+                  color="danger"
+                  @click.stop="unpackOrder(order)"
+                  >{{ translate("Unpack") }}</ion-button
+                >
               </div>
             </div>
           </ion-card>
-          <ion-infinite-scroll @ionInfinite="loadMoreCompletedOrders($event)" threshold="100px" v-show="isCompletedOrderScrollable()" ref="infiniteScrollRef">
-            <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')"/>
+          <ion-infinite-scroll
+            @ionInfinite="loadMoreCompletedOrders($event)"
+            threshold="100px"
+            v-show="isCompletedOrderScrollable()"
+            ref="infiniteScrollRef"
+          >
+            <ion-infinite-scroll-content
+              loading-spinner="crescent"
+              :loading-text="translate('Loading')"
+            />
           </ion-infinite-scroll>
         </div>
       </div>
       <div v-if="isLoadingOrders" class="ion-padding ion-text-center">
         <ion-spinner name="crescent"></ion-spinner>
       </div>
-      <ion-fab v-else-if="completedOrders.total" class="mobile-only" vertical="bottom" horizontal="end" slot="fixed">
-        <ion-fab-button :disabled="hasAnyMissingInfo() || (hasAnyShipmentTrackingInfoMissing() && !hasPermission(Actions.APP_FORCE_SHIP_ORDER))" @click="bulkShipOrders()">
+      <ion-fab
+        v-else-if="completedOrders.total"
+        class="mobile-only"
+        vertical="bottom"
+        horizontal="end"
+        slot="fixed"
+      >
+        <ion-fab-button
+          :disabled="
+            hasAnyMissingInfo() ||
+            (hasAnyShipmentTrackingInfoMissing() &&
+              !hasPermission(Actions.APP_FORCE_SHIP_ORDER))
+          "
+          @click="bulkShipOrders()"
+        >
           <ion-icon :icon="checkmarkDoneOutline" />
         </ion-fab-button>
       </ion-fab>
@@ -183,14 +492,31 @@
     <ion-footer v-if="selectedCarrierPartyId">
       <ion-toolbar>
         <ion-buttons slot="end">
-          <ion-button fill="outline" color="primary" @click="openHistoricalManifestModal">
+          <ion-button
+            fill="outline"
+            color="primary"
+            @click="openHistoricalManifestModal"
+          >
             <ion-icon slot="start" :icon="timeOutline" />
             {{ translate("View historical manifests") }}
           </ion-button>
-          <ion-button fill="solid" color="primary" :disabled="!carrierConfiguration[selectedCarrierPartyId]?.['MANIFEST_GEN_REQUEST']" @click="generateCarrierManifest">
+          <ion-button
+            fill="solid"
+            color="primary"
+            :disabled="
+              !carrierConfiguration[selectedCarrierPartyId]?.[
+                'MANIFEST_GEN_REQUEST'
+              ]
+            "
+            @click="generateCarrierManifest"
+          >
             <ion-icon slot="start" :icon="printOutline" />
             {{ translate("Generate Manifest") }}
-            <ion-spinner name="crescent" slot="end" v-if="isGeneratingManifest" />
+            <ion-spinner
+              name="crescent"
+              slot="end"
+              v-if="isGeneratingManifest"
+            />
           </ion-button>
         </ion-buttons>
       </ion-toolbar>
@@ -230,31 +556,57 @@ import {
   IonToolbar,
   alertController,
   popoverController,
-  modalController
-} from '@ionic/vue';
-import { computed, defineComponent } from 'vue';
-import { caretDownOutline, chevronUpOutline, cubeOutline, printOutline, downloadOutline, gift, giftOutline, listOutline, pricetagOutline, ellipsisVerticalOutline, checkmarkDoneOutline, optionsOutline, timeOutline, analytics } from 'ionicons/icons'
-import Popover from '@/views/ShippingPopover.vue'
-import { useRouter } from 'vue-router';
-import { mapGetters, useStore } from 'vuex'
-import { copyToClipboard, getFeatures, hasActiveFilters, showToast } from '@/utils'
-import { hasError } from '@/adapter'
-import { getProductIdentificationValue, DxpShopifyImg, translate, useProductIdentificationStore, useUserStore } from '@hotwax/dxp-components';
-import emitter from '@/event-bus';
-import ViewSizeSelector from '@/components/ViewSizeSelector.vue'
-import { OrderService } from '@/services/OrderService';
-import { UtilService } from '@/services/UtilService';
-import logger from '@/logger';
-import ShippingLabelErrorModal from '@/components/ShippingLabelErrorModal.vue';
-import { Actions, hasPermission } from '@/authorization'
-import OrderActionsPopover from '@/components/OrderActionsPopover.vue'
-import { isKit, retryShippingLabel } from '@/utils/order'
+  modalController,
+} from "@ionic/vue";
+import { computed, defineComponent } from "vue";
+import {
+  caretDownOutline,
+  chevronUpOutline,
+  cubeOutline,
+  printOutline,
+  downloadOutline,
+  gift,
+  giftOutline,
+  listOutline,
+  pricetagOutline,
+  ellipsisVerticalOutline,
+  checkmarkDoneOutline,
+  optionsOutline,
+  timeOutline,
+  analytics,
+} from "ionicons/icons";
+import Popover from "@/views/ShippingPopover.vue";
+import { useRouter } from "vue-router";
+import { mapGetters, useStore } from "vuex";
+import {
+  copyToClipboard,
+  getFeatures,
+  hasActiveFilters,
+  showToast,
+} from "@/utils";
+import { hasError } from "@/adapter";
+import {
+  getProductIdentificationValue,
+  DxpShopifyImg,
+  translate,
+  useProductIdentificationStore,
+  useUserStore,
+} from "@hotwax/dxp-components";
+import emitter from "@/event-bus";
+import ViewSizeSelector from "@/components/ViewSizeSelector.vue";
+import { OrderService } from "@/services/OrderService";
+import { UtilService } from "@/services/UtilService";
+import logger from "@/logger";
+import ShippingLabelErrorModal from "@/components/ShippingLabelErrorModal.vue";
+import { Actions, hasPermission } from "@/authorization";
+import OrderActionsPopover from "@/components/OrderActionsPopover.vue";
+import { isKit, retryShippingLabel } from "@/utils/order";
 import GiftCardActivationModal from "@/components/GiftCardActivationModal.vue";
-import { DateTime } from 'luxon';
-import HistoricalManifestModal from '@/components/HistoricalManifestModal.vue';
+import { DateTime } from "luxon";
+import HistoricalManifestModal from "@/components/HistoricalManifestModal.vue";
 
 export default defineComponent({
-  name: 'Completed',
+  name: "Completed",
   components: {
     DxpShopifyImg,
     IonBadge,
@@ -285,91 +637,144 @@ export default defineComponent({
     IonThumbnail,
     IonTitle,
     IonToolbar,
-    ViewSizeSelector
+    ViewSizeSelector,
   },
   data() {
     return {
       shipmentMethods: [] as Array<any>,
       carrierPartyIds: [] as Array<any>,
-      searchedQuery: '',
+      searchedQuery: "",
       isScrollingEnabled: false,
       completedOrdersList: [] as any,
       selectedCarrierPartyId: "",
       carrierConfiguration: {} as any,
       isGeneratingManifest: false,
       selectedShipmentMethods: [] as any,
-      isLoadingOrders: false
-    }
+      isLoadingOrders: false,
+    };
   },
   computed: {
     ...mapGetters({
-      completedOrders: 'order/getCompletedOrders',
-      getProduct: 'product/getProduct',
-      getPartyName: 'util/getPartyName',
-      getShipmentMethodDesc: 'util/getShipmentMethodDesc',
-      getProductStock: 'stock/getProductStock',
-      productStoreShipmentMethCount: 'util/getProductStoreShipmentMethCount',
-      isShipNowDisabled: 'util/isShipNowDisabled',
-      isUnpackDisabled: 'util/isUnpackDisabled'
+      completedOrders: "order/getCompletedOrders",
+      getProduct: "product/getProduct",
+      getPartyName: "util/getPartyName",
+      getShipmentMethodDesc: "util/getShipmentMethodDesc",
+      getProductStock: "stock/getProductStock",
+      productStoreShipmentMethCount: "util/getProductStoreShipmentMethCount",
+      isShipNowDisabled: "util/isShipNowDisabled",
+      isUnpackDisabled: "util/isUnpackDisabled",
     }),
     getTotalPackages() {
-      return this.carrierPartyIds.reduce((total: number, carrier: any) => total + Number(carrier.groups), 0);
-    }
+      return this.carrierPartyIds.reduce(
+        (total: number, carrier: any) => total + Number(carrier.groups),
+        0
+      );
+    },
   },
   async ionViewWillEnter() {
     this.isScrollingEnabled = false;
     this.isLoadingOrders = true;
     try {
-      await this.fetchShipmentFacets()
+      await this.fetchShipmentFacets();
       //Remove the selected shipment methods and carriers that are no longer valid after editing the order detail page.
-      this.selectedShipmentMethods = this.selectedShipmentMethods?.filter((shipmentMethod: any) => this.shipmentMethods.includes(shipmentMethod));
-      const selectedCarrier = this.carrierPartyIds?.find((carrierPartyId: any) => carrierPartyId === this.selectedCarrierPartyId)
-      this.selectedCarrierPartyId = selectedCarrier ? selectedCarrier : ""
-      await this.initialiseOrderQuery()
+      this.selectedShipmentMethods = this.selectedShipmentMethods?.filter(
+        (shipmentMethod: any) => this.shipmentMethods.includes(shipmentMethod)
+      );
+      const selectedCarrier = this.carrierPartyIds?.find(
+        (carrierPartyId: any) => carrierPartyId === this.selectedCarrierPartyId
+      );
+      this.selectedCarrierPartyId = selectedCarrier ? selectedCarrier : "";
+      await this.initialiseOrderQuery();
     } finally {
       this.isLoadingOrders = false;
     }
-    emitter.on('updateOrderQuery', this.updateOrderQuery)
-    this.completedOrdersList = JSON.parse(JSON.stringify(this?.completedOrders.list)).slice(0, (this.completedOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
+    emitter.on("updateOrderQuery", this.updateOrderQuery);
+    this.completedOrdersList = JSON.parse(
+      JSON.stringify(this?.completedOrders.list)
+    ).slice(
+      0,
+      (this.completedOrders.query.viewIndex + 1) *
+        (process.env.VUE_APP_VIEW_SIZE as any)
+    );
   },
   beforeRouteLeave() {
-    this.store.dispatch('order/clearCompletedOrders')
-    emitter.off('updateOrderQuery', this.updateOrderQuery)
+    this.store.dispatch("order/clearCompletedOrders");
+    emitter.off("updateOrderQuery", this.updateOrderQuery);
   },
   watch: {
-    'completedOrders.list': {
+    "completedOrders.list": {
       handler() {
-        this.completedOrdersList = JSON.parse(JSON.stringify(this?.completedOrders.list)).slice(0, (this.completedOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
+        this.completedOrdersList = JSON.parse(
+          JSON.stringify(this?.completedOrders.list)
+        ).slice(
+          0,
+          (this.completedOrders.query.viewIndex + 1) *
+            (process.env.VUE_APP_VIEW_SIZE as any)
+        );
       },
-    }
+    },
   },
   methods: {
     getTime(time: any) {
-      return time ? DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED) : "";
+      return time
+        ? DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED)
+        : "";
     },
     getErrorMessage() {
-      return this.searchedQuery ? (hasActiveFilters(this.completedOrders.query) ? translate("No results found for . Try using different filters.", { searchedQuery: this.searchedQuery }) : translate( "No results found for . Try searching In Progress or Open tab instead. If you still can't find what you're looking for, try switching stores.", { searchedQuery: this.searchedQuery, lineBreak: '<br />' })) : translate("doesn't have any completed orders right now.", { facilityName: this.currentFacility?.facilityName });
+      return this.searchedQuery
+        ? hasActiveFilters(this.completedOrders.query)
+          ? translate("No results found for . Try using different filters.", {
+              searchedQuery: this.searchedQuery,
+            })
+          : translate(
+              "No results found for . Try searching In Progress or Open tab instead. If you still can't find what you're looking for, try switching stores.",
+              { searchedQuery: this.searchedQuery, lineBreak: "<br />" }
+            )
+        : translate("doesn't have any completed orders right now.", {
+            facilityName: this.currentFacility?.facilityName,
+          });
     },
     hasAnyMissingInfo(): boolean {
       return this.completedOrders.list.some((order: any) => {
         return order.hasMissingShipmentInfo || order.hasMissingPackageInfo;
-      })
+      });
     },
     async fetchKitComponents(orderItem: any) {
-      await this.store.dispatch('product/fetchProductComponents', { productId: orderItem.productId })
-      
+      await this.store.dispatch("product/fetchProductComponents", {
+        productId: orderItem.productId,
+      });
+
       //update the order in order to toggle kit components section
-      const updatedOrder = this.completedOrders.list.find((order: any) =>  order.shipmentId === orderItem.shipmentId);
-      const updatedItem = updatedOrder.items.find((item: any) => item.orderItemSeqId === orderItem.orderItemSeqId)
-      updatedItem.showKitComponents = orderItem.showKitComponents ? false : true
-      this.completedOrdersList = JSON.parse(JSON.stringify(this?.completedOrders.list)).slice(0, (this.completedOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
+      const updatedOrder = this.completedOrders.list.find(
+        (order: any) => order.shipmentId === orderItem.shipmentId
+      );
+      const updatedItem = updatedOrder.items.find(
+        (item: any) => item.orderItemSeqId === orderItem.orderItemSeqId
+      );
+      updatedItem.showKitComponents = orderItem.showKitComponents
+        ? false
+        : true;
+      this.completedOrdersList = JSON.parse(
+        JSON.stringify(this?.completedOrders.list)
+      ).slice(
+        0,
+        (this.completedOrders.query.viewIndex + 1) *
+          (process.env.VUE_APP_VIEW_SIZE as any)
+      );
     },
     enableScrolling() {
-      const parentElement = (this as any).$refs.contentRef.$el
-      const scrollEl = parentElement.shadowRoot.querySelector("main[part='scroll']")
-      let scrollHeight = scrollEl.scrollHeight, infiniteHeight = (this as any).$refs.infiniteScrollRef.$el.offsetHeight, scrollTop = scrollEl.scrollTop, threshold = 100, height = scrollEl.offsetHeight
-      const distanceFromInfinite = scrollHeight - infiniteHeight - scrollTop - threshold - height
-      if(distanceFromInfinite < 0) {
+      const parentElement = (this as any).$refs.contentRef.$el;
+      const scrollEl = parentElement.shadowRoot.querySelector(
+        "main[part='scroll']"
+      );
+      let scrollHeight = scrollEl.scrollHeight,
+        infiniteHeight = (this as any).$refs.infiniteScrollRef.$el.offsetHeight,
+        scrollTop = scrollEl.scrollTop,
+        threshold = 100,
+        height = scrollEl.offsetHeight;
+      const distanceFromInfinite =
+        scrollHeight - infiniteHeight - scrollTop - threshold - height;
+      if (distanceFromInfinite < 0) {
         this.isScrollingEnabled = false;
       } else {
         this.isScrollingEnabled = true;
@@ -380,100 +785,175 @@ export default defineComponent({
       if (!(this.isScrollingEnabled && this.isCompletedOrderScrollable())) {
         await event.target.complete();
       }
-      const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
+      const completedOrdersQuery = JSON.parse(
+        JSON.stringify(this.completedOrders.query)
+      );
       completedOrdersQuery.viewIndex++;
-      await this.store.dispatch('order/updateCompletedOrderIndex', { ...completedOrdersQuery })
-      this.completedOrdersList = JSON.parse(JSON.stringify(this?.completedOrders.list)).slice(0, (this.completedOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
+      await this.store.dispatch("order/updateCompletedOrderIndex", {
+        ...completedOrdersQuery,
+      });
+      this.completedOrdersList = JSON.parse(
+        JSON.stringify(this?.completedOrders.list)
+      ).slice(
+        0,
+        (this.completedOrders.query.viewIndex + 1) *
+          (process.env.VUE_APP_VIEW_SIZE as any)
+      );
       event.target.complete();
     },
     isCompletedOrderScrollable() {
-      return ((this.completedOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any)) <  this.completedOrders.query.viewSize;
+      return (
+        (this.completedOrders.query.viewIndex + 1) *
+          (process.env.VUE_APP_VIEW_SIZE as any) <
+        this.completedOrders.query.viewSize
+      );
     },
     async initialiseOrderQuery() {
-      const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
-      completedOrdersQuery.viewIndex = 0 // If the size changes, list index should be reintialised
-      completedOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE
-      if(this.selectedCarrierPartyId) completedOrdersQuery.selectedCarrierPartyId = this.selectedCarrierPartyId
-      if(this.selectedShipmentMethods?.length) completedOrdersQuery.selectedShipmentMethods = this.selectedShipmentMethods
-      await this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery })
+      const completedOrdersQuery = JSON.parse(
+        JSON.stringify(this.completedOrders.query)
+      );
+      completedOrdersQuery.viewIndex = 0; // If the size changes, list index should be reintialised
+      completedOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE;
+      if (this.selectedCarrierPartyId)
+        completedOrdersQuery.selectedCarrierPartyId =
+          this.selectedCarrierPartyId;
+      if (this.selectedShipmentMethods?.length)
+        completedOrdersQuery.selectedShipmentMethods =
+          this.selectedShipmentMethods;
+      await this.store.dispatch("order/updateCompletedQuery", {
+        ...completedOrdersQuery,
+      });
     },
     async updateOrderQuery(size: any) {
-      const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
+      const completedOrdersQuery = JSON.parse(
+        JSON.stringify(this.completedOrders.query)
+      );
 
-      completedOrdersQuery.viewSize = size
-      await this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery })
+      completedOrdersQuery.viewSize = size;
+      await this.store.dispatch("order/updateCompletedQuery", {
+        ...completedOrdersQuery,
+      });
     },
     async shipOrder(order: any) {
       try {
-        const resp = await OrderService.shipOrder({shipmentId: order.shipmentId})
+        const resp = await OrderService.shipOrder({
+          shipmentId: order.shipmentId,
+        });
 
-        if(!hasError(resp)) {
-          showToast(translate('Order shipped successfully'))
+        if (!hasError(resp)) {
+          showToast(translate("Order shipped successfully"));
           // TODO: handle the case of data not updated correctly
-          const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
-          await Promise.all([this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery }), this.fetchShipmentFacets()]);
+          const completedOrdersQuery = JSON.parse(
+            JSON.stringify(this.completedOrders.query)
+          );
+          await Promise.all([
+            this.store.dispatch("order/updateCompletedQuery", {
+              ...completedOrdersQuery,
+            }),
+            this.fetchShipmentFacets(),
+          ]);
         } else {
-          throw resp.data
+          throw resp.data;
         }
-      } catch(err) {
-        logger.error('Failed to ship order', err)
-        showToast(translate('Failed to ship order'))
+      } catch (err) {
+        logger.error("Failed to ship order", err);
+        showToast(translate("Failed to ship order"));
       }
     },
     async bulkShipOrders() {
-      const packedOrdersCount = this.completedOrders.list.filter((order: any) => {
-        return this.hasPackedShipments(order);
-      }).length;
-      const shipOrderAlert = await alertController
-        .create({
-           header: translate("Ship orders"),
-           message: translate("You are shipping orders. You cannot unpack and edit orders after they have been shipped. Are you sure you are ready to ship this orders?", {count: packedOrdersCount, space: '<br /><br />'}),
-           buttons: [{
+      const packedOrdersCount = this.completedOrders.list.filter(
+        (order: any) => {
+          return this.hasPackedShipments(order);
+        }
+      ).length;
+      const shipOrderAlert = await alertController.create({
+        header: translate("Ship orders"),
+        message: translate(
+          "You are shipping orders. You cannot unpack and edit orders after they have been shipped. Are you sure you are ready to ship this orders?",
+          { count: packedOrdersCount, space: "<br /><br />" }
+        ),
+        buttons: [
+          {
             role: "cancel",
             text: translate("Cancel"),
-          }, {
+          },
+          {
             text: translate("Ship"),
             handler: async () => {
-              let orderList = JSON.parse(JSON.stringify(this.completedOrders.list))
-              orderList = orderList.filter((order: any) =>  order.statusId === 'SHIPMENT_PACKED')
+              let orderList = JSON.parse(
+                JSON.stringify(this.completedOrders.list)
+              );
+              orderList = orderList.filter(
+                (order: any) => order.statusId === "SHIPMENT_PACKED"
+              );
               // orders with tracking required and missing label must be excluded
-              const trackingRequiredOrders = orderList.filter((order: any) => this.isTrackingRequiredForAnyShipmentPackage(order))
-              let trackingRequiredAndMissingCodeOrders = [] as any
+              const trackingRequiredOrders = orderList.filter((order: any) =>
+                this.isTrackingRequiredForAnyShipmentPackage(order)
+              );
+              let trackingRequiredAndMissingCodeOrders = [] as any;
               if (trackingRequiredOrders.length) {
                 // filtering and excluding orders having missing label image with tracking required
-                trackingRequiredAndMissingCodeOrders = trackingRequiredOrders.filter((order: any) => !order.trackingCode).map((order: any) => order.shipmentId)
+                trackingRequiredAndMissingCodeOrders = trackingRequiredOrders
+                  .filter((order: any) => !order.trackingCode)
+                  .map((order: any) => order.shipmentId);
                 if (trackingRequiredAndMissingCodeOrders.length) {
-                  orderList = orderList.filter((order: any) => !trackingRequiredAndMissingCodeOrders.includes(order.shipmentId))
+                  orderList = orderList.filter(
+                    (order: any) =>
+                      !trackingRequiredAndMissingCodeOrders.includes(
+                        order.shipmentId
+                      )
+                  );
                 }
               }
 
               if (!orderList.length) {
-                showToast(translate("No orders are currently able to be shipped due to missing tracking codes."))
+                showToast(
+                  translate(
+                    "No orders are currently able to be shipped due to missing tracking codes."
+                  )
+                );
                 return;
               }
 
-              let shipmentIds = orderList.map((order: any) =>  order.shipmentId)
+              let shipmentIds = orderList.map((order: any) => order.shipmentId);
 
               try {
-                const resp = await OrderService.bulkShipOrders({shipmentIds})
+                const resp = await OrderService.bulkShipOrders({ shipmentIds });
 
                 if (!hasError(resp)) {
                   !trackingRequiredAndMissingCodeOrders.length
-                    ? showToast(translate('Orders shipped successfully'))
-                    : showToast(translate('out of cannot be shipped due to missing tracking codes.', { remainingOrders: trackingRequiredAndMissingCodeOrders.length, totalOrders: packedOrdersCount }))
+                    ? showToast(translate("Orders shipped successfully"))
+                    : showToast(
+                        translate(
+                          "out of cannot be shipped due to missing tracking codes.",
+                          {
+                            remainingOrders:
+                              trackingRequiredAndMissingCodeOrders.length,
+                            totalOrders: packedOrdersCount,
+                          }
+                        )
+                      );
                   // TODO: handle the case of data not updated correctly
-                  const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
-                  await Promise.all([this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery }), this.fetchShipmentFacets()]);
+                  const completedOrdersQuery = JSON.parse(
+                    JSON.stringify(this.completedOrders.query)
+                  );
+                  await Promise.all([
+                    this.store.dispatch("order/updateCompletedQuery", {
+                      ...completedOrdersQuery,
+                    }),
+                    this.fetchShipmentFacets(),
+                  ]);
                 } else {
-                  throw resp.data
+                  throw resp.data;
                 }
-              } catch(err) {
-                logger.error('Failed to ship orders', err)
-                showToast(translate('Failed to ship orders'))
+              } catch (err) {
+                logger.error("Failed to ship orders", err);
+                showToast(translate("Failed to ship orders"));
               }
-            }
-          }]
-        });
+            },
+          },
+        ],
+      });
       return shipOrderAlert.present();
     },
 
@@ -491,111 +971,139 @@ export default defineComponent({
       const params = {
         orderTypeId: "SALES_ORDER",
         statusId: "SHIPMENT_PACKED",
-        shippedDateFrom: DateTime.now().startOf('day').toMillis(),
+        shippedDateFrom: DateTime.now().startOf("day").toMillis(),
         originFacilityId: this.currentFacility?.facilityId,
-        productStoreId: this.currentEComStore.productStoreId
-      }
+        productStoreId: this.currentEComStore.productStoreId,
+      };
       try {
-        const resp = await OrderService.fetchShipmentFacets(params)
+        const resp = await OrderService.fetchShipmentFacets(params);
 
-        if(!hasError(resp)) {
-          this.shipmentMethods = resp.data.shipmentMethodTypeIds
-          this.carrierPartyIds = resp.data.carrierPartyIds
-          await this.store.dispatch('util/fetchShipmentMethodTypeDesc', resp.data.shipmentMethodTypeIds)
-          await this.store.dispatch('util/fetchPartyInformation', resp.data.carrierPartyIds)
+        if (!hasError(resp)) {
+          this.shipmentMethods = resp.data.shipmentMethodTypeIds;
+          this.carrierPartyIds = resp.data.carrierPartyIds;
+          await this.store.dispatch(
+            "util/fetchShipmentMethodTypeDesc",
+            resp.data.shipmentMethodTypeIds
+          );
+          await this.store.dispatch(
+            "util/fetchPartyInformation",
+            resp.data.carrierPartyIds
+          );
           await this.fetchConfiguredCarrierService(resp.data.carrierPartyIds);
           await this.fetchCarrierManifestInformation(resp.data.carrierPartyIds);
         } else {
-          throw resp.data
+          throw resp.data;
         }
-      } catch(err) {
-        logger.error('Failed to fetch shipment methods', err)
+      } catch (err) {
+        logger.error("Failed to fetch shipment methods", err);
       }
     },
 
     async updateQueryString(queryString: string) {
-      const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
+      const completedOrdersQuery = JSON.parse(
+        JSON.stringify(this.completedOrders.query)
+      );
 
-      completedOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE
-      completedOrdersQuery.queryString = queryString
-      await this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery })
+      completedOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE;
+      completedOrdersQuery.queryString = queryString;
+      await this.store.dispatch("order/updateCompletedQuery", {
+        ...completedOrdersQuery,
+      });
       this.searchedQuery = queryString;
     },
-    async updateSelectedShipmentMethods (method: string) {
-      const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
+    async updateSelectedShipmentMethods(method: string) {
+      const completedOrdersQuery = JSON.parse(
+        JSON.stringify(this.completedOrders.query)
+      );
 
-      const selectedShipmentMethods = completedOrdersQuery.selectedShipmentMethods
-      const index = selectedShipmentMethods.indexOf(method)
+      const selectedShipmentMethods =
+        completedOrdersQuery.selectedShipmentMethods;
+      const index = selectedShipmentMethods.indexOf(method);
       if (index < 0) {
-        selectedShipmentMethods.push(method)
+        selectedShipmentMethods.push(method);
       } else {
-        selectedShipmentMethods.splice(index, 1)
+        selectedShipmentMethods.splice(index, 1);
       }
 
       // making view size default when changing the shipment method to correctly fetch orders
-      completedOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE
-      completedOrdersQuery.selectedShipmentMethods = selectedShipmentMethods
-      this.selectedShipmentMethods = selectedShipmentMethods
+      completedOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE;
+      completedOrdersQuery.selectedShipmentMethods = selectedShipmentMethods;
+      this.selectedShipmentMethods = selectedShipmentMethods;
 
-      this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery })
+      this.store.dispatch("order/updateCompletedQuery", {
+        ...completedOrdersQuery,
+      });
     },
-    async updateSelectedCarrierPartyIds (carrierPartyId: string) {
-      const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
+    async updateSelectedCarrierPartyIds(carrierPartyId: string) {
+      const completedOrdersQuery = JSON.parse(
+        JSON.stringify(this.completedOrders.query)
+      );
 
       // making view size default when changing the shipment method to correctly fetch orders
-      completedOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE
-      completedOrdersQuery.selectedCarrierPartyId = carrierPartyId
+      completedOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE;
+      completedOrdersQuery.selectedCarrierPartyId = carrierPartyId;
 
-      this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery })
+      this.store.dispatch("order/updateCompletedQuery", {
+        ...completedOrdersQuery,
+      });
     },
     async unpackOrder(order: any) {
-      const unpackOrderAlert = await alertController
-        .create({
-           header: translate("Unpack"),
-           message: translate("Unpacking this order will send it back to 'In progress' and it will have to be repacked."),
-           buttons: [{
+      const unpackOrderAlert = await alertController.create({
+        header: translate("Unpack"),
+        message: translate(
+          "Unpacking this order will send it back to 'In progress' and it will have to be repacked."
+        ),
+        buttons: [
+          {
             role: "cancel",
             text: translate("Cancel"),
-          }, {
+          },
+          {
             text: translate("Unpack"),
             handler: async () => {
               try {
-                const resp = await OrderService.unpackOrder({shipmentId: order.shipmentId})
+                const resp = await OrderService.unpackOrder({
+                  shipmentId: order.shipmentId,
+                });
 
-                if(resp.status == 200 && !hasError(resp)) {
-                  showToast(translate('Order unpacked successfully'))
+                if (resp.status == 200 && !hasError(resp)) {
+                  showToast(translate("Order unpacked successfully"));
                   // TODO: handle the case of data not updated correctly
-                  await Promise.all([this.store.dispatch('order/findCompletedOrders'), this.fetchShipmentFacets()]);
+                  await Promise.all([
+                    this.store.dispatch("order/findCompletedOrders"),
+                    this.fetchShipmentFacets(),
+                  ]);
                 } else {
-                  throw resp.data
+                  throw resp.data;
                 }
-              } catch(err) {
-                logger.error('Failed to unpack the order', err)
-                showToast(translate('Failed to unpack the order'))
+              } catch (err) {
+                logger.error("Failed to unpack the order", err);
+                showToast(translate("Failed to unpack the order"));
               }
-            }
-          }]
-        });
+            },
+          },
+        ],
+      });
       return unpackOrderAlert.present();
     },
     hasPackedShipments(order: any) {
       // TODO check if ternary check is needed or we could handle on UI
-      return order.statusId === 'SHIPMENT_PACKED'
+      return order.statusId === "SHIPMENT_PACKED";
     },
     async printPackingSlip(order: any) {
       // if the request to print packing slip is not yet completed, then clicking multiple times on the button
       // should not do anything
-      if(order.isGeneratingPackingSlip) {
+      if (order.isGeneratingPackingSlip) {
         return;
       }
 
-      const shipmentIds = [order.shipmentId]
+      const shipmentIds = [order.shipmentId];
       order.isGeneratingPackingSlip = true;
       await OrderService.printPackingSlip(shipmentIds);
       order.isGeneratingPackingSlip = false;
     },
     async printShippingLabel(order: any) {
-      const shipmentIds = [order.shipmentId]
+      const shipmentIds = [order.shipmentId];
 
       const shippingLabelPdfUrls: string[] = Array.from(
         new Set(
@@ -604,16 +1112,25 @@ export default defineComponent({
             .map((shipmentPackage: any) => shipmentPackage.labelImageUrl)
         )
       );
-                  
-      if(!shipmentIds?.length) {
-        showToast(translate('Failed to generate shipping label'))
-        return
+
+      if (!shipmentIds?.length) {
+        showToast(translate("Failed to generate shipping label"));
+        return;
       }
 
-      await OrderService.printShippingLabel(shipmentIds, shippingLabelPdfUrls, order.shipmentPackages)
-      const internationalInvoiceUrls = order.shipmentPackages
-          ?.filter((shipmentPackage: any) => shipmentPackage.internationalInvoiceUrl)
-          .map((shipmentPackage: any) => shipmentPackage.internationalInvoiceUrl) || [];
+      await OrderService.printShippingLabel(
+        shipmentIds,
+        shippingLabelPdfUrls,
+        order.shipmentPackages
+      );
+      const internationalInvoiceUrls =
+        order.shipmentPackages
+          ?.filter(
+            (shipmentPackage: any) => shipmentPackage.internationalInvoiceUrl
+          )
+          .map(
+            (shipmentPackage: any) => shipmentPackage.internationalInvoiceUrl
+          ) || [];
 
       if (internationalInvoiceUrls.length > 0) {
         await OrderService.printCustomDocuments(internationalInvoiceUrls);
@@ -621,26 +1138,30 @@ export default defineComponent({
     },
     async regenerateShippingLabel(order: any) {
       // If there are no product store shipment method configured, then not generating the label and displaying an error toast
-      if(this.productStoreShipmentMethCount <= 0) {
-        showToast(translate('Unable to generate shipping label due to missing product store shipping method configuration'))
+      if (this.productStoreShipmentMethCount <= 0) {
+        showToast(
+          translate(
+            "Unable to generate shipping label due to missing product store shipping method configuration"
+          )
+        );
         return;
       }
 
       // if the request to print shipping label is not yet completed, then clicking multiple times on the button
       // should not do anything
-      if(order.isGeneratingShippingLabel) {
+      if (order.isGeneratingShippingLabel) {
         return;
       }
 
       order.isGeneratingShippingLabel = true;
 
-      if(order.missingLabelImage) {
-        const response = await this.retryShippingLabel(order)
-        if(response?.isGenerated) {
-          await this.printShippingLabel(response.order)
+      if (order.missingLabelImage) {
+        const response = await this.retryShippingLabel(order);
+        if (response?.isGenerated) {
+          await this.printShippingLabel(response.order);
         }
       } else {
-        await this.printShippingLabel(order)
+        await this.printShippingLabel(order);
       }
 
       order.isGeneratingShippingLabel = false;
@@ -649,43 +1170,51 @@ export default defineComponent({
       const shippingLabelErrorModal = await modalController.create({
         component: ShippingLabelErrorModal,
         componentProps: {
-          shipmentId: order.shipmentId
-        }
+          shipmentId: order.shipmentId,
+        },
       });
       return shippingLabelErrorModal.present();
     },
     fetchProductStock(productId: string) {
-      this.store.dispatch('stock/fetchStock', { productId })
+      this.store.dispatch("stock/fetchStock", { productId });
     },
     isTrackingRequiredForAnyShipmentPackage(order: any) {
-      return order.isTrackingRequired === 'Y'
+      return order.isTrackingRequired === "Y";
     },
     hasAnyShipmentTrackingInfoMissing() {
-      return this.completedOrders.list.some((order: any) => this.isTrackingRequiredForAnyShipmentPackage(order) && !order.trackingCode)
+      return this.completedOrders.list.some(
+        (order: any) =>
+          this.isTrackingRequiredForAnyShipmentPackage(order) &&
+          !order.trackingCode
+      );
     },
     async orderActionsPopover(order: any, ev: Event) {
       const popover = await popoverController.create({
         component: OrderActionsPopover,
         componentProps: {
           order,
-          category: 'completed'
+          category: "completed",
         },
         showBackdrop: false,
-        event: ev
+        event: ev,
       });
       return popover.present();
     },
     async openGiftCardActivationModal(item: any) {
       const modal = await modalController.create({
         component: GiftCardActivationModal,
-        componentProps: { item }
-      })
+        componentProps: { item },
+      });
 
       modal.onDidDismiss().then((result: any) => {
-        if(result.data?.isGCActivated) {
-          this.store.dispatch("order/updateCurrentItemGCActivationDetails", { item, category: "completed", isDetailsPage: false })
+        if (result.data?.isGCActivated) {
+          this.store.dispatch("order/updateCurrentItemGCActivationDetails", {
+            item,
+            category: "completed",
+            isDetailsPage: false,
+          });
         }
-      })
+      });
 
       modal.present();
     },
@@ -697,59 +1226,67 @@ export default defineComponent({
         requestType: ["MANIFEST_GEN_REQUEST", "MANIFEST_PRINT"],
         requestType_op: "in",
         pageIndex: 0,
-        pageSize: carrierPartyIds.length * 2
-      }
+        pageSize: carrierPartyIds.length * 2,
+      };
       try {
-        const resp = await UtilService.fetchConfiguredCarrierService(payload)
+        const resp = await UtilService.fetchConfiguredCarrierService(payload);
 
-        if(!hasError(resp) && resp.data?.length) {
-          this.carrierConfiguration = resp.data.reduce((carriers: any, carrier: any) => {
-            if(!carriers[carrier.carrierPartyId]) {
-              carriers[carrier.carrierPartyId] = {
-                [carrier.requestType]: carrier.serviceName
+        if (!hasError(resp) && resp.data?.length) {
+          this.carrierConfiguration = resp.data.reduce(
+            (carriers: any, carrier: any) => {
+              if (!carriers[carrier.carrierPartyId]) {
+                carriers[carrier.carrierPartyId] = {
+                  [carrier.requestType]: carrier.serviceName,
+                };
+              } else {
+                carriers[carrier.carrierPartyId][carrier.requestType] =
+                  carrier.serviceName;
               }
-            } else {
-              carriers[carrier.carrierPartyId][carrier.requestType] = carrier.serviceName
-            }
 
-            return carriers
-          }, {})
+              return carriers;
+            },
+            {}
+          );
         }
-      } catch(err) {
-        logger.error("Failed to fetch carrier configuration information", err)
+      } catch (err) {
+        logger.error("Failed to fetch carrier configuration information", err);
       }
     },
     async fetchCarrierManifestInformation(carrierPartyIds: Array<string>) {
       // Using loop to fetch records as we only need a single record for each party
       // If used with in operator on partyId field then we need to check if the records exceed 250
       // and thus needs to handle that case as well.
-      for(let partyId of carrierPartyIds) {
+      for (let partyId of carrierPartyIds) {
         const payload = {
           customParametersMap: {
             partyId,
-            fromDate_from: DateTime.now().startOf("day").minus({ days: 7 }).toMillis(),
+            fromDate_from: DateTime.now()
+              .startOf("day")
+              .minus({ days: 7 })
+              .toMillis(),
             facilityId: this.currentFacility.facilityId,
             orderByField: "-contentId",
             pageIndex: 0,
-            pageSize: 250,  // Assuming that there will not be more than 250 manifest in last 7 days for a carrier
+            pageSize: 250, // Assuming that there will not be more than 250 manifest in last 7 days for a carrier
           },
           dataDocumentId: "ManifestContent",
-          filterByDate: true
-        }
+          filterByDate: true,
+        };
         try {
-          const resp = await UtilService.fetchConfiguredCarrierService(payload)
-  
-          if(!hasError(resp) && resp.data?.entityValueList?.length) {
-            if(this.carrierConfiguration[partyId]) {
-              this.carrierConfiguration[partyId]["manifests"] = resp.data.entityValueList
+          const resp = await UtilService.fetchConfiguredCarrierService(payload);
+
+          if (!hasError(resp) && resp.data?.entityValueList?.length) {
+            if (this.carrierConfiguration[partyId]) {
+              this.carrierConfiguration[partyId]["manifests"] =
+                resp.data.entityValueList;
             } else {
               this.carrierConfiguration[partyId] = {
-                ["manifests"]: resp.data.entityValueList
-              }
+                ["manifests"]: resp.data.entityValueList,
+              };
             }
           }
-        } catch(err) {
-          logger.error("Failed to fetch carrier manifest information", err)
+        } catch (err) {
+          logger.error("Failed to fetch carrier manifest information", err);
         }
       }
     },
@@ -758,9 +1295,9 @@ export default defineComponent({
         component: HistoricalManifestModal,
         componentProps: {
           selectedCarrierPartyId: this.selectedCarrierPartyId,
-          carrierConfiguration: this.carrierConfiguration
-        }
-      })
+          carrierConfiguration: this.carrierConfiguration,
+        },
+      });
 
       modal.present();
     },
@@ -769,29 +1306,36 @@ export default defineComponent({
       const payload = {
         facilityId: this.currentFacility?.facilityId,
         carrierPartyId: this.selectedCarrierPartyId,
-        manifestGenerateServiceName: this.carrierConfiguration[this.selectedCarrierPartyId]?.["MANIFEST_GEN_REQUEST"]
-      }
+        manifestGenerateServiceName:
+          this.carrierConfiguration[this.selectedCarrierPartyId]?.[
+            "MANIFEST_GEN_REQUEST"
+          ],
+      };
 
       try {
         await UtilService.generateManifest(payload);
-        showToast(translate("Manifest has been generated successfully"))
+        showToast(translate("Manifest has been generated successfully"));
         // Fetch the latest manifest information once the manifest is generated successfully
-        await this.fetchCarrierManifestInformation([this.selectedCarrierPartyId])
-      } catch(err) {
-        logger.error("Failed to generate manifest", err)
-        showToast(translate("Failed to generate manifest"))
+        await this.fetchCarrierManifestInformation([
+          this.selectedCarrierPartyId,
+        ]);
+      } catch (err) {
+        logger.error("Failed to generate manifest", err);
+        showToast(translate("Failed to generate manifest"));
       }
       this.isGeneratingManifest = false;
-    }
+    },
   },
   setup() {
     const store = useStore();
     const router = useRouter();
-    const userStore = useUserStore()
+    const userStore = useUserStore();
     const productIdentificationStore = useProductIdentificationStore();
-    let productIdentificationPref = computed(() => productIdentificationStore.getProductIdentificationPref)
-    let currentEComStore: any = computed(() => userStore.getCurrentEComStore)
-    let currentFacility: any = computed(() => userStore.getCurrentFacility) 
+    let productIdentificationPref = computed(
+      () => productIdentificationStore.getProductIdentificationPref
+    );
+    let currentEComStore: any = computed(() => userStore.getCurrentEComStore);
+    let currentFacility: any = computed(() => userStore.getCurrentFacility);
 
     return {
       Actions,
@@ -820,8 +1364,8 @@ export default defineComponent({
       router,
       store,
       timeOutline,
-      translate
-    }
-  }
+      translate,
+    };
+  },
 });
 </script>

--- a/src/views/EditPackagingModal.vue
+++ b/src/views/EditPackagingModal.vue
@@ -2,13 +2,17 @@
   <ion-header>
     <ion-toolbar>
       <ion-buttons slot="start">
-        <ion-button @click="closeModal"> 
+        <ion-button data-test-id="edit-packaging-close-btn" @click="closeModal">
           <ion-icon slot="icon-only" :icon="closeOutline" />
         </ion-button>
       </ion-buttons>
-      <ion-title>{{ translate("Edit packaging") }}</ion-title>
+      <ion-title data-test-id="edit-packaging-title">{{
+        translate("Edit packaging")
+      }}</ion-title>
       <ion-buttons slot="end">
-        <ion-button fill="clear">{{ translate("Save") }}</ion-button>
+        <ion-button data-test-id="edit-packaging-save-btn" fill="clear">{{
+          translate("Save")
+        }}</ion-button>
       </ion-buttons>
     </ion-toolbar>
   </ion-header>
@@ -30,7 +34,10 @@
           </ion-label>
         </div>
 
-        <div class="order-metadata">
+        <div
+          class="order-metadata"
+          data-test-id="edit-packaging-order-metadata"
+        >
           <ion-label>
             Next Day Shipping
             <p>{{ translate("Ordered") }} 28th January 2020 2:32 PM EST</p>
@@ -38,11 +45,13 @@
         </div>
       </div>
 
-      <div class="order-item">
+      <div class="order-item" data-test-id="edit-packaging-order-item">
         <div class="product-info">
           <ion-item lines="none">
             <ion-thumbnail slot="start">
-              <img src="https://dev-resources.hotwax.io/resources/uploads/images/product/m/j/mj08-blue_main.jpg" />
+              <img
+                src="https://dev-resources.hotwax.io/resources/uploads/images/product/m/j/mj08-blue_main.jpg"
+              />
             </ion-thumbnail>
             <ion-label>
               <p class="overline">WJ06-XL-PURPLE</p>
@@ -61,21 +70,21 @@
           </ion-item>
         </div>
       </div>
-    </ion-card> 
+    </ion-card>
 
     <ion-list>
       <ion-item lines="none">
-        <ion-note slot="start">{{ translate('Boxes') }}</ion-note>
+        <ion-note slot="start">{{ translate("Boxes") }}</ion-note>
         <ion-button fill="clear" slot="end">
           {{ translate("Add") }}
-          <ion-icon :icon="addCircleOutline"/>
+          <ion-icon :icon="addCircleOutline" />
         </ion-button>
       </ion-item>
       <ion-item>
         <ion-select label="Box A" value="3">
           <ion-select-option value="1">Type 1</ion-select-option>
           <ion-select-option value="2">Type 2</ion-select-option>
-          <ion-select-option value="3">Type 3</ion-select-option>  
+          <ion-select-option value="3">Type 3</ion-select-option>
         </ion-select>
       </ion-item>
     </ion-list>
@@ -83,7 +92,7 @@
 </template>
 
 <script>
-import { 
+import {
   IonButtons,
   IonButton,
   IonCard,
@@ -100,14 +109,15 @@ import {
   IonThumbnail,
   IonTitle,
   IonToolbar,
-  modalController } from "@ionic/vue";
+  modalController,
+} from "@ionic/vue";
 import { defineComponent } from "vue";
 import { addCircleOutline, closeOutline, pricetag } from "ionicons/icons";
-import { translate } from '@hotwax/dxp-components'
+import { translate } from "@hotwax/dxp-components";
 
 export default defineComponent({
   name: "EditPackagingModal",
-  components: { 
+  components: {
     IonButtons,
     IonButton,
     IonCard,
@@ -135,7 +145,7 @@ export default defineComponent({
       addCircleOutline,
       closeOutline,
       pricetag,
-      translate
+      translate,
     };
   },
 });

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -145,6 +145,7 @@
               v-else-if="order.shipmentPackages"
             >
               <ion-button
+                data-test-id="add-box-btn"
                 :disabled="
                   order.items.length <= order.shipmentPackages.length ||
                   addingBoxForShipmentIds.includes(order.shipmentId)
@@ -161,6 +162,7 @@
                 <ion-chip
                   v-for="shipmentPackage in order.shipmentPackages"
                   :key="shipmentPackage.shipmentId"
+                  data-test-id="box-selector"
                   @click.stop="
                     updateShipmentBoxType(shipmentPackage, order, $event)
                   "

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -1,39 +1,79 @@
 <template>
   <ion-page :key="router.currentRoute.value.path">
-    <ViewSizeSelector menu-id="view-size-selector-inprogress" content-id="view-size-selector" />
+    <ViewSizeSelector
+      menu-id="view-size-selector-inprogress"
+      content-id="view-size-selector"
+    />
 
     <ion-header :translucent="true">
       <ion-menu-button menu="start" slot="start" />
       <ion-toolbar>
         <ion-menu-button slot="start" />
-        <ion-title v-if="!inProgressOrders.total">{{ inProgressOrders.total }} {{ translate('orders') }}</ion-title>
-        <ion-title v-else>{{ inProgressOrders.query.viewSize }} {{ translate('of') }} {{ inProgressOrders.total }} {{ translate('orders') }}</ion-title>
+        <ion-title v-if="!inProgressOrders.total"
+          >{{ inProgressOrders.total }} {{ translate("orders") }}</ion-title
+        >
+        <ion-title v-else
+          >{{ inProgressOrders.query.viewSize }} {{ translate("of") }}
+          {{ inProgressOrders.total }} {{ translate("orders") }}</ion-title
+        >
 
         <ion-buttons slot="end">
-          <ion-button :disabled="!hasPermission(Actions.APP_RECYCLE_ORDER) || !inProgressOrders.total || isRejecting" fill="clear" color="danger" @click="recycleInProgressOrders()">
+          <ion-button
+            :disabled="
+              !hasPermission(Actions.APP_RECYCLE_ORDER) ||
+              !inProgressOrders.total ||
+              isRejecting
+            "
+            fill="clear"
+            color="danger"
+            @click="recycleInProgressOrders()"
+          >
             {{ translate("Reject all") }}
           </ion-button>
-          <ion-menu-button menu="view-size-selector-inprogress" :disabled="!inProgressOrders.total">
+          <ion-menu-button
+            menu="view-size-selector-inprogress"
+            :disabled="!inProgressOrders.total"
+          >
             <ion-icon :icon="optionsOutline" />
           </ion-menu-button>
         </ion-buttons>
       </ion-toolbar>
     </ion-header>
-    
-    <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="view-size-selector">
-      <ion-searchbar class="searchbar" :placeholder="translate('Search orders')" v-model="inProgressOrders.query.queryString" @keyup.enter="updateQueryString($event.target.value)"/>
-      <ion-radio-group v-if="picklists?.length" v-model="selectedPicklistId" @ionChange="updateSelectedPicklist($event.detail.value)">
+
+    <ion-content
+      ref="contentRef"
+      :scroll-events="true"
+      @ionScroll="enableScrolling()"
+      id="view-size-selector"
+    >
+      <ion-searchbar
+        data-test-id="search-orders-input"
+        class="searchbar"
+        :placeholder="translate('Search orders')"
+        v-model="inProgressOrders.query.queryString"
+        @keyup.enter="updateQueryString($event.target.value)"
+      />
+      <ion-radio-group
+        data-test-id="picklist-filter-group"
+        v-if="picklists?.length"
+        v-model="selectedPicklistId"
+        @ionChange="updateSelectedPicklist($event.detail.value)"
+      >
         <ion-row class="filters">
           <ion-item lines="none">
             <!-- empty value '' for 'All orders' radio -->
             <ion-radio label-placement="end" value="">
               <ion-label class="ion-text-wrap">
-                {{ translate('All') }}
-                <p>{{ translate('picklists', { count: picklists.length }) }}</p>
+                {{ translate("All") }}
+                <p>{{ translate("picklists", { count: picklists.length }) }}</p>
               </ion-label>
             </ion-radio>
           </ion-item>
-          <ion-item lines="none" v-for="picklist in picklists" :key="picklist.id">
+          <ion-item
+            lines="none"
+            v-for="picklist in picklists"
+            :key="picklist.id"
+          >
             <ion-radio label-placement="end" :value="picklist.id">
               <ion-label class="ion-text-wrap">
                 {{ picklist.pickersName }}
@@ -46,18 +86,39 @@
 
       <div v-if="inProgressOrders.total">
         <div class="results">
-          <ion-button expand="block" class="bulk-action desktop-only" fill="outline" size="large" v-if="!isForceScanEnabled" @click="packOrders()">{{ translate("Pack orders") }}</ion-button>
-          <ion-card class="order" v-for="(order, index) in getInProgressOrders()" :key="index" :class="isForceScanEnabled ? 'ion-margin-top' : ''">
+          <ion-button
+            expand="block"
+            class="bulk-action desktop-only"
+            fill="outline"
+            size="large"
+            v-if="!isForceScanEnabled"
+            @click="packOrders()"
+            >{{ translate("Pack orders") }}</ion-button
+          >
+          <ion-card
+            class="order"
+            v-for="(order, index) in getInProgressOrders()"
+            :key="index"
+            data-test-id="inprogress-order-card"
+            :class="isForceScanEnabled ? 'ion-margin-top' : ''"
+          >
             <div class="order-header">
               <div class="order-primary-info">
                 <ion-label>
-                  <strong>{{ order.customerName }}</strong>
-                  <p>{{ translate("Ordered") }} {{ getTime(order.orderDate) }}</p>
+                  <strong data-test-id="customer-name">{{
+                    order.customerName
+                  }}</strong>
+                  <p>
+                    {{ translate("Ordered") }} {{ getTime(order.orderDate) }}
+                  </p>
                 </ion-label>
               </div>
 
               <div class="order-tags">
-                <ion-chip @click.stop="orderActionsPopover(order, $event)" outline>
+                <ion-chip
+                  @click.stop="orderActionsPopover(order, $event)"
+                  outline
+                >
                   <ion-icon :icon="pricetagOutline" />
                   <ion-label>{{ order.orderName }}</ion-label>
                   <ion-icon :icon="caretDownOutline" />
@@ -67,7 +128,10 @@
               <div class="order-metadata">
                 <ion-label>
                   {{ getShipmentMethodDesc(order.shipmentMethodTypeId) }}
-                  <p v-if="order.reservedDatetime">{{ translate("Last brokered") }} {{ getTime(order.reservedDatetime) }}</p>
+                  <p v-if="order.reservedDatetime">
+                    {{ translate("Last brokered") }}
+                    {{ getTime(order.reservedDatetime) }}
+                  </p>
                 </ion-label>
               </div>
             </div>
@@ -76,32 +140,97 @@
               <ion-skeleton-text animated />
               <ion-skeleton-text animated />
             </div>
-            <div class="box-type desktop-only"  v-else-if="order.shipmentPackages">
-              <ion-button :disabled="order.items.length <= order.shipmentPackages.length || addingBoxForShipmentIds.includes(order.shipmentId)" @click.stop="addShipmentBox(order)" fill="outline" shape="round" size="small"><ion-icon :icon="addOutline" />{{ translate("Add Box") }}</ion-button>
+            <div
+              class="box-type desktop-only"
+              v-else-if="order.shipmentPackages"
+            >
+              <ion-button
+                :disabled="
+                  order.items.length <= order.shipmentPackages.length ||
+                  addingBoxForShipmentIds.includes(order.shipmentId)
+                "
+                @click.stop="addShipmentBox(order)"
+                fill="outline"
+                shape="round"
+                size="small"
+                ><ion-icon :icon="addOutline" />{{
+                  translate("Add Box")
+                }}</ion-button
+              >
               <ion-row>
-                <ion-chip v-for="shipmentPackage in order.shipmentPackages" :key="shipmentPackage.shipmentId" @click.stop="updateShipmentBoxType(shipmentPackage, order, $event)">
-                  {{ `Box ${shipmentPackage?.packageName}` }} {{ `| ${boxTypeDesc(getShipmentPackageType(order, shipmentPackage))}`}}
+                <ion-chip
+                  v-for="shipmentPackage in order.shipmentPackages"
+                  :key="shipmentPackage.shipmentId"
+                  @click.stop="
+                    updateShipmentBoxType(shipmentPackage, order, $event)
+                  "
+                >
+                  {{ `Box ${shipmentPackage?.packageName}` }}
+                  {{
+                    `| ${boxTypeDesc(
+                      getShipmentPackageType(order, shipmentPackage)
+                    )}`
+                  }}
                   <ion-icon :icon="caretDownOutline" />
                 </ion-chip>
               </ion-row>
             </div>
 
-            <div v-for="item in order.items" :key="order.shipmentId + item.shipmentItemSeqId" class="order-line-item">
+            <div
+              v-for="item in order.items"
+              :key="order.shipmentId + item.shipmentItemSeqId"
+              class="order-line-item"
+            >
               <div class="order-item">
                 <div class="product-info">
                   <ion-item lines="none">
-                    <ion-thumbnail slot="start" v-image-preview="getProduct(item.productId)" :key="getProduct(item.productId)?.mainImageUrl">
-                      <DxpShopifyImg :src="getProduct(item.productId).mainImageUrl" :key="getProduct(item.productId).mainImageUrl" size="small"/>
+                    <ion-thumbnail
+                      slot="start"
+                      v-image-preview="getProduct(item.productId)"
+                      :key="getProduct(item.productId)?.mainImageUrl"
+                    >
+                      <DxpShopifyImg
+                        :src="getProduct(item.productId).mainImageUrl"
+                        :key="getProduct(item.productId).mainImageUrl"
+                        size="small"
+                      />
                     </ion-thumbnail>
                     <ion-label>
-                      <p class="overline">{{ getProductIdentificationValue(productIdentificationPref.secondaryId, getProduct(item.productId)) }}</p>
+                      <p class="overline">
+                        {{
+                          getProductIdentificationValue(
+                            productIdentificationPref.secondaryId,
+                            getProduct(item.productId)
+                          )
+                        }}
+                      </p>
                       <div>
-                        {{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) : item.productName }}
-                        <ion-badge color="dark" class="kit-badge" v-if="isKit(item)">{{ translate("Kit") }}</ion-badge>
+                        {{
+                          getProductIdentificationValue(
+                            productIdentificationPref.primaryId,
+                            getProduct(item.productId)
+                          )
+                            ? getProductIdentificationValue(
+                                productIdentificationPref.primaryId,
+                                getProduct(item.productId)
+                              )
+                            : item.productName
+                        }}
+                        <ion-badge
+                          color="dark"
+                          class="kit-badge"
+                          v-if="isKit(item)"
+                          >{{ translate("Kit") }}</ion-badge
+                        >
                       </div>
-                      <p>{{ getFeatures(getProduct(item.productId).productFeatures)}}</p>
+                      <p>
+                        {{
+                          getFeatures(
+                            getProduct(item.productId).productFeatures
+                          )
+                        }}
+                      </p>
                     </ion-label>
-                    
                   </ion-item>
                 </div>
 
@@ -116,17 +245,52 @@
                   <div>
                     <template v-if="item.rejectReason">
                       <ion-chip outline color="danger">
-                        <ion-label> {{ getRejectionReasonDescription(item.rejectReason) }}</ion-label>
-                        <ion-icon :icon="closeCircleOutline" @click.stop="removeRejectionReason($event, item, order)"/>
+                        <ion-label>
+                          {{
+                            getRejectionReasonDescription(item.rejectReason)
+                          }}</ion-label
+                        >
+                        <ion-icon
+                          :icon="closeCircleOutline"
+                          @click.stop="
+                            removeRejectionReason($event, item, order)
+                          "
+                        />
                       </ion-chip>
                     </template>
                     <template v-else-if="isEntierOrderRejectionEnabled(order)">
                       <ion-chip outline color="danger">
-                        <ion-label> {{ getRejectionReasonDescription(rejectEntireOrderReasonId) ? getRejectionReasonDescription(rejectEntireOrderReasonId) : translate('Reject to avoid order split (no variance)')}}</ion-label>
+                        <ion-label>
+                          {{
+                            getRejectionReasonDescription(
+                              rejectEntireOrderReasonId
+                            )
+                              ? getRejectionReasonDescription(
+                                  rejectEntireOrderReasonId
+                                )
+                              : translate(
+                                  "Reject to avoid order split (no variance)"
+                                )
+                          }}</ion-label
+                        >
                       </ion-chip>
                     </template>
                     <template v-else>
-                      <ion-chip :disabled="!order.shipmentPackages || order.shipmentPackages.length === 0" outline @click="openShipmentBoxPopover($event, item, item.orderItemSeqId, order)">
+                      <ion-chip
+                        :disabled="
+                          !order.shipmentPackages ||
+                          order.shipmentPackages.length === 0
+                        "
+                        outline
+                        @click="
+                          openShipmentBoxPopover(
+                            $event,
+                            item,
+                            item.orderItemSeqId,
+                            order
+                          )
+                        "
+                      >
                         {{ `Box ${item.selectedBox}` }}
                         <ion-icon :icon="caretDownOutline" />
                       </ion-chip>
@@ -136,43 +300,152 @@
 
                 <!--Adding checks to avoid any operations if order has missing info, mostly when after packing Solr is not updaing immediately-->
                 <div class="product-metadata">
-                  <ion-button v-if="isKit(item)" fill="clear" size="small" @click.stop="fetchKitComponents(item)">
-                    <ion-icon v-if="item.showKitComponents" color="medium" slot="icon-only" :icon="chevronUpOutline"/>
-                    <ion-icon v-else color="medium" slot="icon-only" :icon="listOutline"/>
+                  <ion-button
+                    v-if="isKit(item)"
+                    fill="clear"
+                    size="small"
+                    @click.stop="fetchKitComponents(item)"
+                  >
+                    <ion-icon
+                      v-if="item.showKitComponents"
+                      color="medium"
+                      slot="icon-only"
+                      :icon="chevronUpOutline"
+                    />
+                    <ion-icon
+                      v-else
+                      color="medium"
+                      slot="icon-only"
+                      :icon="listOutline"
+                    />
                   </ion-button>
-                  <ion-button color="medium" fill="clear" size="small" v-if="item.productTypeId === 'GIFT_CARD'" @click="openGiftCardActivationModal(item)">
-                    <ion-icon slot="icon-only" :icon="item.isGCActivated ? gift : giftOutline"/>
+                  <ion-button
+                    color="medium"
+                    fill="clear"
+                    size="small"
+                    v-if="item.productTypeId === 'GIFT_CARD'"
+                    @click="openGiftCardActivationModal(item)"
+                  >
+                    <ion-icon
+                      slot="icon-only"
+                      :icon="item.isGCActivated ? gift : giftOutline"
+                    />
                   </ion-button>
-                  <ion-button color="danger" fill="clear" size="small" @click.stop="openRejectReasonPopover($event, item, order)">
-                    <ion-icon slot="icon-only" :icon="trashBinOutline"/>
+                  <ion-button
+                    color="danger"
+                    fill="clear"
+                    size="small"
+                    @click.stop="openRejectReasonPopover($event, item, order)"
+                  >
+                    <ion-icon slot="icon-only" :icon="trashBinOutline" />
                   </ion-button>
-                  <ion-note v-if="getProductStock(item.productId).qoh">{{ getProductStock(item.productId).qoh }} {{ translate('pieces in stock') }}</ion-note>
-                  <ion-button color="medium" fill="clear" v-else size="small" @click.stop="fetchProductStock(item.productId)">
-                    <ion-icon slot="icon-only" :icon="cubeOutline"/>
+                  <ion-note v-if="getProductStock(item.productId).qoh"
+                    >{{ getProductStock(item.productId).qoh }}
+                    {{ translate("pieces in stock") }}</ion-note
+                  >
+                  <ion-button
+                    color="medium"
+                    fill="clear"
+                    v-else
+                    size="small"
+                    @click.stop="fetchProductStock(item.productId)"
+                  >
+                    <ion-icon slot="icon-only" :icon="cubeOutline" />
                   </ion-button>
                 </div>
               </div>
 
-              <div v-if="item.showKitComponents && !getProduct(item.productId)?.productComponents" class="kit-components">
+              <div
+                v-if="
+                  item.showKitComponents &&
+                  !getProduct(item.productId)?.productComponents
+                "
+                class="kit-components"
+              >
                 <ion-item lines="none">
-                  <ion-skeleton-text animated style="height: 80%;"/>
+                  <ion-skeleton-text animated style="height: 80%" />
                 </ion-item>
                 <ion-item lines="none">
-                  <ion-skeleton-text animated style="height: 80%;"/>
+                  <ion-skeleton-text animated style="height: 80%" />
                 </ion-item>
               </div>
-              <div v-else-if="item.showKitComponents && getProduct(item.productId)?.productComponents" class="kit-components">
-                <ion-card v-for="(productComponent, index) in getProduct(item.productId).productComponents" :key="index">
+              <div
+                v-else-if="
+                  item.showKitComponents &&
+                  getProduct(item.productId)?.productComponents
+                "
+                class="kit-components"
+              >
+                <ion-card
+                  v-for="(productComponent, index) in getProduct(item.productId)
+                    .productComponents"
+                  :key="index"
+                >
                   <ion-item lines="none">
-                    <ion-thumbnail slot="start" v-image-preview="getProduct(productComponent.productIdTo)" :key="getProduct(productComponent.productIdTo)?.mainImageUrl">
-                      <DxpShopifyImg :src="getProduct(productComponent.productIdTo).mainImageUrl" :key="getProduct(productComponent.productIdTo).mainImageUrl" size="small"/>
+                    <ion-thumbnail
+                      slot="start"
+                      v-image-preview="getProduct(productComponent.productIdTo)"
+                      :key="
+                        getProduct(productComponent.productIdTo)?.mainImageUrl
+                      "
+                    >
+                      <DxpShopifyImg
+                        :src="
+                          getProduct(productComponent.productIdTo).mainImageUrl
+                        "
+                        :key="
+                          getProduct(productComponent.productIdTo).mainImageUrl
+                        "
+                        size="small"
+                      />
                     </ion-thumbnail>
                     <ion-label>
-                      <p class="overline">{{ getProductIdentificationValue(productIdentificationPref.secondaryId, getProduct(productComponent.productIdTo)) }}</p>
-                      {{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(productComponent.productIdTo)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(productComponent.productIdTo)) : productComponent.productIdTo }}
-                      <p>{{ getFeatures(getProduct(productComponent.productIdTo).productFeatures)}}</p>
+                      <p class="overline">
+                        {{
+                          getProductIdentificationValue(
+                            productIdentificationPref.secondaryId,
+                            getProduct(productComponent.productIdTo)
+                          )
+                        }}
+                      </p>
+                      {{
+                        getProductIdentificationValue(
+                          productIdentificationPref.primaryId,
+                          getProduct(productComponent.productIdTo)
+                        )
+                          ? getProductIdentificationValue(
+                              productIdentificationPref.primaryId,
+                              getProduct(productComponent.productIdTo)
+                            )
+                          : productComponent.productIdTo
+                      }}
+                      <p>
+                        {{
+                          getFeatures(
+                            getProduct(productComponent.productIdTo)
+                              .productFeatures
+                          )
+                        }}
+                      </p>
                     </ion-label>
-                    <ion-checkbox v-if="item.rejectReason || isEntierOrderRejectionEnabled(order)" :checked="item.kitComponents?.includes(productComponent.productIdTo)" @ionChange="rejectKitComponent(order, item, productComponent.productIdTo)" />
+                    <ion-checkbox
+                      v-if="
+                        item.rejectReason ||
+                        isEntierOrderRejectionEnabled(order)
+                      "
+                      :checked="
+                        item.kitComponents?.includes(
+                          productComponent.productIdTo
+                        )
+                      "
+                      @ionChange="
+                        rejectKitComponent(
+                          order,
+                          item,
+                          productComponent.productIdTo
+                        )
+                      "
+                    />
                   </ion-item>
                 </ion-card>
               </div>
@@ -180,8 +453,15 @@
 
             <div class="mobile-only">
               <ion-item>
-                <ion-button fill="clear" @click.stop="packOrder(order)">{{ translate("Pack using default packaging") }}</ion-button>
-                <ion-button slot="end" fill="clear" color="medium" @click.stop="packagingPopover">
+                <ion-button fill="clear" @click.stop="packOrder(order)">{{
+                  translate("Pack using default packaging")
+                }}</ion-button>
+                <ion-button
+                  slot="end"
+                  fill="clear"
+                  color="medium"
+                  @click.stop="packagingPopover"
+                >
                   <ion-icon slot="icon-only" :icon="ellipsisVerticalOutline" />
                 </ion-button>
               </ion-item>
@@ -189,16 +469,41 @@
 
             <div class="actions">
               <div>
-                <ion-button :color="order.hasAllRejectedItem ? 'danger' : ''" @click.stop="packOrder(order)">{{ translate(order.hasAllRejectedItem ? "Reject" : order.hasRejectedItem ? "Save and Pack"  : "Pack") }}</ion-button>
+                <ion-button
+                  :color="order.hasAllRejectedItem ? 'danger' : ''"
+                  @click.stop="packOrder(order)"
+                  >{{
+                    translate(
+                      order.hasAllRejectedItem
+                        ? "Reject"
+                        : order.hasRejectedItem
+                        ? "Save and Pack"
+                        : "Pack"
+                    )
+                  }}</ion-button
+                >
               </div>
 
               <div class="desktop-only">
-                <ion-button v-if="order.missingLabelImage && isAutoShippingLabelEnabled" fill="outline" @click.stop="showShippingLabelErrorModal(order)">{{ translate("Shipping label error") }}</ion-button>
+                <ion-button
+                  v-if="order.missingLabelImage && isAutoShippingLabelEnabled"
+                  fill="outline"
+                  @click.stop="showShippingLabelErrorModal(order)"
+                  >{{ translate("Shipping label error") }}</ion-button
+                >
               </div>
             </div>
           </ion-card>
-          <ion-infinite-scroll @ionInfinite="loadMoreInProgressOrders($event)" threshold="100px"  v-show="isInProgressOrderScrollable()" ref="infiniteScrollRef">
-            <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')"/>
+          <ion-infinite-scroll
+            @ionInfinite="loadMoreInProgressOrders($event)"
+            threshold="100px"
+            v-show="isInProgressOrderScrollable()"
+            ref="infiniteScrollRef"
+          >
+            <ion-infinite-scroll-content
+              loading-spinner="crescent"
+              :loading-text="translate('Loading')"
+            />
           </ion-infinite-scroll>
         </div>
       </div>
@@ -206,7 +511,13 @@
         <ion-spinner name="crescent"></ion-spinner>
       </div>
       <template v-else-if="inProgressOrders.total">
-        <ion-fab v-if="!isForceScanEnabled" class="mobile-only" vertical="bottom" horizontal="end" slot="fixed">
+        <ion-fab
+          v-if="!isForceScanEnabled"
+          class="mobile-only"
+          vertical="bottom"
+          horizontal="end"
+          slot="fixed"
+        >
           <ion-fab-button @click="packOrders()">
             <ion-icon :icon="checkmarkDoneOutline" />
           </ion-fab-button>
@@ -220,12 +531,24 @@
     <ion-footer v-if="selectedPicklistId && inProgressOrders.total">
       <ion-toolbar>
         <ion-buttons slot="end">
-          <ion-button fill="outline" color="primary" @click="editPickers(getPicklist(selectedPicklistId))">
+          <ion-button
+            fill="outline"
+            color="primary"
+            @click="editPickers(getPicklist(selectedPicklistId))"
+          >
             <ion-icon slot="start" :icon="pencilOutline" />
             {{ translate("Edit Pickers") }}
           </ion-button>
-          <ion-button fill="solid" color="primary" @click="printPicklist(getPicklist(selectedPicklistId))">
-            <ion-spinner v-if="getPicklist(selectedPicklistId).isGeneratingPicklist" slot="start" name="crescent" />
+          <ion-button
+            fill="solid"
+            color="primary"
+            @click="printPicklist(getPicklist(selectedPicklistId))"
+          >
+            <ion-spinner
+              v-if="getPicklist(selectedPicklistId).isGeneratingPicklist"
+              slot="start"
+              name="crescent"
+            />
             <ion-icon v-else slot="start" :icon="printOutline" />
             {{ translate("Print Picklist") }}
           </ion-button>
@@ -268,8 +591,8 @@ import {
   alertController,
   popoverController,
   modalController,
-} from '@ionic/vue';
-import { computed, defineComponent } from 'vue';
+} from "@ionic/vue";
+import { computed, defineComponent } from "vue";
 import {
   addOutline,
   caretDownOutline,
@@ -286,35 +609,46 @@ import {
   optionsOutline,
   pricetagOutline,
   printOutline,
-  trashBinOutline
-} from 'ionicons/icons'
+  trashBinOutline,
+} from "ionicons/icons";
 import PackagingPopover from "@/views/PackagingPopover.vue";
-import { mapGetters, useStore } from 'vuex';
-import { copyToClipboard, getFeatures, getFacilityFilter, hasActiveFilters, showToast } from '@/utils';
-import { isKit } from '@/utils/order'
-import { hasError } from '@/adapter';
-import { getProductIdentificationValue, DxpShopifyImg, translate, useProductIdentificationStore, useUserStore } from '@hotwax/dxp-components';
-import ViewSizeSelector from '@/components/ViewSizeSelector.vue';
-import emitter from '@/event-bus';
-import { UtilService } from '@/services/UtilService';
-import { DateTime } from 'luxon';
-import logger from '@/logger';
-import { Actions, hasPermission } from '@/authorization'
-import EditPickersModal from '@/components/EditPickersModal.vue';
-import ShipmentBoxTypePopover from '@/components/ShipmentBoxTypePopover.vue'
-import OrderActionsPopover from '@/components/OrderActionsPopover.vue'
-import ShippingLabelErrorModal from '@/components/ShippingLabelErrorModal.vue'
-import ReportIssuePopover from '@/components/ReportIssuePopover.vue'
-import ShipmentBoxPopover from '@/components/ShipmentBoxPopover.vue'
+import { mapGetters, useStore } from "vuex";
+import {
+  copyToClipboard,
+  getFeatures,
+  getFacilityFilter,
+  hasActiveFilters,
+  showToast,
+} from "@/utils";
+import { isKit } from "@/utils/order";
+import { hasError } from "@/adapter";
+import {
+  getProductIdentificationValue,
+  DxpShopifyImg,
+  translate,
+  useProductIdentificationStore,
+  useUserStore,
+} from "@hotwax/dxp-components";
+import ViewSizeSelector from "@/components/ViewSizeSelector.vue";
+import emitter from "@/event-bus";
+import { UtilService } from "@/services/UtilService";
+import { DateTime } from "luxon";
+import logger from "@/logger";
+import { Actions, hasPermission } from "@/authorization";
+import EditPickersModal from "@/components/EditPickersModal.vue";
+import ShipmentBoxTypePopover from "@/components/ShipmentBoxTypePopover.vue";
+import OrderActionsPopover from "@/components/OrderActionsPopover.vue";
+import ShippingLabelErrorModal from "@/components/ShippingLabelErrorModal.vue";
+import ReportIssuePopover from "@/components/ReportIssuePopover.vue";
+import ShipmentBoxPopover from "@/components/ShipmentBoxPopover.vue";
 import ScanOrderItemModal from "@/components/ScanOrderItemModal.vue";
-import GenerateTrackingCodeModal from '@/components/GenerateTrackingCodeModal.vue';
+import GenerateTrackingCodeModal from "@/components/GenerateTrackingCodeModal.vue";
 import GiftCardActivationModal from "@/components/GiftCardActivationModal.vue";
-import { OrderService } from '@/services/OrderService';
+import { OrderService } from "@/services/OrderService";
 import { useRouter } from "vue-router";
 
-
 export default defineComponent({
-  name: 'InProgress',
+  name: "InProgress",
   components: {
     IonBadge,
     IonButton,
@@ -341,28 +675,28 @@ export default defineComponent({
     IonSearchbar,
     IonSkeletonText,
     IonSpinner,
-    IonThumbnail,   
+    IonThumbnail,
     IonTitle,
     IonToolbar,
     DxpShopifyImg,
-    ViewSizeSelector
+    ViewSizeSelector,
   },
   computed: {
     ...mapGetters({
-      inProgressOrders: 'order/getInProgressOrders',
-      getProduct: 'product/getProduct',
-      rejectReasonOptions: 'util/getRejectReasonOptions',
-      userPreference: 'user/getUserPreference',
-      boxTypeDesc: 'util/getShipmentBoxDesc',
-      getProductStock: 'stock/getProductStock',
-      isForceScanEnabled: 'util/isForceScanEnabled',
-      partialOrderRejectionConfig: 'util/getPartialOrderRejectionConfig',
-      collateralRejectionConfig: 'util/getCollateralRejectionConfig',
-      affectQohConfig: 'util/getAffectQohConfig',
+      inProgressOrders: "order/getInProgressOrders",
+      getProduct: "product/getProduct",
+      rejectReasonOptions: "util/getRejectReasonOptions",
+      userPreference: "user/getUserPreference",
+      boxTypeDesc: "util/getShipmentBoxDesc",
+      getProductStock: "stock/getProductStock",
+      isForceScanEnabled: "util/isForceScanEnabled",
+      partialOrderRejectionConfig: "util/getPartialOrderRejectionConfig",
+      collateralRejectionConfig: "util/getCollateralRejectionConfig",
+      affectQohConfig: "util/getAffectQohConfig",
       excludeOrderBrokerDays: "util/getExcludeOrderBrokerDays",
-      carrierShipmentBoxTypes: 'util/getCarrierShipmentBoxTypes',
-      getShipmentMethodDesc: 'util/getShipmentMethodDesc',
-      isAutoShippingLabelEnabled: 'util/isAutoShippingLabelEnabled',
+      carrierShipmentBoxTypes: "util/getCarrierShipmentBoxTypes",
+      getShipmentMethodDesc: "util/getShipmentMethodDesc",
+      isAutoShippingLabelEnabled: "util/isAutoShippingLabelEnabled",
     }),
   },
   data() {
@@ -370,22 +704,28 @@ export default defineComponent({
       picklists: [] as any,
       defaultShipmentBoxType: {} as any,
       orderBoxes: [] as any,
-      searchedQuery: '',
+      searchedQuery: "",
       addingBoxForShipmentIds: [] as any,
-      selectedPicklistId: '',
+      selectedPicklistId: "",
       isScrollingEnabled: false,
       isRejecting: false,
       rejectEntireOrderReasonId: "REJ_AVOID_ORD_SPLIT",
-      isLoadingOrders: false
-    }
+      isLoadingOrders: false,
+    };
   },
   methods: {
     getTime(time: any) {
       return DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED);
     },
-    getRejectionReasonDescription (rejectionReasonId: string) {
-      const reason = this.rejectReasonOptions?.find((reason: any) => reason.enumId === rejectionReasonId)
-      return reason?.description ? reason.description : reason?.enumDescription ? reason.enumDescription : reason?.enumId;
+    getRejectionReasonDescription(rejectionReasonId: string) {
+      const reason = this.rejectReasonOptions?.find(
+        (reason: any) => reason.enumId === rejectionReasonId
+      );
+      return reason?.description
+        ? reason.description
+        : reason?.enumDescription
+        ? reason.enumDescription
+        : reason?.enumId;
     },
     async openRejectReasonPopover(ev: Event, item: any, order: any) {
       const reportIssuePopover = await popoverController.create({
@@ -400,44 +740,67 @@ export default defineComponent({
       const result = await reportIssuePopover.onDidDismiss();
 
       if (result.data) {
-        this.updateRejectReason(result.data, item, order)
+        this.updateRejectReason(result.data, item, order);
       }
     },
     async fetchKitComponents(orderItem: any) {
-      await this.store.dispatch('product/fetchProductComponents', { productId: orderItem.productId })
-      
+      await this.store.dispatch("product/fetchProductComponents", {
+        productId: orderItem.productId,
+      });
+
       //update the order in order to toggle kit components section
-      const updatedOrder = this.inProgressOrders.list.find((order: any) => order.orderId === orderItem.orderId && order.picklistBinId === orderItem.picklistBinId);
-      const updatedItem = updatedOrder.items.find((item: any) => item.orderItemSeqId === orderItem.orderItemSeqId)
-      updatedItem.showKitComponents = orderItem.showKitComponents ? false : true
+      const updatedOrder = this.inProgressOrders.list.find(
+        (order: any) =>
+          order.orderId === orderItem.orderId &&
+          order.picklistBinId === orderItem.picklistBinId
+      );
+      const updatedItem = updatedOrder.items.find(
+        (item: any) => item.orderItemSeqId === orderItem.orderItemSeqId
+      );
+      updatedItem.showKitComponents = orderItem.showKitComponents
+        ? false
+        : true;
       if (!updatedItem.kitComponents) {
-        updatedItem.kitComponents = this.getProduct(updatedItem.productId).productComponents.map((productComponent: any) => productComponent.productIdTo)
+        updatedItem.kitComponents = this.getProduct(
+          updatedItem.productId
+        ).productComponents.map(
+          (productComponent: any) => productComponent.productIdTo
+        );
       }
-      this.store.dispatch('order/updateInProgressOrder', updatedOrder)
+      this.store.dispatch("order/updateInProgressOrder", updatedOrder);
     },
     async removeRejectionReason(ev: Event, item: any, order: any) {
       delete item["rejectReason"];
       delete item["kitComponents"];
       item.rejectReason = "";
-        order.items.map((orderItem: any) => {
-          if(orderItem.orderItemSeqId === item.orderItemSeqId) {
-            delete orderItem["rejectReason"];
-            delete orderItem["kitComponents"];
-          }
-        })
-        order.hasRejectedItem = order.items.some((item:any) => item.rejectReason);
-        order.hasAllRejectedItem = this.isEntierOrderRejectionEnabled(order) || order.items.every((item: any) => item.rejectReason)
-      this.store.dispatch('order/updateInProgressOrder', order)
+      order.items.map((orderItem: any) => {
+        if (orderItem.orderItemSeqId === item.orderItemSeqId) {
+          delete orderItem["rejectReason"];
+          delete orderItem["kitComponents"];
+        }
+      });
+      order.hasRejectedItem = order.items.some(
+        (item: any) => item.rejectReason
+      );
+      order.hasAllRejectedItem =
+        this.isEntierOrderRejectionEnabled(order) ||
+        order.items.every((item: any) => item.rejectReason);
+      this.store.dispatch("order/updateInProgressOrder", order);
     },
 
-    async openShipmentBoxPopover(ev: Event, item: any, orderItemSeqId: number, order: any) {
+    async openShipmentBoxPopover(
+      ev: Event,
+      item: any,
+      orderItemSeqId: number,
+      order: any
+    ) {
       const popover = await popoverController.create({
         component: ShipmentBoxPopover,
-        componentProps: { 
-          shipmentPackages: order.shipmentPackages
+        componentProps: {
+          shipmentPackages: order.shipmentPackages,
         },
         showBackdrop: false,
-        event: ev
+        event: ev,
       });
 
       popover.present();
@@ -445,14 +808,29 @@ export default defineComponent({
       const result = await popover.onDidDismiss();
 
       if (result.data && item.selectedBox !== result.data) {
-        this.updateBox(result.data, item, order)
+        this.updateBox(result.data, item, order);
       }
     },
     getErrorMessage() {
-      return this.searchedQuery ? (hasActiveFilters(this.inProgressOrders.query) ? translate("No results found for . Try using different filters.", { searchedQuery: this.searchedQuery }) : translate( "No results found for . Try searching Open or Completed tab instead. If you still can't find what you're looking for, try switching stores.", { searchedQuery: this.searchedQuery, lineBreak: '<br />' })) : translate("doesn't have any orders in progress right now.", { facilityName: this.currentFacility?.facilityName });
+      return this.searchedQuery
+        ? hasActiveFilters(this.inProgressOrders.query)
+          ? translate("No results found for . Try using different filters.", {
+              searchedQuery: this.searchedQuery,
+            })
+          : translate(
+              "No results found for . Try searching Open or Completed tab instead. If you still can't find what you're looking for, try switching stores.",
+              { searchedQuery: this.searchedQuery, lineBreak: "<br />" }
+            )
+        : translate("doesn't have any orders in progress right now.", {
+            facilityName: this.currentFacility?.facilityName,
+          });
     },
     getInProgressOrders() {
-      return JSON.parse(JSON.stringify(this.inProgressOrders.list)).splice(0, (this.inProgressOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
+      return JSON.parse(JSON.stringify(this.inProgressOrders.list)).splice(
+        0,
+        (this.inProgressOrders.query.viewIndex + 1) *
+          (process.env.VUE_APP_VIEW_SIZE as any)
+      );
     },
     async packagingPopover(ev: Event) {
       const popover = await popoverController.create({
@@ -465,7 +843,9 @@ export default defineComponent({
     },
     async packOrder(order: any) {
       if (order.hasRejectedItem) {
-        const itemsToReject = order.items.filter((item: any) => item.rejectReason)
+        const itemsToReject = order.items.filter(
+          (item: any) => item.rejectReason
+        );
         this.reportIssue(order, itemsToReject);
         return;
       }
@@ -475,108 +855,151 @@ export default defineComponent({
       let forceScan = this.isForceScanEnabled;
       if (this.isEntierOrderRejectionEnabled(order)) {
         //no need to scan when all the items are going to reject when partial order rejection is not allowed
-        forceScan = false
+        forceScan = false;
       } else if (forceScan) {
         //no need to scan when all the items are going to reject
-        forceScan = !order.items.every((item: any) => item.rejectReason)
+        forceScan = !order.items.every((item: any) => item.rejectReason);
       }
 
       if (order.hasAllRejectedItem) {
-        await this.rejectEntireOrder(order, updateParameter)
+        await this.rejectEntireOrder(order, updateParameter);
       } else if (forceScan) {
-        await this.scanOrder(order, updateParameter)
+        await this.scanOrder(order, updateParameter);
       } else {
         this.confirmPackOrder(order, updateParameter);
       }
     },
     async rejectEntireOrder(order: any, updateParameter?: string) {
-      emitter.emit('presentLoader');
+      emitter.emit("presentLoader");
       try {
-        const updatedOrderDetail = await this.getUpdatedOrderDetail(order, updateParameter)
+        const updatedOrderDetail = await this.getUpdatedOrderDetail(
+          order,
+          updateParameter
+        );
         const params = {
           shipmentId: order.shipmentId,
           orderId: order.orderId,
           facilityId: order.originFacilityId,
-          rejectedOrderItems: updatedOrderDetail.rejectedOrderItems
-        }
+          rejectedOrderItems: updatedOrderDetail.rejectedOrderItems,
+        };
         const resp = await OrderService.packOrder(params);
 
         if (hasError(resp)) {
-          throw resp.data
+          throw resp.data;
         }
 
         await this.fetchOrderAndPickerInformation();
-        showToast(translate('Order rejected successfully'));
-        return true
-
+        showToast(translate("Order rejected successfully"));
+        return true;
       } catch (err) {
-        logger.error('Failed to reject order', err)
-        showToast(translate('Failed to reject order'))
+        logger.error("Failed to reject order", err);
+        showToast(translate("Failed to reject order"));
       } finally {
         emitter.emit("dismissLoader");
       }
-      return false
+      return false;
     },
-    async confirmPackOrder(order: any, updateParameter?: string, trackingCode?: string) {
-      const confirmPackOrder = await alertController
-        .create({
-          header: translate("Pack order"),
-          message: translate("You are packing an order. Select additional documents that you would like to print.", {space: '<br /><br />'}),
-          inputs: [{
-            name: 'printShippingLabel',
-            type: 'checkbox',
-            label: translate('Shipping labels'),
-            value: 'printShippingLabel',
+    async confirmPackOrder(
+      order: any,
+      updateParameter?: string,
+      trackingCode?: string
+    ) {
+      const confirmPackOrder = await alertController.create({
+        header: translate("Pack order"),
+        message: translate(
+          "You are packing an order. Select additional documents that you would like to print.",
+          { space: "<br /><br />" }
+        ),
+        inputs: [
+          {
+            name: "printShippingLabel",
+            type: "checkbox",
+            label: translate("Shipping labels"),
+            value: "printShippingLabel",
             checked: this.userPreference.printShippingLabel,
-          }, {
-            name: 'printPackingSlip',
-            type: 'checkbox',
-            label: translate('Packing slip'),
-            value: 'printPackingSlip',
-            checked: this.userPreference.printPackingSlip
-          }],
-          buttons: [{
+          },
+          {
+            name: "printPackingSlip",
+            type: "checkbox",
+            label: translate("Packing slip"),
+            value: "printPackingSlip",
+            checked: this.userPreference.printPackingSlip,
+          },
+        ],
+        buttons: [
+          {
             text: translate("Cancel"),
-            role: 'cancel'
-          }, {
+            role: "cancel",
+          },
+          {
             text: translate("Pack"),
-            role: 'confirm',
+            role: "confirm",
             handler: async (data) => {
-              const packingResponse = await this.executePackOrder(order, updateParameter, trackingCode, data)
+              const packingResponse = await this.executePackOrder(
+                order,
+                updateParameter,
+                trackingCode,
+                data
+              );
               if (!packingResponse.isPacked) {
                 //On error in packing, fetching update detail expecially to fetch carrier, shipment method, gteway message etc. If there is error (gatewayMessage not empty) opening Generate tracking code modal to enter tracking detail manually
-                const updatedOrder = await this.store.dispatch('order/updateShipmentPackageDetail', order)
-                await this.generateTrackingCodeForPacking(updatedOrder, updateParameter, data, packingResponse.errors)
+                const updatedOrder = await this.store.dispatch(
+                  "order/updateShipmentPackageDetail",
+                  order
+                );
+                await this.generateTrackingCodeForPacking(
+                  updatedOrder,
+                  updateParameter,
+                  data,
+                  packingResponse.errors
+                );
               }
-            }
-          }]
-        });
+            },
+          },
+        ],
+      });
       return confirmPackOrder.present();
     },
-    async executePackOrder(order: any, updateParameter?: string, trackingCode?: string, documentOptions?: any) {
-      emitter.emit('presentLoader');
+    async executePackOrder(
+      order: any,
+      updateParameter?: string,
+      trackingCode?: string,
+      documentOptions?: any
+    ) {
+      emitter.emit("presentLoader");
       let toast: any;
-      const shipmentIds = [order.shipmentId]
-      const manualTrackingCode = trackingCode
+      const shipmentIds = [order.shipmentId];
+      const manualTrackingCode = trackingCode;
       try {
-        const updatedOrderDetail = await this.getUpdatedOrderDetail(order, updateParameter) as any
+        const updatedOrderDetail = (await this.getUpdatedOrderDetail(
+          order,
+          updateParameter
+        )) as any;
         const params = {
           shipmentId: order.shipmentId,
           orderId: order.orderId,
           facilityId: order.originFacilityId,
           rejectedOrderItems: updatedOrderDetail.rejectedOrderItems,
           shipmentPackageContents: updatedOrderDetail.shipmentPackageContents,
-          trackingCode: manualTrackingCode
-        }
+          trackingCode: manualTrackingCode,
+        };
         const resp = await OrderService.packOrder(params);
-        
+
         //Fetching updated shipment detail after successful packing
-        const updatedOrder = await this.store.dispatch('order/updateShipmentPackageDetail', order)
-       
+        const updatedOrder = await this.store.dispatch(
+          "order/updateShipmentPackageDetail",
+          order
+        );
+
         if (documentOptions.length) {
           // additional parameters for dismiss button and manual dismiss ability
-          toast = await showToast(translate('Order packed successfully. Document generation in process'), { canDismiss: true, manualDismiss: true })
-          toast.present()
+          toast = await showToast(
+            translate(
+              "Order packed successfully. Document generation in process"
+            ),
+            { canDismiss: true, manualDismiss: true }
+          );
+          toast.present();
 
           const shippingLabelPdfUrls: string[] = Array.from(
             new Set(
@@ -586,24 +1009,48 @@ export default defineComponent({
             )
           );
 
-          if (documentOptions.includes('printPackingSlip') && documentOptions.includes('printShippingLabel')) {
+          if (
+            documentOptions.includes("printPackingSlip") &&
+            documentOptions.includes("printShippingLabel")
+          ) {
             if (shippingLabelPdfUrls && shippingLabelPdfUrls.length > 0) {
-              await OrderService.printPackingSlip(shipmentIds)
-              await OrderService.printShippingLabel(shipmentIds, shippingLabelPdfUrls, updatedOrder.shipmentPackages);
+              await OrderService.printPackingSlip(shipmentIds);
+              await OrderService.printShippingLabel(
+                shipmentIds,
+                shippingLabelPdfUrls,
+                updatedOrder.shipmentPackages
+              );
             } else {
-              await OrderService.printShippingLabelAndPackingSlip(shipmentIds, updatedOrder.shipmentPackages)
+              await OrderService.printShippingLabelAndPackingSlip(
+                shipmentIds,
+                updatedOrder.shipmentPackages
+              );
             }
-          } else if (documentOptions.includes('printPackingSlip')) {
-            await OrderService.printPackingSlip(shipmentIds)
-          } else if (documentOptions.includes('printShippingLabel') && !manualTrackingCode && !updatedOrder.missingLabelImage) {
-            await OrderService.printShippingLabel(shipmentIds, shippingLabelPdfUrls, updatedOrder.shipmentPackages);
+          } else if (documentOptions.includes("printPackingSlip")) {
+            await OrderService.printPackingSlip(shipmentIds);
+          } else if (
+            documentOptions.includes("printShippingLabel") &&
+            !manualTrackingCode &&
+            !updatedOrder.missingLabelImage
+          ) {
+            await OrderService.printShippingLabel(
+              shipmentIds,
+              shippingLabelPdfUrls,
+              updatedOrder.shipmentPackages
+            );
           }
 
           const internationalInvoiceUrls: string[] = Array.from(
             new Set(
               updatedOrder.shipmentPackages
-                ?.filter((shipmentPackage: any) => shipmentPackage.internationalInvoiceUrl)
-                .map((shipmentPackage: any) => shipmentPackage.internationalInvoiceUrl) || []
+                ?.filter(
+                  (shipmentPackage: any) =>
+                    shipmentPackage.internationalInvoiceUrl
+                )
+                .map(
+                  (shipmentPackage: any) =>
+                    shipmentPackage.internationalInvoiceUrl
+                ) || []
             )
           );
 
@@ -611,74 +1058,94 @@ export default defineComponent({
             await OrderService.printCustomDocuments(internationalInvoiceUrls);
           }
 
-          toast.dismiss()
+          toast.dismiss();
         } else {
-          showToast(translate('Order packed successfully'));
+          showToast(translate("Order packed successfully"));
         }
         // TODO: handle the case of fetching in progress orders after packing an order
         // when packing an order the API runs too fast and the solr index does not update resulting in having the current packed order in the inProgress section
         await this.fetchOrderAndPickerInformation();
-        return { isPacked: true }
+        return { isPacked: true };
       } catch (err: any) {
         // in case of error, if loader and toast are not dismissed above
-        if (toast) toast.dismiss()
-        showToast(translate('Failed to pack order'))
-        logger.error('Failed to pack order', err)
-        return {isPacked: false, errors: err?.response?.data?.errors}
+        if (toast) toast.dismiss();
+        showToast(translate("Failed to pack order"));
+        logger.error("Failed to pack order", err);
+        return { isPacked: false, errors: err?.response?.data?.errors };
       } finally {
         emitter.emit("dismissLoader");
       }
     },
     async packOrders() {
-      const alert = await alertController
-        .create({
-          header: translate("Pack orders"),
-          message: translate("You are packing orders. Select additional documents that you would like to print.", {count: this.inProgressOrders.list.length, space: '<br /><br />'}),
-          inputs: [{
-            name: 'printShippingLabel',
-            type: 'checkbox',
-            label: translate('Shipping labels'),
-            value: 'printShippingLabel',
+      const alert = await alertController.create({
+        header: translate("Pack orders"),
+        message: translate(
+          "You are packing orders. Select additional documents that you would like to print.",
+          { count: this.inProgressOrders.list.length, space: "<br /><br />" }
+        ),
+        inputs: [
+          {
+            name: "printShippingLabel",
+            type: "checkbox",
+            label: translate("Shipping labels"),
+            value: "printShippingLabel",
             checked: this.userPreference.printShippingLabel,
-          }, {
-            name: 'printPackingSlip',
-            type: 'checkbox',
-            label: translate('Packing slip'),
-            value: 'printPackingSlip',
-            checked: this.userPreference.printPackingSlip
-          }],
-          buttons: [{
+          },
+          {
+            name: "printPackingSlip",
+            type: "checkbox",
+            label: translate("Packing slip"),
+            value: "printPackingSlip",
+            checked: this.userPreference.printPackingSlip,
+          },
+        ],
+        buttons: [
+          {
             text: translate("Cancel"),
-            role: 'cancel'
-          }, {
+            role: "cancel",
+          },
+          {
             text: translate("Pack"),
-            role: 'confirm',
+            role: "confirm",
             handler: async (data) => {
-              emitter.emit('presentLoader');
-              let orderList = JSON.parse(JSON.stringify(this.inProgressOrders.list))
-              
+              emitter.emit("presentLoader");
+              let orderList = JSON.parse(
+                JSON.stringify(this.inProgressOrders.list)
+              );
+
               let toast: any;
               // Considering only unique shipment IDs
               // TODO check reason for redundant shipment IDs
-              const shipments = [] as any
+              const shipments = [] as any;
               for (const order of orderList) {
-                const updatedOrderDetail = await this.getUpdatedOrderDetail(order) as any
+                const updatedOrderDetail = (await this.getUpdatedOrderDetail(
+                  order
+                )) as any;
                 shipments.push({
                   shipmentId: order.shipmentId,
                   orderId: order.orderId,
                   facilityId: order.originFacilityId,
                   rejectedOrderItems: updatedOrderDetail.rejectedOrderItems,
-                  shipmentPackageContents: updatedOrderDetail.shipmentPackageContents,
-                })
+                  shipmentPackageContents:
+                    updatedOrderDetail.shipmentPackageContents,
+                });
               }
-              const shipmentIds = shipments.map((shipment: any) => shipment.shipmentId)
+              const shipmentIds = shipments.map(
+                (shipment: any) => shipment.shipmentId
+              );
 
               const internationalInvoiceUrls: string[] = Array.from(
                 new Set(
                   orderList
                     .flatMap((order: any) => order.shipmentPackages ?? []) // Flatten all shipments
-                    .filter((shipmentPackage: any) => shipmentPackage.internationalInvoiceUrl) // Filter shipments with invoice URL
-                    .map((shipmentPackage: any) => shipmentPackage.internationalInvoiceUrl) // Extract URLs
+                    .filter(
+                      (shipmentPackage: any) =>
+                        shipmentPackage.internationalInvoiceUrl
+                    ) // Filter shipments with invoice URL
+                    .map(
+                      (shipmentPackage: any) =>
+                        shipmentPackage.internationalInvoiceUrl
+                    ) // Extract URLs
                 )
               );
 
@@ -686,114 +1153,185 @@ export default defineComponent({
                 new Set(
                   orderList
                     .flatMap((order: any) => order.shipmentPackages ?? []) // Flatten all shipments
-                    .filter((shipmentPackage: any) => shipmentPackage.labelImageUrl) // Filter shipments with label image URL
-                    .map((shipmentPackage: any) => shipmentPackage.labelImageUrl) // Extract URLs
+                    .filter(
+                      (shipmentPackage: any) => shipmentPackage.labelImageUrl
+                    ) // Filter shipments with label image URL
+                    .map(
+                      (shipmentPackage: any) => shipmentPackage.labelImageUrl
+                    ) // Extract URLs
                 )
               );
 
-              const shipmentPackages = orderList.
-              map((order: any) =>
-                [...new Set(order.shipmentPackages
-                  .map((shipmentPackage: any) => shipmentPackage)
-                )]
-              ).flat() as Array<string>;
+              const shipmentPackages = orderList
+                .map((order: any) => [
+                  ...new Set(
+                    order.shipmentPackages.map(
+                      (shipmentPackage: any) => shipmentPackage
+                    )
+                  ),
+                ])
+                .flat() as Array<string>;
 
               try {
                 const resp = await OrderService.packOrders({
-                  shipments
+                  shipments,
                 });
 
                 if (hasError(resp)) {
-                  throw resp.data
+                  throw resp.data;
                 }
 
                 //Generate documents only for successfully packed shipments, not for those where packing failed.
                 const packedShipmentIds = resp.data?.packedShipmentIds ?? [];
 
                 if (!packedShipmentIds.length) {
-                  throw resp.data
+                  throw resp.data;
                 }
 
                 if (data.length) {
                   // additional parameters for dismiss button and manual dismiss ability
-                  toast = await showToast(translate('Order packed successfully. Document generation in process'), { canDismiss: true, manualDismiss: true })
-                  toast.present()
-                  if (data.includes('printPackingSlip') && data.includes('printShippingLabel')) {
-                    if (shippingLabelPdfUrls && shippingLabelPdfUrls.length > 0) {
-                      await OrderService.printPackingSlip(packedShipmentIds)
-                      await OrderService.printShippingLabel(packedShipmentIds, shippingLabelPdfUrls, shipmentPackages);
+                  toast = await showToast(
+                    translate(
+                      "Order packed successfully. Document generation in process"
+                    ),
+                    { canDismiss: true, manualDismiss: true }
+                  );
+                  toast.present();
+                  if (
+                    data.includes("printPackingSlip") &&
+                    data.includes("printShippingLabel")
+                  ) {
+                    if (
+                      shippingLabelPdfUrls &&
+                      shippingLabelPdfUrls.length > 0
+                    ) {
+                      await OrderService.printPackingSlip(packedShipmentIds);
+                      await OrderService.printShippingLabel(
+                        packedShipmentIds,
+                        shippingLabelPdfUrls,
+                        shipmentPackages
+                      );
                     } else {
-                      await OrderService.printShippingLabelAndPackingSlip(packedShipmentIds, shipmentPackages)
+                      await OrderService.printShippingLabelAndPackingSlip(
+                        packedShipmentIds,
+                        shipmentPackages
+                      );
                     }
-                  } else if (data.includes('printPackingSlip')) {
-                    await OrderService.printPackingSlip(packedShipmentIds)
-                  } else if (data.includes('printShippingLabel')) {
-                    await OrderService.printShippingLabel(packedShipmentIds, shippingLabelPdfUrls, shipmentPackages);
+                  } else if (data.includes("printPackingSlip")) {
+                    await OrderService.printPackingSlip(packedShipmentIds);
+                  } else if (data.includes("printShippingLabel")) {
+                    await OrderService.printShippingLabel(
+                      packedShipmentIds,
+                      shippingLabelPdfUrls,
+                      shipmentPackages
+                    );
                   }
-                  //print custom documents like international invoice 
-                  await OrderService.printCustomDocuments(internationalInvoiceUrls);
+                  //print custom documents like international invoice
+                  await OrderService.printCustomDocuments(
+                    internationalInvoiceUrls
+                  );
 
-                  toast.dismiss()
+                  toast.dismiss();
                 } else {
-                  showToast(translate('Order packed successfully'));
+                  showToast(translate("Order packed successfully"));
                 }
                 await this.fetchOrderAndPickerInformation();
               } catch (err) {
                 // in case of error, if loader and toast are not dismissed above
-                if (toast) toast.dismiss()
-                emitter.emit('dismissLoader');
-                showToast(translate('Failed to pack orders'))
-                logger.error('Failed to pack orders', err)
+                if (toast) toast.dismiss();
+                emitter.emit("dismissLoader");
+                showToast(translate("Failed to pack orders"));
+                logger.error("Failed to pack orders", err);
               } finally {
-                emitter.emit("dismissLoader")
+                emitter.emit("dismissLoader");
               }
-            }
-          }]
-        });
+            },
+          },
+        ],
+      });
       return alert.present();
     },
-    
+
     async reportIssue(order: any, itemsToReject: any) {
       let message;
       const rejectedItem = itemsToReject[0];
-      const productName = rejectedItem.productName
+      const productName = rejectedItem.productName;
 
       let ordersCount = 0;
 
-      if(this.collateralRejectionConfig) {
+      if (this.collateralRejectionConfig) {
         // TODO: ordersCount is not correct as current we are identifying orders count by only checking items visible on UI and not other orders
-        ordersCount = this.inProgressOrders.list.map((inProgressOrder: any) => inProgressOrder.items.filter((item: any) => itemsToReject.some((itemToReject: any) => itemToReject.productId === item.productId) && item.shipmentId !== order.shipmentId))?.filter((item: any) => item.length).length;
+        ordersCount = this.inProgressOrders.list
+          .map((inProgressOrder: any) =>
+            inProgressOrder.items.filter(
+              (item: any) =>
+                itemsToReject.some(
+                  (itemToReject: any) =>
+                    itemToReject.productId === item.productId
+                ) && item.shipmentId !== order.shipmentId
+            )
+          )
+          ?.filter((item: any) => item.length).length;
       }
 
       if (itemsToReject.length === 1 && ordersCount) {
-        message = translate("is identified as unfulfillable. other containing this product will be unassigned from this store and sent to be rebrokered.", { productName, space: '<br /><br />', orders: ordersCount, orderText: ordersCount > 1 ? 'orders' : 'order' })
+        message = translate(
+          "is identified as unfulfillable. other containing this product will be unassigned from this store and sent to be rebrokered.",
+          {
+            productName,
+            space: "<br /><br />",
+            orders: ordersCount,
+            orderText: ordersCount > 1 ? "orders" : "order",
+          }
+        );
       } else if (itemsToReject.length === 1 && !ordersCount) {
-        message = translate("is identified as unfulfillable. This order item will be unassigned from this store and sent to be rebrokered.", { productName, space: '<br /><br />' })
+        message = translate(
+          "is identified as unfulfillable. This order item will be unassigned from this store and sent to be rebrokered.",
+          { productName, space: "<br /><br />" }
+        );
       } else if (itemsToReject.length > 1 && ordersCount) {
-        message = translate(", and other products are identified as unfulfillable. other containing these products will be unassigned from this store and sent to be rebrokered.", { productName, products: itemsToReject.length - 1, space: '<br /><br />', orders: ordersCount, orderText: ordersCount > 1 ? 'orders' : 'order' })
+        message = translate(
+          ", and other products are identified as unfulfillable. other containing these products will be unassigned from this store and sent to be rebrokered.",
+          {
+            productName,
+            products: itemsToReject.length - 1,
+            space: "<br /><br />",
+            orders: ordersCount,
+            orderText: ordersCount > 1 ? "orders" : "order",
+          }
+        );
       } else {
-        message = translate(", and other products are identified as unfulfillable. These order items will be unassigned from this store and sent to be rebrokered.", { productName, products: itemsToReject.length - 1, space: '<br /><br />' })
+        message = translate(
+          ", and other products are identified as unfulfillable. These order items will be unassigned from this store and sent to be rebrokered.",
+          {
+            productName,
+            products: itemsToReject.length - 1,
+            space: "<br /><br />",
+          }
+        );
       }
-      const alert = await alertController
-        .create({
-          header: translate("Report an issue"),
-          message,
-          buttons: [{
+      const alert = await alertController.create({
+        header: translate("Report an issue"),
+        message,
+        buttons: [
+          {
             text: translate("Cancel"),
-            role: 'cancel'
-          }, {
+            role: "cancel",
+          },
+          {
             text: translate("Report"),
-            role: 'confirm',
-            handler: async() => {
+            role: "confirm",
+            handler: async () => {
               await this.initiatePackOrder(order, "report");
-            }
-          }]
-        });
-      
+            },
+          },
+        ],
+      });
+
       return alert.present();
     },
-    async findInProgressOrders () {
-      await this.store.dispatch('order/findInProgressOrders')
+    async findInProgressOrders() {
+      await this.store.dispatch("order/findInProgressOrders");
     },
     getUpdatedOrderDetail(order: any, updateParameter?: string) {
       const items = JSON.parse(JSON.stringify(order.items));
@@ -801,53 +1339,61 @@ export default defineComponent({
       const rejectedOrderItems = [] as any;
       const shipmentPackageContents = [] as any;
       items.map((item: any, index: number) => {
-        const shipmentPackage = order.shipmentPackages.find((shipmentPackage: any) => shipmentPackage.packageName === item.selectedBox)
-        if (updateParameter === 'report' && item.rejectReason) {
+        const shipmentPackage = order.shipmentPackages.find(
+          (shipmentPackage: any) =>
+            shipmentPackage.packageName === item.selectedBox
+        );
+        if (updateParameter === "report" && item.rejectReason) {
           const rejectedItemInfo = {
-            "orderId": item.orderId,
-            "orderItemSeqId": item.orderItemSeqId,
-            "shipmentId": item.shipmentId,
-            "shipmentItemSeqId": item.shipmentItemSeqId,
-            "productId": item.productId,
-            "facilityId": this.currentFacility?.facilityId,
-            "updateQOH": this.affectQohConfig || false,
-            "maySplit": this.isEntierOrderRejectionEnabled(order) ? "N" : "Y",
-            "cascadeRejectByProduct": this.collateralRejectionConfig ? "Y" : "N",
-            "rejectionReasonId": item.rejectReason,
-            "kitComponents": item.kitComponents,
-            "comments": "Store Rejected Inventory"
-          } as any
-          
+            orderId: item.orderId,
+            orderItemSeqId: item.orderItemSeqId,
+            shipmentId: item.shipmentId,
+            shipmentItemSeqId: item.shipmentItemSeqId,
+            productId: item.productId,
+            facilityId: this.currentFacility?.facilityId,
+            updateQOH: this.affectQohConfig || false,
+            maySplit: this.isEntierOrderRejectionEnabled(order) ? "N" : "Y",
+            cascadeRejectByProduct: this.collateralRejectionConfig ? "Y" : "N",
+            rejectionReasonId: item.rejectReason,
+            kitComponents: item.kitComponents,
+            comments: "Store Rejected Inventory",
+          } as any;
+
           if (this.excludeOrderBrokerDays !== undefined) {
-            rejectedItemInfo["excludeOrderFacilityDuration"] = this.excludeOrderBrokerDays
+            rejectedItemInfo["excludeOrderFacilityDuration"] =
+              this.excludeOrderBrokerDays;
           }
-          rejectedOrderItems.push(rejectedItemInfo)
+          rejectedOrderItems.push(rejectedItemInfo);
         } else if (item.selectedBox !== item.currentBox) {
           shipmentPackageContents.push({
             shipmentId: item.shipmentId,
             shipmentItemSeqId: item.shipmentItemSeqId,
             shipmentPackageSeqId: shipmentPackage.shipmentPackageSeqId,
-            quantity: item.quantity
-          })
+            quantity: item.quantity,
+          });
         }
-      })
-      return { rejectedOrderItems, shipmentPackageContents }
+      });
+      return { rejectedOrderItems, shipmentPackageContents };
     },
     updateRejectReason(updatedReason: string, item: any, order: any) {
       item.rejectReason = updatedReason;
       order.items.map((orderItem: any) => {
-        if(orderItem.orderItemSeqId === item.orderItemSeqId) {
+        if (orderItem.orderItemSeqId === item.orderItemSeqId) {
           orderItem.rejectReason = updatedReason;
         }
-      })
-      order.hasRejectedItem = true
-      order.hasAllRejectedItem = this.isEntierOrderRejectionEnabled(order) || order.items.every((item: any) => item.rejectReason)
-      this.store.dispatch('order/updateInProgressOrder', order)
+      });
+      order.hasRejectedItem = true;
+      order.hasAllRejectedItem =
+        this.isEntierOrderRejectionEnabled(order) ||
+        order.items.every((item: any) => item.rejectReason);
+      this.store.dispatch("order/updateInProgressOrder", order);
     },
     rejectKitComponent(order: any, item: any, componentProductId: string) {
-      let kitComponents = item.kitComponents ? item.kitComponents : []
+      let kitComponents = item.kitComponents ? item.kitComponents : [];
       if (kitComponents.includes(componentProductId)) {
-        kitComponents = kitComponents.filter((rejectedComponent: any) => rejectedComponent !== componentProductId)
+        kitComponents = kitComponents.filter(
+          (rejectedComponent: any) => rejectedComponent !== componentProductId
+        );
       } else {
         kitComponents.push(componentProductId);
       }
@@ -856,21 +1402,21 @@ export default defineComponent({
         if (orderItem.orderItemSeqId === item.orderItemSeqId) {
           orderItem.kitComponents = kitComponents;
         }
-      })
-      this.store.dispatch('order/updateInProgressOrder', order)
+      });
+      this.store.dispatch("order/updateInProgressOrder", order);
     },
     isEntierOrderRejectionEnabled(order: any) {
-      return !this.partialOrderRejectionConfig && order.hasRejectedItem
+      return !this.partialOrderRejectionConfig && order.hasRejectedItem;
     },
-    
+
     updateBox(updatedBox: string, item: any, order: any) {
       item.selectedBox = updatedBox;
       order.items.map((orderItem: any) => {
-        if(orderItem.orderItemSeqId === item.orderItemSeqId) {
+        if (orderItem.orderItemSeqId === item.orderItemSeqId) {
           orderItem.selectedBox = updatedBox;
         }
-      })
-      this.store.dispatch('order/updateInProgressOrder', order)
+      });
+      this.store.dispatch("order/updateInProgressOrder", order);
     },
     async fetchPickersInformation() {
       let pageIndex = 0;
@@ -882,22 +1428,31 @@ export default defineComponent({
           const payload = {
             originFacilityId: this.currentFacility?.facilityId,
             statusId: "SHIPMENT_APPROVED",
-            "shipmentMethodTypeId": "STOREPICKUP",
-            "shipmentMethodTypeId_op": "equals",
-            "shipmentMethodTypeId_not": "Y",
+            shipmentMethodTypeId: "STOREPICKUP",
+            shipmentMethodTypeId_op: "equals",
+            shipmentMethodTypeId_not: "Y",
             pageIndex, // Ensure updated pageIndex is used
-            pageSize: 50
+            pageSize: 50,
           };
 
           resp = await OrderService.fetchPicklists(payload);
 
           if (!hasError(resp)) {
             resp.data?.forEach((shipment: any) => {
-              if (shipment?.order?.statusId === "ORDER_APPROVED" && shipment?.order?.productStoreId === this.currentEComStore.productStoreId) {
+              if (
+                shipment?.order?.statusId === "ORDER_APPROVED" &&
+                shipment?.order?.productStoreId ===
+                  this.currentEComStore.productStoreId
+              ) {
                 shipment?.picklistShipment?.forEach((picklistShipment: any) => {
                   if (!picklistInfo[picklistShipment.picklistId]) {
-                    const picklistRoles = picklistShipment?.picklist?.roles.filter((role: any) => !role.thruDate)
-                    const pickerIds = (picklistRoles ?? []).map((role: any) => role?.partyId);
+                    const picklistRoles =
+                      picklistShipment?.picklist?.roles.filter(
+                        (role: any) => !role.thruDate
+                      );
+                    const pickerIds = (picklistRoles ?? []).map(
+                      (role: any) => role?.partyId
+                    );
 
                     const pickersName = (picklistRoles ?? [])
                       .map((role: any) => {
@@ -915,12 +1470,13 @@ export default defineComponent({
                       ...picklistShipment.picklist,
                       id: picklistShipment.picklistId,
                       date: picklistShipment.picklist?.picklistDate
-                        ? DateTime.fromMillis(picklistShipment.picklist.picklistDate).toLocaleString(DateTime.TIME_SIMPLE)
+                        ? DateTime.fromMillis(
+                            picklistShipment.picklist.picklistDate
+                          ).toLocaleString(DateTime.TIME_SIMPLE)
                         : null,
                       pickersName,
-                      pickerIds
+                      pickerIds,
                     };
-
                   }
                 });
               }
@@ -936,22 +1492,31 @@ export default defineComponent({
         // Assign the processed picklists to `this.picklists`
         this.picklists = Object.values(picklistInfo);
         if (this.selectedPicklistId) {
-          const selectedPicklist = this.picklists.find((picklist: any) => picklist.id === this.selectedPicklistId)
-          this.selectedPicklistId = selectedPicklist ? selectedPicklist.id : ""
+          const selectedPicklist = this.picklists.find(
+            (picklist: any) => picklist.id === this.selectedPicklistId
+          );
+          this.selectedPicklistId = selectedPicklist ? selectedPicklist.id : "";
         }
       } catch (err) {
-        logger.error('Failed to fetch picklists', err);
+        logger.error("Failed to fetch picklists", err);
       }
     },
     getPicklist(id: string) {
-      return this.picklists.find((picklist: any) => picklist.id === id)
+      return this.picklists.find((picklist: any) => picklist.id === id);
     },
     enableScrolling() {
-      const parentElement = (this as any).$refs.contentRef.$el
-      const scrollEl = parentElement.shadowRoot.querySelector("main[part='scroll']")
-      let scrollHeight = scrollEl.scrollHeight, infiniteHeight = (this as any).$refs.infiniteScrollRef.$el.offsetHeight, scrollTop = scrollEl.scrollTop, threshold = 100, height = scrollEl.offsetHeight
-      const distanceFromInfinite = scrollHeight - infiniteHeight - scrollTop - threshold - height
-      if(distanceFromInfinite < 0) {
+      const parentElement = (this as any).$refs.contentRef.$el;
+      const scrollEl = parentElement.shadowRoot.querySelector(
+        "main[part='scroll']"
+      );
+      let scrollHeight = scrollEl.scrollHeight,
+        infiniteHeight = (this as any).$refs.infiniteScrollRef.$el.offsetHeight,
+        scrollTop = scrollEl.scrollTop,
+        threshold = 100,
+        height = scrollEl.offsetHeight;
+      const distanceFromInfinite =
+        scrollHeight - infiniteHeight - scrollTop - threshold - height;
+      if (distanceFromInfinite < 0) {
         this.isScrollingEnabled = false;
       } else {
         this.isScrollingEnabled = true;
@@ -962,104 +1527,127 @@ export default defineComponent({
       if (!(this.isScrollingEnabled && this.isInProgressOrderScrollable())) {
         await event.target.complete();
       }
-      const inProgressOrdersQuery = JSON.parse(JSON.stringify(this.inProgressOrders.query))
+      const inProgressOrdersQuery = JSON.parse(
+        JSON.stringify(this.inProgressOrders.query)
+      );
       inProgressOrdersQuery.viewIndex++;
-      await this.store.dispatch('order/updateInProgressIndex', { ...inProgressOrdersQuery })
+      await this.store.dispatch("order/updateInProgressIndex", {
+        ...inProgressOrdersQuery,
+      });
       event.target.complete();
     },
     isInProgressOrderScrollable() {
-      return ((this.inProgressOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any)) <  this.inProgressOrders.query.viewSize;
+      return (
+        (this.inProgressOrders.query.viewIndex + 1) *
+          (process.env.VUE_APP_VIEW_SIZE as any) <
+        this.inProgressOrders.query.viewSize
+      );
     },
     async updateSelectedPicklist(id: string) {
-      const inProgressOrdersQuery = JSON.parse(JSON.stringify(this.inProgressOrders.query))
+      const inProgressOrdersQuery = JSON.parse(
+        JSON.stringify(this.inProgressOrders.query)
+      );
 
       // making view size default when changing the shipment method to correctly fetch orders
-      inProgressOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE
-      inProgressOrdersQuery.selectedPicklist = id
-      inProgressOrdersQuery.viewIndex = 0
+      inProgressOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE;
+      inProgressOrdersQuery.selectedPicklist = id;
+      inProgressOrdersQuery.viewIndex = 0;
 
-      this.store.dispatch('order/updateInProgressQuery', { ...inProgressOrdersQuery })
+      this.store.dispatch("order/updateInProgressQuery", {
+        ...inProgressOrdersQuery,
+      });
     },
     async fetchDefaultShipmentBox() {
-      let defaultBoxTypeId = 'YOURPACKNG'
-      let defaultBoxType = {}
+      let defaultBoxTypeId = "YOURPACKNG";
+      let defaultBoxType = {};
 
       try {
         let resp = await UtilService.fetchDefaultShipmentBox({
           systemResourceId: "shipment",
           systemPropertyId: "shipment.default.boxtype",
           fieldsToSelect: ["systemPropertyValue", "systemResourceId"],
-          pageSize: 1
-        })
+          pageSize: 1,
+        });
 
-        if(!hasError(resp)) {
-          defaultBoxTypeId = resp.data?.[0].systemPropertyValue
+        if (!hasError(resp)) {
+          defaultBoxTypeId = resp.data?.[0].systemPropertyValue;
         } else {
-          throw resp.data
+          throw resp.data;
         }
-        
+
         const payload = {
-          "shipmentBoxTypeId": defaultBoxTypeId,
-          "pageSize": 1
-        }
+          shipmentBoxTypeId: defaultBoxTypeId,
+          pageSize: 1,
+        };
         resp = await UtilService.fetchShipmentBoxType(payload);
         if (!hasError(resp)) {
           defaultBoxType = resp.data[0];
         }
       } catch (err) {
-        logger.error('Failed to fetch default shipment box type information', err)
+        logger.error(
+          "Failed to fetch default shipment box type information",
+          err
+        );
       }
 
       return defaultBoxType;
     },
     async addShipmentBox(order: any) {
-      this.addingBoxForShipmentIds.push(order.shipmentId)
+      this.addingBoxForShipmentIds.push(order.shipmentId);
 
-      const { carrierPartyId, shipmentMethodTypeId } = order
-      
-      if(!Object.keys(this.defaultShipmentBoxType).length) {
-        this.defaultShipmentBoxType = await this.fetchDefaultShipmentBox() as any;
+      const { carrierPartyId, shipmentMethodTypeId } = order;
+
+      if (!Object.keys(this.defaultShipmentBoxType).length) {
+        this.defaultShipmentBoxType =
+          (await this.fetchDefaultShipmentBox()) as any;
       }
 
       let packageName = "A";
-      const packageNames = order?.shipmentPackages.
-          filter((shipmentPackage:any) => shipmentPackage.packageName).
-          map((shipmentPackage:any) => shipmentPackage.packageName);
+      const packageNames = order?.shipmentPackages
+        .filter((shipmentPackage: any) => shipmentPackage.packageName)
+        .map((shipmentPackage: any) => shipmentPackage.packageName);
       if (packageNames && packageNames.length) {
-          packageNames.sort((a:any, b:any) => b.localeCompare(a));
-          packageName = String.fromCharCode(packageNames[0].charCodeAt(0) + 1);
+        packageNames.sort((a: any, b: any) => b.localeCompare(a));
+        packageName = String.fromCharCode(packageNames[0].charCodeAt(0) + 1);
       }
 
       const params = {
         shipmentId: order.shipmentId,
         shipmentBoxTypeId: this.defaultShipmentBoxType?.shipmentBoxTypeId,
-        boxLength	: this.defaultShipmentBoxType?.boxLength,
-        boxHeight	: this.defaultShipmentBoxType?.boxHeight,
-        boxWidth	: this.defaultShipmentBoxType?.boxWidth,
-        weightUomId :	this.defaultShipmentBoxType?.weightUomId,
-        dimensionUomId : this.defaultShipmentBoxType?.dimensionUomId,
+        boxLength: this.defaultShipmentBoxType?.boxLength,
+        boxHeight: this.defaultShipmentBoxType?.boxHeight,
+        boxWidth: this.defaultShipmentBoxType?.boxWidth,
+        weightUomId: this.defaultShipmentBoxType?.weightUomId,
+        dimensionUomId: this.defaultShipmentBoxType?.dimensionUomId,
         packageName,
-        dateCreated: DateTime.now().toMillis()
-      } as any
+        dateCreated: DateTime.now().toMillis(),
+      } as any;
 
-      carrierPartyId && (params['carrierPartyId'] = carrierPartyId)
-      shipmentMethodTypeId && (params['shipmentMethodTypeId'] = shipmentMethodTypeId)
+      carrierPartyId && (params["carrierPartyId"] = carrierPartyId);
+      shipmentMethodTypeId &&
+        (params["shipmentMethodTypeId"] = shipmentMethodTypeId);
 
       try {
-        const resp = await OrderService.addShipmentBox(params)
+        const resp = await OrderService.addShipmentBox(params);
 
-        if(!hasError(resp)) {
-          showToast(translate('Box added successfully'))
+        if (!hasError(resp)) {
+          showToast(translate("Box added successfully"));
           // TODO: only update the order in which the box is added instead of fetching all the inProgress orders
-          await Promise.all([this.fetchPickersInformation(), this.findInProgressOrders()])
+          await Promise.all([
+            this.fetchPickersInformation(),
+            this.findInProgressOrders(),
+          ]);
         } else {
-          throw resp.data
+          throw resp.data;
         }
       } catch (err) {
-        showToast(translate('Failed to add box'))
-        logger.error('Failed to add box', err)
+        showToast(translate("Failed to add box"));
+        logger.error("Failed to add box", err);
       }
-      this.addingBoxForShipmentIds.splice(this.addingBoxForShipmentIds.indexOf(order.shipmentId), 1)
+      this.addingBoxForShipmentIds.splice(
+        this.addingBoxForShipmentIds.indexOf(order.shipmentId),
+        1
+      );
     },
     getShipmentPackageType(order: any, shipmentPackage: any) {
       let packageType = shipmentPackage.shipmentBoxTypeId;
@@ -1070,39 +1658,53 @@ export default defineComponent({
       return packageType;
     },
     getShipmentBoxTypes(carrierPartyId: string) {
-      return this.carrierShipmentBoxTypes[carrierPartyId] ? this.carrierShipmentBoxTypes[carrierPartyId] : [];
+      return this.carrierShipmentBoxTypes[carrierPartyId]
+        ? this.carrierShipmentBoxTypes[carrierPartyId]
+        : [];
     },
     async updateQueryString(queryString: string) {
-      const inProgressOrdersQuery = JSON.parse(JSON.stringify(this.inProgressOrders.query))
+      const inProgressOrdersQuery = JSON.parse(
+        JSON.stringify(this.inProgressOrders.query)
+      );
 
-      inProgressOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE
-      inProgressOrdersQuery.queryString = queryString
-      await this.store.dispatch('order/updateInProgressQuery', { ...inProgressOrdersQuery })
+      inProgressOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE;
+      inProgressOrdersQuery.queryString = queryString;
+      await this.store.dispatch("order/updateInProgressQuery", {
+        ...inProgressOrdersQuery,
+      });
       this.searchedQuery = queryString;
     },
     async updateOrderQuery(size?: any, queryString?: any, hideLoader = false) {
-      const inProgressOrdersQuery = JSON.parse(JSON.stringify(this.inProgressOrders.query))
+      const inProgressOrdersQuery = JSON.parse(
+        JSON.stringify(this.inProgressOrders.query)
+      );
 
-      size && (inProgressOrdersQuery.viewSize = size)
-      queryString && (inProgressOrdersQuery.queryString = '')
-      inProgressOrdersQuery.viewIndex = 0 // If the size changes, list index should be reintialised
-      inProgressOrdersQuery.selectedPicklist = this.selectedPicklistId
-      await this.store.dispatch('order/updateInProgressQuery', { ...inProgressOrdersQuery, hideLoader })
+      size && (inProgressOrdersQuery.viewSize = size);
+      queryString && (inProgressOrdersQuery.queryString = "");
+      inProgressOrdersQuery.viewIndex = 0; // If the size changes, list index should be reintialised
+      inProgressOrdersQuery.selectedPicklist = this.selectedPicklistId;
+      await this.store.dispatch("order/updateInProgressQuery", {
+        ...inProgressOrdersQuery,
+        hideLoader,
+      });
     },
     async initialiseOrderQuery() {
-      await this.updateOrderQuery(process.env.VUE_APP_VIEW_SIZE, '')
+      await this.updateOrderQuery(process.env.VUE_APP_VIEW_SIZE, "");
     },
     async printPicklist(picklist: any) {
       picklist.isGeneratingPicklist = true;
-      await OrderService.printPicklist(picklist.id)
+      await OrderService.printPicklist(picklist.id);
       picklist.isGeneratingPicklist = false;
     },
-    async updateShipmentBoxType(shipmentPackage: any, order: any, ev: CustomEvent) {
-
+    async updateShipmentBoxType(
+      shipmentPackage: any,
+      order: any,
+      ev: CustomEvent
+    ) {
       // Don't open popover when not having shipmentBoxTypes available
-      const shipmentBoxTypes = this.getShipmentBoxTypes(order.carrierPartyId)
+      const shipmentBoxTypes = this.getShipmentBoxTypes(order.carrierPartyId);
       if (!shipmentBoxTypes.length) {
-        logger.error('Failed to fetch shipment box types')
+        logger.error("Failed to fetch shipment box types");
         return;
       }
 
@@ -1110,53 +1712,62 @@ export default defineComponent({
         component: ShipmentBoxTypePopover,
         event: ev,
         showBackdrop: false,
-        componentProps: { shipmentBoxTypes }
+        componentProps: { shipmentBoxTypes },
       });
 
       popover.present();
 
       const result = await popover.onDidDismiss();
 
-      if(result.data && shipmentPackage.shipmentBoxTypeId !== result.data) {
+      if (result.data && shipmentPackage.shipmentBoxTypeId !== result.data) {
         shipmentPackage.shipmentBoxTypeId = result.data;
-        this.store.dispatch('order/updateInProgressOrder', order);
+        this.store.dispatch("order/updateInProgressOrder", order);
       }
     },
     async recycleInProgressOrders() {
       const alert = await alertController.create({
-        header: translate('Reject all in progress orders'),
-        message: translate('Reject in progress orders.', { ordersCount: this.inProgressOrders.total }),
-        buttons: [{
-          text: translate('Cancel'),
-          role: 'cancel'
-        }, {
-          text: translate('Reject'),
-          handler: async () => {
-            this.isRejecting = true;
-            emitter.emit("presentLoader")  
-            await alert.dismiss()  
+        header: translate("Reject all in progress orders"),
+        message: translate("Reject in progress orders.", {
+          ordersCount: this.inProgressOrders.total,
+        }),
+        buttons: [
+          {
+            text: translate("Cancel"),
+            role: "cancel",
+          },
+          {
+            text: translate("Reject"),
+            handler: async () => {
+              this.isRejecting = true;
+              emitter.emit("presentLoader");
+              await alert.dismiss();
 
-            let resp;
+              let resp;
 
-            try {
-              resp = await OrderService.recycleInProgressOrders({
-                "facilityId": this.currentFacility?.facilityId,
-                "productStoreId": this.currentEComStore.productStoreId,
-                "reasonId": "INACTIVE_STORE"
-              })
+              try {
+                resp = await OrderService.recycleInProgressOrders({
+                  facilityId: this.currentFacility?.facilityId,
+                  productStoreId: this.currentEComStore.productStoreId,
+                  reasonId: "INACTIVE_STORE",
+                });
 
-              if(!hasError(resp)) {
-                showToast(translate('Rejecting has been started. All in progress orders will be rejected shortly.'))
-              } else {
-                throw resp.data
+                if (!hasError(resp)) {
+                  showToast(
+                    translate(
+                      "Rejecting has been started. All in progress orders will be rejected shortly."
+                    )
+                  );
+                } else {
+                  throw resp.data;
+                }
+              } catch (err) {
+                showToast(translate("Failed to reject in progress orders"));
+                logger.error("Failed to reject in progress orders", err);
               }
-            } catch(err) {
-              showToast(translate('Failed to reject in progress orders'))
-              logger.error('Failed to reject in progress orders', err)
-            }
-            emitter.emit("dismissLoader")
-          }
-        }]
+              emitter.emit("dismissLoader");
+            },
+          },
+        ],
       });
 
       await alert.present();
@@ -1165,33 +1776,44 @@ export default defineComponent({
       const editPickersModal = await modalController.create({
         component: EditPickersModal,
         componentProps: {
-          selectedPicklist
-        }
+          selectedPicklist,
+        },
       });
 
       editPickersModal.onDidDismiss().then((result) => {
         // manually updating the picklist data as UI is not updated because same data
         // is returned from solr on fetchPickersInformation API call
-        if (result.data?.editedPicklist && Object.keys(result.data?.editedPicklist).length) {
-          const editedPicklist = result.data.editedPicklist
-          this.picklists = JSON.parse(JSON.stringify(this.picklists.map((picklist: any) => picklist.id === editedPicklist.id ? picklist = editedPicklist : picklist)))
+        if (
+          result.data?.editedPicklist &&
+          Object.keys(result.data?.editedPicklist).length
+        ) {
+          const editedPicklist = result.data.editedPicklist;
+          this.picklists = JSON.parse(
+            JSON.stringify(
+              this.picklists.map((picklist: any) =>
+                picklist.id === editedPicklist.id
+                  ? (picklist = editedPicklist)
+                  : picklist
+              )
+            )
+          );
         }
-      })
+      });
 
       return editPickersModal.present();
     },
     fetchProductStock(productId: string) {
-      this.store.dispatch('stock/fetchStock', { productId })
+      this.store.dispatch("stock/fetchStock", { productId });
     },
     async orderActionsPopover(order: any, ev: Event) {
       const popover = await popoverController.create({
         component: OrderActionsPopover,
         componentProps: {
           order,
-          category: 'in-progress'
+          category: "in-progress",
         },
         showBackdrop: false,
-        event: ev
+        event: ev,
       });
       return popover.present();
     },
@@ -1200,48 +1822,64 @@ export default defineComponent({
       const shippingLabelErrorModal = await modalController.create({
         component: ShippingLabelErrorModal,
         componentProps: {
-          shipmentId: order.shipmentId
-        }
+          shipmentId: order.shipmentId,
+        },
       });
       return shippingLabelErrorModal.present();
     },
     async scanOrder(order: any, updateParameter?: string) {
       const modal = await modalController.create({
         component: ScanOrderItemModal,
-        componentProps: { order }
-      })
+        componentProps: { order },
+      });
 
       modal.onDidDismiss().then((result: any) => {
-        if(result.data?.packOrder) {
+        if (result.data?.packOrder) {
           this.confirmPackOrder(order, updateParameter);
         }
-      })
+      });
 
       modal.present();
     },
-    async generateTrackingCodeForPacking(order: any, updateParameter?: string, documentOptions = {}, packingError?: string) {
+    async generateTrackingCodeForPacking(
+      order: any,
+      updateParameter?: string,
+      documentOptions = {},
+      packingError?: string
+    ) {
       const modal = await modalController.create({
         component: GenerateTrackingCodeModal,
-        componentProps: { order, executePackOrder: this.executePackOrder, rejectEntireOrder: this.rejectEntireOrder, updateParameter, documentOptions, packingError }
-      })
+        componentProps: {
+          order,
+          executePackOrder: this.executePackOrder,
+          rejectEntireOrder: this.rejectEntireOrder,
+          updateParameter,
+          documentOptions,
+          packingError,
+        },
+      });
       modal.present();
     },
 
     async openGiftCardActivationModal(item: any) {
       const modal = await modalController.create({
         component: GiftCardActivationModal,
-        componentProps: { item }
-      })
+        componentProps: { item },
+      });
 
       modal.onDidDismiss().then((result: any) => {
-        if(result.data?.isGCActivated) {
-          this.store.dispatch("order/updateCurrentItemGCActivationDetails", { item, category: "in-progress", isDetailsPage: false })
+        if (result.data?.isGCActivated) {
+          this.store.dispatch("order/updateCurrentItemGCActivationDetails", {
+            item,
+            category: "in-progress",
+            isDetailsPage: false,
+          });
         }
-      })
+      });
 
       modal.present();
     },
-    async fetchOrderAndPickerInformation(){
+    async fetchOrderAndPickerInformation() {
       await this.fetchPickersInformation();
       await this.updateOrderQuery(process.env.VUE_APP_VIEW_SIZE, "", true);
     },
@@ -1250,29 +1888,31 @@ export default defineComponent({
     this.isScrollingEnabled = false;
     this.isLoadingOrders = true;
     try {
-      await this.fetchPickersInformation()
+      await this.fetchPickersInformation();
       await Promise.all([
-        this.store.dispatch('util/fetchRejectReasonOptions'),
-        this.initialiseOrderQuery()
+        this.store.dispatch("util/fetchRejectReasonOptions"),
+        this.initialiseOrderQuery(),
       ]);
     } finally {
       this.isLoadingOrders = false;
     }
 
-    emitter.on('updateOrderQuery', this.updateOrderQuery)
+    emitter.on("updateOrderQuery", this.updateOrderQuery);
   },
   beforeRouteLeave() {
-    this.store.dispatch('order/clearInProgressOrders')
-    emitter.off('updateOrderQuery', this.updateOrderQuery)
+    this.store.dispatch("order/clearInProgressOrders");
+    emitter.off("updateOrderQuery", this.updateOrderQuery);
   },
   setup() {
     const router = useRouter();
     const store = useStore();
-    const userStore = useUserStore()
+    const userStore = useUserStore();
     const productIdentificationStore = useProductIdentificationStore();
-    let productIdentificationPref = computed(() => productIdentificationStore.getProductIdentificationPref)
-    let currentEComStore: any = computed(() => userStore.getCurrentEComStore)
-    let currentFacility: any = computed(() => userStore.getCurrentFacility) 
+    let productIdentificationPref = computed(
+      () => productIdentificationStore.getProductIdentificationPref
+    );
+    let currentEComStore: any = computed(() => userStore.getCurrentEComStore);
+    let currentFacility: any = computed(() => userStore.getCurrentFacility);
 
     return {
       Actions,
@@ -1304,9 +1944,9 @@ export default defineComponent({
       router,
       trashBinOutline,
       store,
-      translate
-    }
-  }
+      translate,
+    };
+  },
 });
 </script>
 
@@ -1324,7 +1964,8 @@ export default defineComponent({
   height: 30px;
 }
 
-ion-segment > ion-segment-button > ion-skeleton-text, ion-item > ion-skeleton-text {
+ion-segment > ion-segment-button > ion-skeleton-text,
+ion-item > ion-skeleton-text {
   width: 100%;
   height: 30px;
 }
@@ -1333,4 +1974,3 @@ ion-segment > ion-segment-button > ion-skeleton-text, ion-item > ion-skeleton-te
   grid-template-columns: repeat(3, 1fr);
 }
 </style>
-

--- a/src/views/OpenOrders.vue
+++ b/src/views/OpenOrders.vue
@@ -9,12 +9,17 @@
         <ion-title v-else>{{ openOrders.query.viewSize }} {{ translate('of') }} {{ openOrders.total }} {{ translate('orders') }}</ion-title>
      
         <ion-buttons slot="end">
-          <ion-button @click="viewNotifications()">
+          <ion-button data-testid="fulfillment-open-notifications-btn"
+           @click="viewNotifications()">
             <ion-icon slot="icon-only" :icon="notificationsOutline" :color="(unreadNotificationsStatus && notifications.length) ? 'primary' : ''" />
-          </ion-button>
-          <ion-button :disabled="!hasPermission(Actions.APP_RECYCLE_ORDER) || !openOrders.total || isRejecting" fill="clear" color="danger" @click="recycleOutstandingOrders()">
-            {{ translate("Reject all") }}
-          </ion-button>
+          <ion-button
+  data-testid="fulfillment-open-reject-all-btn"
+  :disabled="!hasPermission(Actions.APP_RECYCLE_ORDER) || !openOrders.total || isRejecting"
+  fill="clear"
+  color="danger"
+  @click="recycleOuts">
+  {{ translate("Reject all") }}
+</ion-button>
           <ion-menu-button menu="view-size-selector-open" :disabled="!openOrders.total">
             <ion-icon :icon="optionsOutline" />
           </ion-menu-button>
@@ -38,9 +43,10 @@
       <div v-if="openOrders.total">
 
         <div class="results">
-          <ion-button class="bulk-action desktop-only" size="large" @click="assignPickers">{{ translate("Print Picklist") }}</ion-button>
+          <ion-button data-testid="fulfillment-open-print-picklist-btn" class="bulk action desktop-only" size="large" @click="assignPickers"> {{ translate("Print Picklist") }}
+</ion-button>
 
-          <ion-card class="order" v-for="(order, index) in getOpenOrders()" :key="index">
+          <ion-card class="order" data-testid="fulfillment-open-order-card" v-for="(order, index) in getOpenOrders()" :key="index">
             <div class="order-header">
               <div class="order-primary-info">
                 <ion-label>

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -13,21 +13,57 @@
             <h3>{{ order.orderName }}</h3>
           </div>
           <div class="order-tags">
-            <ion-chip outline @click="copyToClipboard(order.orderId, 'Copied to clipboard')">
+            <ion-chip
+              outline
+              data-test-id="order-id-chip"
+              @click="copyToClipboard(order.orderId, 'Copied to clipboard')"
+            >
               <ion-icon :icon="pricetagOutline" />
               <ion-label>{{ order.orderId }}</ion-label>
             </ion-chip>
-            <ion-chip v-if="category !== 'open'" outline @click="printPicklist(order)">
+            <ion-chip
+              v-if="category !== 'open'"
+              outline
+              @click="printPicklist(order)"
+            >
               <ion-icon :icon="documentTextOutline" />
-              <ion-label>{{ translate('Linked picklist') }}: {{ order.picklistId }}</ion-label>
+              <ion-label
+                >{{ translate("Linked picklist") }}:
+                {{ order.picklistId }}</ion-label
+              >
             </ion-chip>
-            <ion-chip outline v-if="order?.paymentPreferences?.length > 0" :color="statusColor[order?.paymentPreferences[0]?.statusId]">
+            <ion-chip
+              outline
+              data-test-id="payment-status-chip"
+              v-if="order?.paymentPreferences?.length > 0"
+              :color="statusColor[order?.paymentPreferences[0]?.statusId]"
+            >
               <ion-icon :icon="cashOutline" />
-              <ion-label>{{ translate(getPaymentMethodDesc(order?.paymentPreferences[0]?.paymentMethodTypeId)) }} : {{ translate(getStatusDesc(order?.paymentPreferences[0]?.statusId)) }}</ion-label>
+              <ion-label
+                >{{
+                  translate(
+                    getPaymentMethodDesc(
+                      order?.paymentPreferences[0]?.paymentMethodTypeId
+                    )
+                  )
+                }}
+                :
+                {{
+                  translate(
+                    getStatusDesc(order?.paymentPreferences[0]?.statusId)
+                  )
+                }}</ion-label
+              >
             </ion-chip>
           </div>
           <div class="order-metadata">
-            <ion-badge>{{ category === 'open' ? translate('Open') : (category === 'in-progress' ? translate('In Progress') : translate('Completed')) }}</ion-badge>
+            <ion-badge>{{
+              category === "open"
+                ? translate("Open")
+                : category === "in-progress"
+                ? translate("In Progress")
+                : translate("Completed")
+            }}</ion-badge>
           </div>
         </div>
 
@@ -35,21 +71,45 @@
           <div class="order-header">
             <div class="order-primary-info">
               <ion-label>
-                <strong>{{ order.customerName }}</strong>
-                <p>{{ translate("Ordered") }} {{ category === 'open' ? formatUtcDate(order.orderDate, 'dd MMMM yyyy hh:mm a ZZZZ') : getTime(order.orderDate) }}</p>
+                <strong data-test-id="customer-name">{{
+                  order.customerName
+                }}</strong>
+                <p data-test-id="order-date">
+                  {{ translate("Ordered") }}
+                  {{
+                    category === "open"
+                      ? formatUtcDate(
+                          order.orderDate,
+                          "dd MMMM yyyy hh:mm a ZZZZ"
+                        )
+                      : getTime(order.orderDate)
+                  }}
+                </p>
               </ion-label>
             </div>
             <div class="order-tags">
               <ion-chip outline>
                 <ion-icon :icon="ribbonOutline" />
-                <ion-label>{{ order.primaryShipGroupSeqId ? order.primaryShipGroupSeqId : order.shipGroupSeqId }}</ion-label>
+                <ion-label>{{
+                  order.primaryShipGroupSeqId
+                    ? order.primaryShipGroupSeqId
+                    : order.shipGroupSeqId
+                }}</ion-label>
               </ion-chip>
             </div>
 
             <div class="order-metadata">
               <ion-label>
                 {{ getShipmentMethodDesc(order.shipmentMethodTypeId) }}
-                <p v-if="order.reservedDatetime">{{ translate("Last brokered") }} {{ formatUtcDate(order.reservedDatetime, 'dd MMMM yyyy hh:mm a ZZZZ') }}</p>
+                <p v-if="order.reservedDatetime">
+                  {{ translate("Last brokered") }}
+                  {{
+                    formatUtcDate(
+                      order.reservedDatetime,
+                      "dd MMMM yyyy hh:mm a ZZZZ"
+                    )
+                  }}
+                </p>
               </ion-label>
             </div>
           </div>
@@ -59,108 +119,302 @@
               <ion-skeleton-text animated />
               <ion-skeleton-text animated />
             </div>
-            <div class="box-type desktop-only" v-else-if="order.shipmentPackages">
-              <ion-button :disabled="order.items.length <= order.shipmentPackages.length || addingBoxForShipmentIds.includes(order.orderId)" @click.stop="addShipmentBox(order)" fill="outline" shape="round" size="small"><ion-icon :icon="addOutline" />
+            <div
+              class="box-type desktop-only"
+              v-else-if="order.shipmentPackages"
+            >
+              <ion-button
+                :disabled="
+                  order.items.length <= order.shipmentPackages.length ||
+                  addingBoxForShipmentIds.includes(order.orderId)
+                "
+                @click.stop="addShipmentBox(order)"
+                fill="outline"
+                shape="round"
+                size="small"
+                ><ion-icon :icon="addOutline" />
                 {{ translate("Add Box") }}
               </ion-button>
               <ion-row>
-                <ion-chip v-for="shipmentPackage in order.shipmentPackages" :key="shipmentPackage.shipmentId" @click.stop="updateShipmentBoxType(shipmentPackage, order, $event)">
-                  {{ `Box ${shipmentPackage?.packageName}` }} {{ `| ${boxTypeDesc(getShipmentPackageType(order, shipmentPackage))}`}}
+                <ion-chip
+                  v-for="shipmentPackage in order.shipmentPackages"
+                  :key="shipmentPackage.shipmentId"
+                  @click.stop="
+                    updateShipmentBoxType(shipmentPackage, order, $event)
+                  "
+                >
+                  {{ `Box ${shipmentPackage?.packageName}` }}
+                  {{
+                    `| ${boxTypeDesc(
+                      getShipmentPackageType(order, shipmentPackage)
+                    )}`
+                  }}
                   <ion-icon :icon="caretDownOutline" />
                 </ion-chip>
               </ion-row>
-            </div>  
+            </div>
           </div>
 
-          <div v-for="item in order.items" :key="item" class="order-line-item">
+          <div
+            v-for="item in order.items"
+            :key="item"
+            class="order-line-item"
+            data-test-id="order-line-item"
+          >
             <div class="order-item">
-            <div class="product-info">
-              <ion-item lines="none">
-                <ion-thumbnail slot="start" v-image-preview="getProduct(item.productId)" :key="getProduct(item.productId)?.mainImageUrl">
-                  <DxpShopifyImg :src="getProduct(item.productId).mainImageUrl" size="small"/>
-                </ion-thumbnail>
-                <ion-label>
-                  <p class="overline">{{ getProductIdentificationValue(productIdentificationPref.secondaryId, getProduct(item.productId)) }}</p>
-                  <div>
-                    {{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) : getProduct(item.productId).productName }}
-                    <ion-badge class="kit-badge" color="dark" v-if="isKit(item)">{{ translate("Kit") }}</ion-badge>
-                  </div>
-                  <p>{{ getFeatures(getProduct(item.productId).productFeatures)}}</p>
-                </ion-label>
-              </ion-item>
-            </div>
-
-            <div v-if="category === 'in-progress'" class="desktop-only ion-text-center" >
-              <template v-if="item.rejectReason">
-                <ion-chip outline color="danger" >
-                  <ion-label> {{ getRejectionReasonDescription(item.rejectReason) }}</ion-label>
-                  <ion-icon :icon="closeCircleOutline" @click.stop="removeRejectionReason($event, item, order)"/>
-                </ion-chip>
-              </template>
-              <template v-else-if="isEntierOrderRejectionEnabled(order)">
-                <ion-chip outline color="danger">
-                  <ion-label> {{ getRejectionReasonDescription(rejectEntireOrderReasonId) ? getRejectionReasonDescription(rejectEntireOrderReasonId) : translate('Reject to avoid order split (no variance)')}}</ion-label>
-                </ion-chip>
-              </template>
-              <template v-else>
-                <ion-chip outline @click="openShipmentBoxPopover($event, item, order)">
-                  <ion-icon :icon="fileTrayOutline" />
-                  {{ `Box ${item.selectedBox || ''}` }} 
-                  <ion-icon :icon="caretDownOutline" />
-                </ion-chip>
-              </template>
-            </div>
-
-            <!-- In completed and inprogress category we only have two items in product item while css needs 3 hence adding an empty div. -->
-            <div v-else></div>
-
-            <!-- TODO: add a spinner if the api takes too long to fetch the stock -->
-             <!--Adding checks to avoid any operations if order has missing info, mostly when after packing Solr is not updaing immediately-->
-            <div class="product-metadata">
-              <ion-note v-if="getProductStock(item.productId).qoh" class="ion-padding-end">{{ getProductStock(item.productId).qoh }} {{ translate('pieces in stock') }}</ion-note>
-              <ion-button color="medium" fill="clear" v-else size="small" @click="fetchProductStock(item.productId)">
-                {{ translate('Check stock') }}
-                <ion-icon slot="end" :icon="cubeOutline"/>
-              </ion-button>
-              <!-- TODO make functional -->
-              <ion-button v-if="category === 'in-progress'" @click="openRejectReasonPopover($event, item, order)" class="desktop-only" color="danger" fill="clear" size="small">
-                {{ translate('Report an issue') }}
-                <ion-icon slot="end" :icon="trashBinOutline"/>
-              </ion-button>
-              <ion-button v-if="isKit(item)" fill="clear" color="medium" size="small" @click.stop="fetchKitComponent(item)">
-                {{ translate('Components') }}
-                <ion-icon v-if="item.showKitComponents" color="medium" slot="end" :icon="chevronUpOutline"/>
-                <ion-icon v-else color="medium" slot="end" :icon="listOutline"/>
-              </ion-button>
-              <ion-button v-if="item.productTypeId === 'GIFT_CARD'" fill="clear" color="medium" size="small" @click="openGiftCardActivationModal(item)">
-                {{ translate('Gift card') }}
-                <ion-icon color="medium" slot="end" :icon="item.isGCActivated ? gift : giftOutline"/>
-              </ion-button>
-            </div>
-            </div>
-            <div v-if="item.showKitComponents && getProduct(item.productId)?.productComponents" class="kit-components">
-              <ion-card v-for="(productComponent, index) in getProduct(item.productId).productComponents" :key="index">
+              <div class="product-info">
                 <ion-item lines="none">
-                  <ion-thumbnail slot="start" v-image-preview="getProduct(productComponent.productIdTo)" :key="getProduct(productComponent.productIdTo)?.mainImageUrl">
-                    <DxpShopifyImg :src="getProduct(productComponent.productIdTo).mainImageUrl" size="small"/>
+                  <ion-thumbnail
+                    slot="start"
+                    v-image-preview="getProduct(item.productId)"
+                    :key="getProduct(item.productId)?.mainImageUrl"
+                  >
+                    <DxpShopifyImg
+                      :src="getProduct(item.productId).mainImageUrl"
+                      size="small"
+                    />
                   </ion-thumbnail>
                   <ion-label>
-                    <p class="overline">{{ getProductIdentificationValue(productIdentificationPref.secondaryId, getProduct(productComponent.productIdTo)) }}</p>
+                    <p class="overline">
+                      {{
+                        getProductIdentificationValue(
+                          productIdentificationPref.secondaryId,
+                          getProduct(item.productId)
+                        )
+                      }}
+                    </p>
                     <div>
-                      {{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(productComponent.productIdTo)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(productComponent.productIdTo)) : productComponent.productIdTo }}
+                      {{
+                        getProductIdentificationValue(
+                          productIdentificationPref.primaryId,
+                          getProduct(item.productId)
+                        )
+                          ? getProductIdentificationValue(
+                              productIdentificationPref.primaryId,
+                              getProduct(item.productId)
+                            )
+                          : getProduct(item.productId).productName
+                      }}
+                      <ion-badge
+                        class="kit-badge"
+                        color="dark"
+                        v-if="isKit(item)"
+                        >{{ translate("Kit") }}</ion-badge
+                      >
                     </div>
-                    <p>{{ getFeatures(getProduct(productComponent.productIdTo).productFeatures)}}</p>
+                    <p>
+                      {{
+                        getFeatures(getProduct(item.productId).productFeatures)
+                      }}
+                    </p>
                   </ion-label>
-                  <ion-checkbox v-if="item.rejectReason || isEntierOrderRejectionEnabled(order)" :checked="item.kitComponents?.includes(productComponent.productIdTo)" @ionChange="rejectKitComponent(order, item, productComponent.productIdTo)" />
+                </ion-item>
+              </div>
+
+              <div
+                v-if="category === 'in-progress'"
+                class="desktop-only ion-text-center"
+              >
+                <template v-if="item.rejectReason">
+                  <ion-chip outline color="danger">
+                    <ion-label>
+                      {{
+                        getRejectionReasonDescription(item.rejectReason)
+                      }}</ion-label
+                    >
+                    <ion-icon
+                      :icon="closeCircleOutline"
+                      @click.stop="removeRejectionReason($event, item, order)"
+                    />
+                  </ion-chip>
+                </template>
+                <template v-else-if="isEntierOrderRejectionEnabled(order)">
+                  <ion-chip outline color="danger">
+                    <ion-label>
+                      {{
+                        getRejectionReasonDescription(rejectEntireOrderReasonId)
+                          ? getRejectionReasonDescription(
+                              rejectEntireOrderReasonId
+                            )
+                          : translate(
+                              "Reject to avoid order split (no variance)"
+                            )
+                      }}</ion-label
+                    >
+                  </ion-chip>
+                </template>
+                <template v-else>
+                  <ion-chip
+                    outline
+                    @click="openShipmentBoxPopover($event, item, order)"
+                  >
+                    <ion-icon :icon="fileTrayOutline" />
+                    {{ `Box ${item.selectedBox || ""}` }}
+                    <ion-icon :icon="caretDownOutline" />
+                  </ion-chip>
+                </template>
+              </div>
+
+              <!-- In completed and inprogress category we only have two items in product item while css needs 3 hence adding an empty div. -->
+              <div v-else></div>
+
+              <!-- TODO: add a spinner if the api takes too long to fetch the stock -->
+              <!--Adding checks to avoid any operations if order has missing info, mostly when after packing Solr is not updaing immediately-->
+              <div class="product-metadata">
+                <ion-note
+                  v-if="getProductStock(item.productId).qoh"
+                  class="ion-padding-end"
+                  >{{ getProductStock(item.productId).qoh }}
+                  {{ translate("pieces in stock") }}</ion-note
+                >
+                <ion-button
+                  data-test-id="check-stock-btn"
+                  color="medium"
+                  fill="clear"
+                  size="small"
+                  @click="fetchProductStock(item.productId)"
+                >
+                  {{ translate("Check stock") }}
+                  <ion-icon slot="end" :icon="cubeOutline" />
+                </ion-button>
+                <!-- TODO make functional -->
+                <ion-button
+                  v-if="category === 'in-progress'"
+                  @click="openRejectReasonPopover($event, item, order)"
+                  class="desktop-only"
+                  color="danger"
+                  fill="clear"
+                  size="small"
+                >
+                  {{ translate("Report an issue") }}
+                  <ion-icon slot="end" :icon="trashBinOutline" />
+                </ion-button>
+                <ion-button
+                  v-if="isKit(item)"
+                  fill="clear"
+                  color="medium"
+                  size="small"
+                  @click.stop="fetchKitComponent(item)"
+                >
+                  {{ translate("Components") }}
+                  <ion-icon
+                    v-if="item.showKitComponents"
+                    color="medium"
+                    slot="end"
+                    :icon="chevronUpOutline"
+                  />
+                  <ion-icon
+                    v-else
+                    color="medium"
+                    slot="end"
+                    :icon="listOutline"
+                  />
+                </ion-button>
+                <ion-button
+                  v-if="item.productTypeId === 'GIFT_CARD'"
+                  fill="clear"
+                  color="medium"
+                  size="small"
+                  @click="openGiftCardActivationModal(item)"
+                >
+                  {{ translate("Gift card") }}
+                  <ion-icon
+                    color="medium"
+                    slot="end"
+                    :icon="item.isGCActivated ? gift : giftOutline"
+                  />
+                </ion-button>
+              </div>
+            </div>
+            <div
+              v-if="
+                item.showKitComponents &&
+                getProduct(item.productId)?.productComponents
+              "
+              class="kit-components"
+            >
+              <ion-card
+                v-for="(productComponent, index) in getProduct(item.productId)
+                  .productComponents"
+                :key="index"
+              >
+                <ion-item lines="none">
+                  <ion-thumbnail
+                    slot="start"
+                    v-image-preview="getProduct(productComponent.productIdTo)"
+                    :key="
+                      getProduct(productComponent.productIdTo)?.mainImageUrl
+                    "
+                  >
+                    <DxpShopifyImg
+                      :src="
+                        getProduct(productComponent.productIdTo).mainImageUrl
+                      "
+                      size="small"
+                    />
+                  </ion-thumbnail>
+                  <ion-label>
+                    <p class="overline">
+                      {{
+                        getProductIdentificationValue(
+                          productIdentificationPref.secondaryId,
+                          getProduct(productComponent.productIdTo)
+                        )
+                      }}
+                    </p>
+                    <div>
+                      {{
+                        getProductIdentificationValue(
+                          productIdentificationPref.primaryId,
+                          getProduct(productComponent.productIdTo)
+                        )
+                          ? getProductIdentificationValue(
+                              productIdentificationPref.primaryId,
+                              getProduct(productComponent.productIdTo)
+                            )
+                          : productComponent.productIdTo
+                      }}
+                    </div>
+                    <p>
+                      {{
+                        getFeatures(
+                          getProduct(productComponent.productIdTo)
+                            .productFeatures
+                        )
+                      }}
+                    </p>
+                  </ion-label>
+                  <ion-checkbox
+                    v-if="
+                      item.rejectReason || isEntierOrderRejectionEnabled(order)
+                    "
+                    :checked="
+                      item.kitComponents?.includes(productComponent.productIdTo)
+                    "
+                    @ionChange="
+                      rejectKitComponent(
+                        order,
+                        item,
+                        productComponent.productIdTo
+                      )
+                    "
+                  />
                 </ion-item>
               </ion-card>
             </div>
           </div>
-          
+
           <div v-if="category === 'in-progress'" class="mobile-only">
             <ion-item>
-              <ion-button fill="clear" @click="packOrder(order)">{{ translate("Pack using default packaging") }}</ion-button>
-              <ion-button slot="end" fill="clear" color="medium" @click="packagingPopover">
+              <ion-button fill="clear" @click="packOrder(order)">{{
+                translate("Pack using default packaging")
+              }}</ion-button>
+              <ion-button
+                slot="end"
+                fill="clear"
+                color="medium"
+                @click="packagingPopover"
+              >
                 <ion-icon slot="icon-only" :icon="ellipsisVerticalOutline" />
               </ion-button>
             </ion-item>
@@ -168,8 +422,24 @@
 
           <div v-else-if="category === 'completed'" class="mobile-only">
             <ion-item>
-              <ion-button :disabled="isShipNowDisabled || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || ((isTrackingRequiredForAnyShipmentPackage(order) && !order.trackingCode) && !hasPermission(Actions.APP_FORCE_SHIP_ORDER))" fill="clear" >{{ translate("Ship Now") }}</ion-button>
-              <ion-button slot="end" fill="clear" color="medium" @click.stop="shippingPopover">
+              <ion-button
+                :disabled="
+                  isShipNowDisabled ||
+                  order.hasMissingShipmentInfo ||
+                  order.hasMissingPackageInfo ||
+                  (isTrackingRequiredForAnyShipmentPackage(order) &&
+                    !order.trackingCode &&
+                    !hasPermission(Actions.APP_FORCE_SHIP_ORDER))
+                "
+                fill="clear"
+                >{{ translate("Ship Now") }}</ion-button
+              >
+              <ion-button
+                slot="end"
+                fill="clear"
+                color="medium"
+                @click.stop="shippingPopover"
+              >
                 <ion-icon slot="icon-only" :icon="ellipsisVerticalOutline" />
               </ion-button>
             </ion-item>
@@ -179,13 +449,33 @@
             <!-- positive -->
             <div>
               <template v-if="category === 'in-progress'">
-                <ion-button :color="order.hasAllRejectedItem ? 'danger' : ''" @click="packOrder(order)">
+                <ion-button
+                  :color="order.hasAllRejectedItem ? 'danger' : ''"
+                  @click="packOrder(order)"
+                >
                   <ion-icon slot="start" :icon="archiveOutline" />
-                  {{ translate(order.hasAllRejectedItem ? "Reject order" : order.hasRejectedItem ? "Save and Pack Order" : "Pack order") }}
+                  {{
+                    translate(
+                      order.hasAllRejectedItem
+                        ? "Reject order"
+                        : order.hasRejectedItem
+                        ? "Save and Pack Order"
+                        : "Pack order"
+                    )
+                  }}
                 </ion-button>
-                <Component :is="printDocumentsExt" :category="category" :order="order" :currentFacility="currentFacility" :hasMissingInfo="order.missingLabelImage"/>
-              </template>  
-              <ion-button v-else-if="category === 'open'" @click="assignPickers">
+                <Component
+                  :is="printDocumentsExt"
+                  :category="category"
+                  :order="order"
+                  :currentFacility="currentFacility"
+                  :hasMissingInfo="order.missingLabelImage"
+                />
+              </template>
+              <ion-button
+                v-else-if="category === 'open'"
+                @click="assignPickers"
+              >
                 <ion-icon slot="start" :icon="personAddOutline" />
                 {{ translate("Pick order") }}
               </ion-button>
@@ -194,19 +484,54 @@
                   <ion-icon slot="start" :icon="bagCheckOutline" />
                   {{ translate("Shipped") }}
                 </ion-button>
-                <ion-button v-else :disabled="isShipNowDisabled || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || ((isTrackingRequiredForAnyShipmentPackage(order) && !order.trackingCode) && !hasPermission(Actions.APP_FORCE_SHIP_ORDER))" @click.stop="shipOrder(order)">
+                <ion-button
+                  v-else
+                  :disabled="
+                    isShipNowDisabled ||
+                    order.hasMissingShipmentInfo ||
+                    order.hasMissingPackageInfo ||
+                    (isTrackingRequiredForAnyShipmentPackage(order) &&
+                      !order.trackingCode &&
+                      !hasPermission(Actions.APP_FORCE_SHIP_ORDER))
+                  "
+                  @click.stop="shipOrder(order)"
+                >
                   <ion-icon slot="start" :icon="bagCheckOutline" />
                   {{ translate("Ship order") }}
                 </ion-button>
-                <ion-button :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo" fill="outline" @click.stop="printPackingSlip(order)">
+                <ion-button
+                  :disabled="
+                    order.hasMissingShipmentInfo || order.hasMissingPackageInfo
+                  "
+                  fill="outline"
+                  @click.stop="printPackingSlip(order)"
+                >
                   {{ translate("Print Customer Letter") }}
-                  <ion-spinner data-spinner-size="medium" color="primary" slot="end" v-if="order.isGeneratingPackingSlip" name="crescent" />
+                  <ion-spinner
+                    data-spinner-size="medium"
+                    color="primary"
+                    slot="end"
+                    v-if="order.isGeneratingPackingSlip"
+                    name="crescent"
+                  />
                 </ion-button>
               </div>
             </div>
             <!-- negative -->
             <div class="desktop-only" v-if="category === 'completed'">
-              <ion-button :disabled="isUnpackDisabled || !hasPermission(Actions.APP_UNPACK_ORDER) || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || !hasPackedShipments(order)" fill="outline" color="danger" @click.stop="unpackOrder(order)">{{ translate("Unpack") }}</ion-button>
+              <ion-button
+                :disabled="
+                  isUnpackDisabled ||
+                  !hasPermission(Actions.APP_UNPACK_ORDER) ||
+                  order.hasMissingShipmentInfo ||
+                  order.hasMissingPackageInfo ||
+                  !hasPackedShipments(order)
+                "
+                fill="outline"
+                color="danger"
+                @click.stop="unpackOrder(order)"
+                >{{ translate("Unpack") }}</ion-button
+              >
             </div>
           </div>
         </ion-card>
@@ -215,23 +540,59 @@
           <ion-card>
             <ion-card-header>
               <ion-card-title>
-                {{ translate('Destination') }}
+                {{ translate("Destination") }}
               </ion-card-title>
             </ion-card-header>
             <ion-item lines="none">
               <ion-label>
                 <h3>{{ order?.shippingAddress?.toName }}</h3>
-                <p class="ion-text-wrap">{{ order?.shippingAddress?.address1 }}</p>
-                <p class="ion-text-wrap" v-if="order?.shippingAddress?.address2">{{ order.shippingAddress.address2 }}</p>
-                <p class="ion-text-wrap">{{ order?.shippingAddress?.city ? order.shippingAddress.city + "," : "" }} {{ order.shippingAddress?.postalCode }}</p>
-                <p class="ion-text-wrap">{{ order?.shippingAddress?.stateName ? order.shippingAddress.stateName + "," : "" }} {{ order.shippingAddress?.countryName }}</p>
-                <p class="ion-text-wrap" v-if="order?.telecomNumber?.contactNumber">{{ order?.telecomNumber?.contactNumber }}</p>
+                <p class="ion-text-wrap">
+                  {{ order?.shippingAddress?.address1 }}
+                </p>
+                <p
+                  class="ion-text-wrap"
+                  v-if="order?.shippingAddress?.address2"
+                >
+                  {{ order.shippingAddress.address2 }}
+                </p>
+                <p class="ion-text-wrap">
+                  {{
+                    order?.shippingAddress?.city
+                      ? order.shippingAddress.city + ","
+                      : ""
+                  }}
+                  {{ order.shippingAddress?.postalCode }}
+                </p>
+                <p class="ion-text-wrap">
+                  {{
+                    order?.shippingAddress?.stateName
+                      ? order.shippingAddress.stateName + ","
+                      : ""
+                  }}
+                  {{ order.shippingAddress?.countryName }}
+                </p>
+                <p
+                  class="ion-text-wrap"
+                  v-if="order?.telecomNumber?.contactNumber"
+                >
+                  {{ order?.telecomNumber?.contactNumber }}
+                </p>
               </ion-label>
             </ion-item>
-            <ion-item color="light" lines="none" v-if="order?.shippingInstructions">
+            <ion-item
+              color="light"
+              lines="none"
+              v-if="order?.shippingInstructions"
+            >
               <ion-label class="ion-text-wrap">
                 <p class="overline">{{ translate("Handling Instructions") }}</p>
-                <p>{{ order?.shippingInstructions ? order.shippingInstructions : 'Sample Handling instructions' }}</p>
+                <p>
+                  {{
+                    order?.shippingInstructions
+                      ? order.shippingInstructions
+                      : "Sample Handling instructions"
+                  }}
+                </p>
               </ion-label>
             </ion-item>
           </ion-card>
@@ -241,16 +602,38 @@
               <ion-card-title>{{ translate("Payment") }}</ion-card-title>
             </ion-card-header>
             <div v-if="order.paymentPreferences?.length">
-              <ion-list v-for="(orderPayment, index) in order.paymentPreferences" :key="`${order.orderId}-${orderPayment.orderPaymentPreferenceId}`">
+              <ion-list
+                v-for="(orderPayment, index) in order.paymentPreferences"
+                :key="`${order.orderId}-${orderPayment.orderPaymentPreferenceId}`"
+              >
                 <ion-item lines="none">
                   <ion-label class="ion-text-wrap">
-                    <p class="overline">{{ orderPayment.paymentMethodTypeId }}</p>
-                    <ion-label>{{ translate(getPaymentMethodDesc(orderPayment.paymentMethodTypeId)) || orderPayment.paymentMethodTypeId }}</ion-label>
-                    <ion-note :color="getColorByDesc(getStatusDesc(orderPayment.statusId))">{{ translate(getStatusDesc(orderPayment.statusId)) }}</ion-note>
+                    <p class="overline">
+                      {{ orderPayment.paymentMethodTypeId }}
+                    </p>
+                    <ion-label>{{
+                      translate(
+                        getPaymentMethodDesc(orderPayment.paymentMethodTypeId)
+                      ) || orderPayment.paymentMethodTypeId
+                    }}</ion-label>
+                    <ion-note
+                      :color="
+                        getColorByDesc(getStatusDesc(orderPayment.statusId))
+                      "
+                      >{{
+                        translate(getStatusDesc(orderPayment.statusId))
+                      }}</ion-note
+                    >
                   </ion-label>
                   <div slot="end" class="ion-text-end">
-                    <ion-badge v-if="order.paymentPreferences.length > 1 && index === 0" color="dark">{{ translate("Latest") }}</ion-badge>
-                    <ion-label slot="end">{{ formatCurrency(orderPayment.maxAmount, order.currencyUom) }}</ion-label>
+                    <ion-badge
+                      v-if="order.paymentPreferences.length > 1 && index === 0"
+                      color="dark"
+                      >{{ translate("Latest") }}</ion-badge
+                    >
+                    <ion-label slot="end">{{
+                      formatCurrency(orderPayment.maxAmount, order.currencyUom)
+                    }}</ion-label>
                   </div>
                 </ion-item>
               </ion-list>
@@ -260,40 +643,108 @@
             </p>
           </ion-card>
 
-          <ion-card v-if="['in-progress', 'completed'].includes(order.category)">
+          <ion-card
+            v-if="['in-progress', 'completed'].includes(order.category)"
+          >
             <ion-card-header>
               <ion-card-title>
-                {{ translate('Shipment method') }}
+                {{ translate("Shipment method") }}
               </ion-card-title>
             </ion-card-header>
             <ion-item v-if="isCODPaymentPending">
               <ion-label>{{ translate("Cash on delivery order") }}</ion-label>
-              <ion-icon slot="end" color="success" :icon="checkmarkCircleOutline" />
+              <ion-icon
+                slot="end"
+                color="success"
+                :icon="checkmarkCircleOutline"
+              />
             </ion-item>
-            <ion-item button v-if="isOrderAdjustmentPending" @click="openOrderAdjustmentInfo">
-              <ion-label>{{ translate("This shipping label will include order level charges because it is the first label.") }}</ion-label>
+            <ion-item
+              button
+              v-if="isOrderAdjustmentPending"
+              @click="openOrderAdjustmentInfo"
+            >
+              <ion-label>{{
+                translate(
+                  "This shipping label will include order level charges because it is the first label."
+                )
+              }}</ion-label>
               <ion-icon slot="end" color="success" :icon="cashOutline" />
             </ion-item>
-            <ion-item button v-else-if="isCODPaymentPending" @click="openOrderAdjustmentInfo">
-              <ion-label>{{ translate("This shipping label will not include order level charges.") }}</ion-label>
+            <ion-item
+              button
+              v-else-if="isCODPaymentPending"
+              @click="openOrderAdjustmentInfo"
+            >
+              <ion-label>{{
+                translate(
+                  "This shipping label will not include order level charges."
+                )
+              }}</ion-label>
               <ion-icon slot="end" :icon="cashOutline" />
             </ion-item>
             <ion-item>
-              <ion-select :disabled="!order.missingLabelImage || !hasPermission(Actions.APP_ORDER_SHIPMENT_METHOD_UPDATE)" :label="translate('Carrier')" v-model="carrierPartyId" interface="popover" @ionChange="updateCarrierAndShippingMethod(carrierPartyId, '')" :selected-text="getSelectedCarrier(carrierPartyId)">
-                <ion-select-option v-for="carrier in facilityCarriers" :key="carrier.partyId" :value="carrier.partyId">{{ translate(carrier.groupName) }}</ion-select-option>
+              <ion-select
+                :disabled="
+                  !order.missingLabelImage ||
+                  !hasPermission(Actions.APP_ORDER_SHIPMENT_METHOD_UPDATE)
+                "
+                :label="translate('Carrier')"
+                v-model="carrierPartyId"
+                interface="popover"
+                @ionChange="updateCarrierAndShippingMethod(carrierPartyId, '')"
+                :selected-text="getSelectedCarrier(carrierPartyId)"
+              >
+                <ion-select-option
+                  v-for="carrier in facilityCarriers"
+                  :key="carrier.partyId"
+                  :value="carrier.partyId"
+                  >{{ translate(carrier.groupName) }}</ion-select-option
+                >
               </ion-select>
             </ion-item>
             <ion-item>
               <template v-if="carrierMethods && carrierMethods.length > 0">
-                <ion-select :disabled="!order.missingLabelImage || !hasPermission(Actions.APP_ORDER_SHIPMENT_METHOD_UPDATE)" :label="translate('Method')" v-model="shipmentMethodTypeId" interface="popover" @ionChange="updateCarrierAndShippingMethod(carrierPartyId, shipmentMethodTypeId)" :selected-text="getSelectedShipmentMethod(shipmentMethodTypeId)">
-                  <ion-select-option v-for="method in carrierMethods" :key="method.partyId + method.shipmentMethodTypeId" :value="method.shipmentMethodTypeId">{{ translate(method.description) }}</ion-select-option>
+                <ion-select
+                  :disabled="
+                    !order.missingLabelImage ||
+                    !hasPermission(Actions.APP_ORDER_SHIPMENT_METHOD_UPDATE)
+                  "
+                  :label="translate('Method')"
+                  v-model="shipmentMethodTypeId"
+                  interface="popover"
+                  @ionChange="
+                    updateCarrierAndShippingMethod(
+                      carrierPartyId,
+                      shipmentMethodTypeId
+                    )
+                  "
+                  :selected-text="
+                    getSelectedShipmentMethod(shipmentMethodTypeId)
+                  "
+                >
+                  <ion-select-option
+                    v-for="method in carrierMethods"
+                    :key="method.partyId + method.shipmentMethodTypeId"
+                    :value="method.shipmentMethodTypeId"
+                    >{{ translate(method.description) }}</ion-select-option
+                  >
                 </ion-select>
               </template>
               <template v-else-if="!isUpdatingCarrierDetail">
                 <ion-label>
-                  {{ translate('No shipment methods linked to', {carrierName: getCarrierName(carrierPartyId)}) }}
+                  {{
+                    translate("No shipment methods linked to", {
+                      carrierName: getCarrierName(carrierPartyId),
+                    })
+                  }}
                 </ion-label>
-                <ion-button @click="openShippingMethodDocumentReference()" fill="clear" color="medium" slot="end">
+                <ion-button
+                  @click="openShippingMethodDocumentReference()"
+                  fill="clear"
+                  color="medium"
+                  slot="end"
+                >
                   <ion-icon slot="icon-only" :icon="informationCircleOutline" />
                 </ion-button>
               </template>
@@ -301,16 +752,44 @@
             <template v-if="order.missingLabelImage">
               <ion-item lines="none" v-if="shipmentLabelErrorMessage">
                 <ion-label class="ion-text-wrap">
-                  <p class=overline>{{ translate("Error Log") }}</p>
+                  <p class="overline">{{ translate("Error Log") }}</p>
                   {{ shipmentLabelErrorMessage }}
                 </ion-label>
               </ion-item>
               <template v-if="category === 'completed'">
-                <ion-button :disabled="!shipmentMethodTypeId || !hasPackedShipments(order)" fill="outline" expand="block" class="ion-margin" @click.stop="regenerateShippingLabel(order)">
-                  {{ shipmentLabelErrorMessage ? translate("Retry Label") : translate("Generate Label") }}
-                  <ion-spinner color="primary" slot="end" data-spinner-size="medium" v-if="order.isGeneratingShippingLabel" name="crescent" />
+                <ion-button
+                  :disabled="
+                    !shipmentMethodTypeId || !hasPackedShipments(order)
+                  "
+                  fill="outline"
+                  expand="block"
+                  class="ion-margin"
+                  @click.stop="regenerateShippingLabel(order)"
+                >
+                  {{
+                    shipmentLabelErrorMessage
+                      ? translate("Retry Label")
+                      : translate("Generate Label")
+                  }}
+                  <ion-spinner
+                    color="primary"
+                    slot="end"
+                    data-spinner-size="medium"
+                    v-if="order.isGeneratingShippingLabel"
+                    name="crescent"
+                  />
                 </ion-button>
-                <ion-button :disabled="!shipmentMethodTypeId || !carrierPartyId || !hasPackedShipments(order)" fill="clear" expand="block" color="medium" @click="openTrackingCodeModal()">
+                <ion-button
+                  :disabled="
+                    !shipmentMethodTypeId ||
+                    !carrierPartyId ||
+                    !hasPackedShipments(order)
+                  "
+                  fill="clear"
+                  expand="block"
+                  color="medium"
+                  @click="openTrackingCodeModal()"
+                >
                   {{ translate("Add tracking code manually") }}
                 </ion-button>
               </template>
@@ -319,69 +798,153 @@
               <ion-label>
                 {{ order.trackingCode }}
                 <p>{{ translate("tracking code") }}</p>
-              </ion-label>        
-              <ion-button slot="end" fill="clear" color="medium" @click="shippingLabelActionPopover($event, order)">
+              </ion-label>
+              <ion-button
+                slot="end"
+                fill="clear"
+                color="medium"
+                @click="shippingLabelActionPopover($event, order)"
+              >
                 <ion-icon slot="icon-only" :icon="ellipsisVerticalOutline" />
               </ion-button>
             </ion-item>
           </ion-card>
 
-          <Component v-if="hasPermission(Actions.APP_INVOICING_STATUS_VIEW)" :is="orderInvoiceExt" :category="category" :order="order" :userProfile="userProfile" :maargBaseUrl="getMaargBaseUrl" :userToken="getUserToken" />
+          <Component
+            v-if="hasPermission(Actions.APP_INVOICING_STATUS_VIEW)"
+            :is="orderInvoiceExt"
+            :category="category"
+            :order="order"
+            :userProfile="userProfile"
+            :maargBaseUrl="getMaargBaseUrl"
+            :userToken="getUserToken"
+          />
         </div>
-        
-        <h4 class="ion-padding-top ion-padding-start" v-if="order.otherShipGroups?.length">{{ translate('Other shipments in this order') }}</h4>
+
+        <h4
+          class="ion-padding-top ion-padding-start"
+          v-if="order.otherShipGroups?.length"
+        >
+          {{ translate("Other shipments in this order") }}
+        </h4>
         <div class="shipgroup-details">
-          <ion-card v-for="shipGroup in order.otherShipGroups" :key="shipGroup.shipmentId">
+          <ion-card
+            v-for="shipGroup in order.otherShipGroups"
+            :key="shipGroup.shipmentId"
+          >
             <ion-card-header>
               <div>
-                <ion-card-subtitle class="overline">{{ getfacilityTypeDesc(shipGroup.facilityTypeId) }}</ion-card-subtitle>
-                <ion-card-title>{{ shipGroup.facilityName ?  shipGroup.facilityName : shipGroup.facilityId}}</ion-card-title>
-                {{ shipGroup.primaryShipGroupSeqId ? shipGroup.primaryShipGroupSeqId : shipGroup.shipGroupSeqId }}
+                <ion-card-subtitle class="overline">{{
+                  getfacilityTypeDesc(shipGroup.facilityTypeId)
+                }}</ion-card-subtitle>
+                <ion-card-title>{{
+                  shipGroup.facilityName
+                    ? shipGroup.facilityName
+                    : shipGroup.facilityId
+                }}</ion-card-title>
+                {{
+                  shipGroup.primaryShipGroupSeqId
+                    ? shipGroup.primaryShipGroupSeqId
+                    : shipGroup.shipGroupSeqId
+                }}
               </div>
               <ion-badge :color="shipGroup.category ? 'primary' : 'medium'">
                 {{
                   shipGroup.category
-                    ? shipGroup.category === 'open'
-                      ? translate('Open')
-                      : shipGroup.category === 'in-progress'
-                        ? translate('In Progress')
-                        : translate('Completed')
-                    : translate('Pending allocation')
+                    ? shipGroup.category === "open"
+                      ? translate("Open")
+                      : shipGroup.category === "in-progress"
+                      ? translate("In Progress")
+                      : translate("Completed")
+                    : translate("Pending allocation")
                 }}
               </ion-badge>
-
             </ion-card-header>
-    
+
             <ion-item v-if="shipGroup.carrierPartyId">
               {{ getPartyName(shipGroup.carrierPartyId) }}
               <ion-label slot="end">{{ shipGroup.trackingCode }}</ion-label>
               <ion-icon slot="end" :icon="locateOutline" />
             </ion-item>
-    
-            <ion-item v-if="shipGroup.shippingInstructions" color="light" lines="none">
+
+            <ion-item
+              v-if="shipGroup.shippingInstructions"
+              color="light"
+              lines="none"
+            >
               <ion-label class="ion-text-wrap">
                 <p class="overline">{{ translate("Handling Instructions") }}</p>
                 <p>{{ shipGroup.shippingInstructions }}</p>
               </ion-label>
             </ion-item>
-    
+
             <ion-item lines="none" v-for="item in shipGroup.items" :key="item">
-              <ion-thumbnail slot="start" v-image-preview="getProduct(item.productId)" :key="getProduct(item.productId)?.mainImageUrl">
-                <DxpShopifyImg :src="getProduct(item.productId).mainImageUrl" size="small"/>
+              <ion-thumbnail
+                slot="start"
+                v-image-preview="getProduct(item.productId)"
+                :key="getProduct(item.productId)?.mainImageUrl"
+              >
+                <DxpShopifyImg
+                  :src="getProduct(item.productId).mainImageUrl"
+                  size="small"
+                />
               </ion-thumbnail>
               <ion-label>
-                <p class="overline">{{ getProductIdentificationValue(productIdentificationPref.secondaryId, getProduct(item.productId)) }}</p>
+                <p class="overline">
+                  {{
+                    getProductIdentificationValue(
+                      productIdentificationPref.secondaryId,
+                      getProduct(item.productId)
+                    )
+                  }}
+                </p>
                 <div>
-                  {{ getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) ? getProductIdentificationValue(productIdentificationPref.primaryId, getProduct(item.productId)) : getProduct(item.productId).productName }}
-                  <ion-badge class="kit-badge" color="dark" v-if="isKit(item)">{{ translate("Kit") }}</ion-badge>
+                  {{
+                    getProductIdentificationValue(
+                      productIdentificationPref.primaryId,
+                      getProduct(item.productId)
+                    )
+                      ? getProductIdentificationValue(
+                          productIdentificationPref.primaryId,
+                          getProduct(item.productId)
+                        )
+                      : getProduct(item.productId).productName
+                  }}
+                  <ion-badge
+                    class="kit-badge"
+                    color="dark"
+                    v-if="isKit(item)"
+                    >{{ translate("Kit") }}</ion-badge
+                  >
                 </div>
               </ion-label>
-              
+
               <div class="other-shipment-actions">
                 <!-- TODO: add a spinner if the api takes too long to fetch the stock -->
-                <ion-note slot="end" v-if="getProductStock(item.productId, item.facilityId).qoh">{{ getProductStock(item.productId, item.facilityId).qoh }} {{ translate('pieces in stock') }}</ion-note>
-                <ion-button slot="end" fill="clear" v-else-if="['open', 'in-progress', 'completed'].includes(shipGroup.category)" size="small" @click.stop="fetchProductStock(item.productId, item.facilityId)">
-                  <ion-icon color="medium" slot="icon-only" :icon="cubeOutline"/>
+                <ion-note
+                  slot="end"
+                  v-if="getProductStock(item.productId, item.facilityId).qoh"
+                  >{{ getProductStock(item.productId, item.facilityId).qoh }}
+                  {{ translate("pieces in stock") }}</ion-note
+                >
+                <ion-button
+                  slot="end"
+                  fill="clear"
+                  v-else-if="
+                    ['open', 'in-progress', 'completed'].includes(
+                      shipGroup.category
+                    )
+                  "
+                  size="small"
+                  @click.stop="
+                    fetchProductStock(item.productId, item.facilityId)
+                  "
+                >
+                  <ion-icon
+                    color="medium"
+                    slot="icon-only"
+                    :icon="cubeOutline"
+                  />
                 </ion-button>
               </div>
             </ion-item>
@@ -393,7 +956,13 @@
         <ion-label>{{ translate("Loading...") }}</ion-label>
       </div>
       <div v-else class="empty-state">
-        <p>{{ translate("Unable to fetch the order details. Either the order has been shipped or something went wrong. Please try again after some time.")}}</p>
+        <p>
+          {{
+            translate(
+              "Unable to fetch the order details. Either the order has been shipped or something went wrong. Please try again after some time."
+            )
+          }}
+        </p>
       </div>
     </ion-content>
   </ion-page>
@@ -427,11 +996,11 @@ import {
   IonToolbar,
   IonThumbnail,
   modalController,
-  popoverController
+  popoverController,
 } from "@ionic/vue";
 import { computed, defineComponent } from "vue";
 import { mapGetters, useStore } from "vuex";
-import { useRouter } from 'vue-router'
+import { useRouter } from "vue-router";
 import {
   addOutline,
   archiveOutline,
@@ -453,37 +1022,51 @@ import {
   pricetagOutline,
   trashBinOutline,
   ribbonOutline,
-  checkmarkCircleOutline
-} from 'ionicons/icons';
-import { getProductIdentificationValue, translate, DxpShopifyImg, useProductIdentificationStore, useUserStore } from '@hotwax/dxp-components';
-import { copyToClipboard, formatUtcDate, getFeatures, getFacilityFilter, showToast, getColorByDesc, formatCurrency } from '@/utils'
-import { Actions, hasPermission } from '@/authorization'
-import OrderActionsPopover from '@/components/OrderActionsPopover.vue'
-import emitter from '@/event-bus';
+  checkmarkCircleOutline,
+} from "ionicons/icons";
+import {
+  getProductIdentificationValue,
+  translate,
+  DxpShopifyImg,
+  useProductIdentificationStore,
+  useUserStore,
+} from "@hotwax/dxp-components";
+import {
+  copyToClipboard,
+  formatUtcDate,
+  getFeatures,
+  getFacilityFilter,
+  showToast,
+  getColorByDesc,
+  formatCurrency,
+} from "@/utils";
+import { Actions, hasPermission } from "@/authorization";
+import OrderActionsPopover from "@/components/OrderActionsPopover.vue";
+import emitter from "@/event-bus";
 import { OrderService } from "@/services/OrderService";
 import { hasError } from "@/adapter";
-import logger from '@/logger';
+import logger from "@/logger";
 import { UtilService } from "@/services/UtilService";
-import { DateTime } from 'luxon';
-import { prepareOrderQuery, prepareSolrQuery } from '@/utils/solrHelper';
-import Popover from '@/views/ShippingPopover.vue'
+import { DateTime } from "luxon";
+import { prepareOrderQuery, prepareSolrQuery } from "@/utils/solrHelper";
+import Popover from "@/views/ShippingPopover.vue";
 import PackagingPopover from "@/views/PackagingPopover.vue";
-import AssignPickerModal from '@/views/AssignPickerModal.vue';
-import ShipmentBoxTypePopover from '@/components/ShipmentBoxTypePopover.vue'
-import ShipmentBoxPopover from '@/components/ShipmentBoxPopover.vue'
-import ReportIssuePopover from '@/components/ReportIssuePopover.vue'
-import { isKit, retryShippingLabel } from '@/utils/order'
+import AssignPickerModal from "@/views/AssignPickerModal.vue";
+import ShipmentBoxTypePopover from "@/components/ShipmentBoxTypePopover.vue";
+import ShipmentBoxPopover from "@/components/ShipmentBoxPopover.vue";
+import ReportIssuePopover from "@/components/ReportIssuePopover.vue";
+import { isKit, retryShippingLabel } from "@/utils/order";
 import ScanOrderItemModal from "@/components/ScanOrderItemModal.vue";
-import ShippingLabelActionPopover from '@/components/ShippingLabelActionPopover.vue';
-import GenerateTrackingCodeModal from '@/components/GenerateTrackingCodeModal.vue';
-import TrackingCodeModal from '@/components/TrackingCodeModal.vue';
-import GiftCardActivationModal from '@/components/GiftCardActivationModal.vue';
+import ShippingLabelActionPopover from "@/components/ShippingLabelActionPopover.vue";
+import GenerateTrackingCodeModal from "@/components/GenerateTrackingCodeModal.vue";
+import TrackingCodeModal from "@/components/TrackingCodeModal.vue";
+import GiftCardActivationModal from "@/components/GiftCardActivationModal.vue";
 import { useDynamicImport } from "@/utils/moduleFederation";
 import OrderAdjustmentModal from "@/components/OrderAdjustmentModal.vue";
 
 export default defineComponent({
   name: "OrderDetail",
-  props: ['category', 'orderId', 'shipGroupSeqId', 'shipmentId'],
+  props: ["category", "orderId", "shipGroupSeqId", "shipmentId"],
   components: {
     DxpShopifyImg,
     IonBackButton,
@@ -509,39 +1092,39 @@ export default defineComponent({
     IonSpinner,
     IonTitle,
     IonToolbar,
-    IonThumbnail
+    IonThumbnail,
   },
   computed: {
     ...mapGetters({
-      boxTypeDesc: 'util/getShipmentBoxDesc',
-      completedOrders: 'order/getCompletedOrders',
-      getProduct: 'product/getProduct',
-      getProductStock: 'stock/getProductStock',
-      inProgressOrders: 'order/getInProgressOrders',
+      boxTypeDesc: "util/getShipmentBoxDesc",
+      completedOrders: "order/getCompletedOrders",
+      getProduct: "product/getProduct",
+      getProductStock: "stock/getProductStock",
+      inProgressOrders: "order/getInProgressOrders",
       order: "order/getCurrent",
-      rejectReasonOptions: 'util/getRejectReasonOptions',
-      userPreference: 'user/getUserPreference',
-      getPartyName: 'util/getPartyName',
-      getfacilityTypeDesc: 'util/getFacilityTypeDesc',
-      getPaymentMethodDesc: 'util/getPaymentMethodDesc',
-      getStatusDesc: 'util/getStatusDesc',
-      productStoreShipmentMethCount: 'util/getProductStoreShipmentMethCount',
-      partialOrderRejectionConfig: 'util/getPartialOrderRejectionConfig',
-      collateralRejectionConfig: 'util/getCollateralRejectionConfig',
-      affectQohConfig: 'util/getAffectQohConfig',
+      rejectReasonOptions: "util/getRejectReasonOptions",
+      userPreference: "user/getUserPreference",
+      getPartyName: "util/getPartyName",
+      getfacilityTypeDesc: "util/getFacilityTypeDesc",
+      getPaymentMethodDesc: "util/getPaymentMethodDesc",
+      getStatusDesc: "util/getStatusDesc",
+      productStoreShipmentMethCount: "util/getProductStoreShipmentMethCount",
+      partialOrderRejectionConfig: "util/getPartialOrderRejectionConfig",
+      collateralRejectionConfig: "util/getCollateralRejectionConfig",
+      affectQohConfig: "util/getAffectQohConfig",
       excludeOrderBrokerDays: "util/getExcludeOrderBrokerDays",
-      isForceScanEnabled: 'util/isForceScanEnabled',
-      productStoreShipmentMethods: 'carrier/getProductStoreShipmentMethods',
-      facilityCarriers: 'carrier/getFacilityCarriers',
-      userProfile: 'user/getUserProfile',
-      isShipNowDisabled: 'util/isShipNowDisabled',
-      isUnpackDisabled: 'util/isUnpackDisabled',
+      isForceScanEnabled: "util/isForceScanEnabled",
+      productStoreShipmentMethods: "carrier/getProductStoreShipmentMethods",
+      facilityCarriers: "carrier/getFacilityCarriers",
+      userProfile: "user/getUserProfile",
+      isShipNowDisabled: "util/isShipNowDisabled",
+      isUnpackDisabled: "util/isUnpackDisabled",
       instanceUrl: "user/getInstanceUrl",
-      carrierShipmentBoxTypes: 'util/getCarrierShipmentBoxTypes',
-      getShipmentMethodDesc: 'util/getShipmentMethodDesc',
-      getUserToken: 'user/getUserToken',
-      getMaargBaseUrl: 'user/getMaargBaseUrl'
-    })
+      carrierShipmentBoxTypes: "util/getCarrierShipmentBoxTypes",
+      getShipmentMethodDesc: "util/getShipmentMethodDesc",
+      getUserToken: "user/getUserToken",
+      getMaargBaseUrl: "user/getMaargBaseUrl",
+    }),
   },
   data() {
     return {
@@ -552,20 +1135,20 @@ export default defineComponent({
       defaultShipmentBoxType: {} as any,
       itemsIssueSegmentSelected: [] as any,
       statusColor: {
-        'PAYMENT_AUTHORIZED': '',
-        'PAYMENT_CANCELLED': 'warning',
-        'PAYMENT_DECLINED': 'warning',
-        'PAYMENT_NOT_AUTH': 'warning',
-        'PAYMENT_NOT_RECEIVED': 'warning',
-        'PAYMENT_RECEIVED': '',
-        'PAYMENT_REFUNDED': 'warning',
-        'PAYMENT_SETTLED': ''
+        PAYMENT_AUTHORIZED: "",
+        PAYMENT_CANCELLED: "warning",
+        PAYMENT_DECLINED: "warning",
+        PAYMENT_NOT_AUTH: "warning",
+        PAYMENT_NOT_RECEIVED: "warning",
+        PAYMENT_RECEIVED: "",
+        PAYMENT_REFUNDED: "warning",
+        PAYMENT_SETTLED: "",
       } as any,
       rejectEntireOrderReasonId: "REJ_AVOID_ORD_SPLIT",
       shipmentLabelErrorMessage: "",
       shipmentMethodTypeId: "",
       carrierPartyId: "",
-      carrierMethods:[] as any,
+      carrierMethods: [] as any,
       isUpdatingCarrierDetail: false,
       orderInvoicingInfo: {} as any,
       orderInvoiceExt: "" as any,
@@ -575,57 +1158,98 @@ export default defineComponent({
       orderHeaderAdjustmentTotal: 0,
       adjustmentsByGroup: {} as any,
       orderAdjustmentShipmentId: "",
-      printDocumentsExt: "" as any
-    }
+      printDocumentsExt: "" as any,
+    };
   },
   async ionViewDidEnter() {
-    this.store.dispatch('util/fetchRejectReasonOptions')
-    this.category === 'open'
-    ? await this.store.dispatch('order/getOpenOrder', { orderId: this.orderId, shipGroupSeqId: this.shipGroupSeqId})
-    : this.category === 'in-progress'
-    ? await this.store.dispatch('order/getInProgressOrder', { orderId: this.orderId, shipmentId: this.shipmentId })
-    : await this.store.dispatch('order/getCompletedOrder', { orderId: this.orderId, shipmentId: this.shipmentId })
-    await Promise.all([this.store.dispatch('util/fetchCarrierShipmentBoxTypes'), this.store.dispatch('carrier/fetchFacilityCarriers'), this.store.dispatch('carrier/fetchProductStoreShipmentMeths'), this.fetchOrderInvoicingStatus()]);
+    this.store.dispatch("util/fetchRejectReasonOptions");
+    this.category === "open"
+      ? await this.store.dispatch("order/getOpenOrder", {
+          orderId: this.orderId,
+          shipGroupSeqId: this.shipGroupSeqId,
+        })
+      : this.category === "in-progress"
+      ? await this.store.dispatch("order/getInProgressOrder", {
+          orderId: this.orderId,
+          shipmentId: this.shipmentId,
+        })
+      : await this.store.dispatch("order/getCompletedOrder", {
+          orderId: this.orderId,
+          shipmentId: this.shipmentId,
+        });
+    await Promise.all([
+      this.store.dispatch("util/fetchCarrierShipmentBoxTypes"),
+      this.store.dispatch("carrier/fetchFacilityCarriers"),
+      this.store.dispatch("carrier/fetchProductStoreShipmentMeths"),
+      this.fetchOrderInvoicingStatus(),
+    ]);
     if (this.facilityCarriers) {
-      const shipmentPackageRouteSegDetail = this.order.shipmentPackageRouteSegDetails?.[0];
-      this.carrierPartyId = shipmentPackageRouteSegDetail?.carrierPartyId ? shipmentPackageRouteSegDetail?.carrierPartyId : this.facilityCarriers[0].partyId;
-      this.carrierMethods = await this.getProductStoreShipmentMethods(this.carrierPartyId);
-      this.shipmentMethodTypeId = shipmentPackageRouteSegDetail?.shipmentMethodTypeId;
+      const shipmentPackageRouteSegDetail =
+        this.order.shipmentPackageRouteSegDetails?.[0];
+      this.carrierPartyId = shipmentPackageRouteSegDetail?.carrierPartyId
+        ? shipmentPackageRouteSegDetail?.carrierPartyId
+        : this.facilityCarriers[0].partyId;
+      this.carrierMethods = await this.getProductStoreShipmentMethods(
+        this.carrierPartyId
+      );
+      this.shipmentMethodTypeId =
+        shipmentPackageRouteSegDetail?.shipmentMethodTypeId;
     }
-    
-    // Fetching shipment label errors 
-    await this.fetchShipmentLabelError()
 
-    this.isCODPaymentPending = false
-    this.isOrderAdjustmentPending = false
+    // Fetching shipment label errors
+    await this.fetchShipmentLabelError();
+
+    this.isCODPaymentPending = false;
+    this.isOrderAdjustmentPending = false;
     this.fetchCODPaymentInfo();
-},
+  },
   async mounted() {
     // Remove http://, https://, /api, or :port
-    const instance = this.instanceUrl.split("-")[0].replace(new RegExp("^(https|http)://"), "").replace(new RegExp("/api.*"), "").replace(new RegExp(":.*"), "")
-    this.printDocumentsExt = await useDynamicImport({ scope: "fulfillment_extensions", module: `${instance}_PrintDocument`})
-    this.orderInvoiceExt = await useDynamicImport({ scope: "fulfillment_extensions", module: `${instance}_OrderInvoice`})
+    const instance = this.instanceUrl
+      .split("-")[0]
+      .replace(new RegExp("^(https|http)://"), "")
+      .replace(new RegExp("/api.*"), "")
+      .replace(new RegExp(":.*"), "");
+    this.printDocumentsExt = await useDynamicImport({
+      scope: "fulfillment_extensions",
+      module: `${instance}_PrintDocument`,
+    });
+    this.orderInvoiceExt = await useDynamicImport({
+      scope: "fulfillment_extensions",
+      module: `${instance}_OrderInvoice`,
+    });
   },
   methods: {
     getTime(time: any) {
       return DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED);
     },
     async fetchShipmentLabelError() {
-      const shipmentId = this.order?.shipmentId
+      const shipmentId = this.order?.shipmentId;
       const labelError = await OrderService.fetchShipmentLabelError(shipmentId);
       if (labelError) {
-        this.shipmentLabelErrorMessage = labelError
+        this.shipmentLabelErrorMessage = labelError;
       }
     },
     getCarrierName(carrierPartyId: string) {
-      const selectedCarrier = this.facilityCarriers.find((carrier: any) => carrier.partyId === carrierPartyId)
-      return selectedCarrier && selectedCarrier.groupName ? selectedCarrier.groupName : carrierPartyId
+      const selectedCarrier = this.facilityCarriers.find(
+        (carrier: any) => carrier.partyId === carrierPartyId
+      );
+      return selectedCarrier && selectedCarrier.groupName
+        ? selectedCarrier.groupName
+        : carrierPartyId;
     },
     openShippingMethodDocumentReference() {
-      window.open('https://docs.hotwax.co/documents/v/system-admins/fulfillment/shipping-methods/carrier-and-shipment-methods', '_blank');
+      window.open(
+        "https://docs.hotwax.co/documents/v/system-admins/fulfillment/shipping-methods/carrier-and-shipment-methods",
+        "_blank"
+      );
     },
-    async getProductStoreShipmentMethods(carrierPartyId: string) { 
-      return this.productStoreShipmentMethods?.filter((method: any) => method.partyId === carrierPartyId) || [];
+    async getProductStoreShipmentMethods(carrierPartyId: string) {
+      return (
+        this.productStoreShipmentMethods?.filter(
+          (method: any) => method.partyId === carrierPartyId
+        ) || []
+      );
     },
     async shippingLabelActionPopover(ev: Event, currentOrder: any) {
       const popover = await popoverController.create({
@@ -634,95 +1258,143 @@ export default defineComponent({
           currentOrder: currentOrder,
         },
         event: ev,
-        showBackdrop: false
+        showBackdrop: false,
       });
 
-      return popover.present()
+      return popover.present();
     },
-    async updateCarrierAndShippingMethod(carrierPartyId: string, shipmentMethodTypeId: string) {
+    async updateCarrierAndShippingMethod(
+      carrierPartyId: string,
+      shipmentMethodTypeId: string
+    ) {
       let resp;
       try {
         emitter.emit("presentLoader");
         this.isUpdatingCarrierDetail = true;
-        const carrierShipmentMethods = await this.getProductStoreShipmentMethods(carrierPartyId);
-        shipmentMethodTypeId = shipmentMethodTypeId ? shipmentMethodTypeId : carrierShipmentMethods?.[0]?.shipmentMethodTypeId;
-        const shipmentRouteSegmentId = this.order?.shipmentPackageRouteSegDetails[0]?.shipmentRouteSegmentId
-        const isTrackingRequired = carrierShipmentMethods.find((method: any) => method.shipmentMethodTypeId === shipmentMethodTypeId)?.isTrackingRequired
+        const carrierShipmentMethods =
+          await this.getProductStoreShipmentMethods(carrierPartyId);
+        shipmentMethodTypeId = shipmentMethodTypeId
+          ? shipmentMethodTypeId
+          : carrierShipmentMethods?.[0]?.shipmentMethodTypeId;
+        const shipmentRouteSegmentId =
+          this.order?.shipmentPackageRouteSegDetails[0]?.shipmentRouteSegmentId;
+        const isTrackingRequired = carrierShipmentMethods.find(
+          (method: any) => method.shipmentMethodTypeId === shipmentMethodTypeId
+        )?.isTrackingRequired;
 
         const params = {
           shipmentId: this.order.shipmentId,
           shipmentRouteSegmentId,
-          shipmentMethodTypeId : shipmentMethodTypeId ? shipmentMethodTypeId : "",
+          shipmentMethodTypeId: shipmentMethodTypeId
+            ? shipmentMethodTypeId
+            : "",
           carrierPartyId,
-          isTrackingRequired: isTrackingRequired ? isTrackingRequired : "Y"
-        }
+          isTrackingRequired: isTrackingRequired ? isTrackingRequired : "Y",
+        };
 
-        resp = await OrderService.updateShipmentCarrierAndMethod(params)
+        resp = await OrderService.updateShipmentCarrierAndMethod(params);
         if (!hasError(resp)) {
-          this.shipmentMethodTypeId = shipmentMethodTypeId
+          this.shipmentMethodTypeId = shipmentMethodTypeId;
           emitter.emit("dismissLoader");
-          showToast(translate("Shipment method detail updated successfully."))
-          
+          showToast(translate("Shipment method detail updated successfully."));
+
           //fetching updated shipment packages
-          await this.store.dispatch('order/updateShipmentPackageDetail', this.order) 
+          await this.store.dispatch(
+            "order/updateShipmentPackageDetail",
+            this.order
+          );
           this.carrierMethods = carrierShipmentMethods;
           this.isUpdatingCarrierDetail = false;
         } else {
           throw resp.data;
         }
-        
       } catch (err) {
         this.isUpdatingCarrierDetail = false;
         this.carrierPartyId = this.order.shipmentPackages?.[0].carrierPartyId;
-        this.shipmentMethodTypeId = this.order.shipmentPackages?.[0].shipmentMethodTypeId;
+        this.shipmentMethodTypeId =
+          this.order.shipmentPackages?.[0].shipmentMethodTypeId;
 
         emitter.emit("dismissLoader");
-        logger.error('Failed to update carrier and method', err);
+        logger.error("Failed to update carrier and method", err);
         showToast(translate("Failed to update shipment method detail."));
       }
     },
-    async updateCarrierShipmentDetails(carrierPartyId: string, shipmentMethodTypeId: string) {
-      this.carrierPartyId = carrierPartyId
-      this.shipmentMethodTypeId = shipmentMethodTypeId
-      this.carrierMethods = await this.getProductStoreShipmentMethods(carrierPartyId);
-      this.shipmentLabelErrorMessage = ""
+    async updateCarrierShipmentDetails(
+      carrierPartyId: string,
+      shipmentMethodTypeId: string
+    ) {
+      this.carrierPartyId = carrierPartyId;
+      this.shipmentMethodTypeId = shipmentMethodTypeId;
+      this.carrierMethods = await this.getProductStoreShipmentMethods(
+        carrierPartyId
+      );
+      this.shipmentLabelErrorMessage = "";
     },
-    async fetchKitComponent(orderItem: any, isOtherShipment = false ) {
-      await this.store.dispatch('product/fetchProductComponents', { productId: orderItem.productId })
-      
+    async fetchKitComponent(orderItem: any, isOtherShipment = false) {
+      await this.store.dispatch("product/fetchProductComponents", {
+        productId: orderItem.productId,
+      });
+
       //update the order in order to toggle kit components section
       if (isOtherShipment) {
-        const updatedShipGroup = this.order?.shipGroups.find((shipGroup: any) => shipGroup.shipGroupSeqId === orderItem.shipGroupSeqId)
-        if (updatedShipGroup){
-          const updatedItem = updatedShipGroup?.items.find((item: any) => item.orderItemSeqId === orderItem.orderItemSeqId)
-          updatedItem.showKitComponents = orderItem.showKitComponents ? false : true
+        const updatedShipGroup = this.order?.shipGroups.find(
+          (shipGroup: any) =>
+            shipGroup.shipGroupSeqId === orderItem.shipGroupSeqId
+        );
+        if (updatedShipGroup) {
+          const updatedItem = updatedShipGroup?.items.find(
+            (item: any) => item.orderItemSeqId === orderItem.orderItemSeqId
+          );
+          updatedItem.showKitComponents = orderItem.showKitComponents
+            ? false
+            : true;
         }
       } else {
-        const updatedItem = this.order.items.find((item: any) => item.orderItemSeqId === orderItem.orderItemSeqId)
-        updatedItem.showKitComponents = orderItem.showKitComponents ? false : true
+        const updatedItem = this.order.items.find(
+          (item: any) => item.orderItemSeqId === orderItem.orderItemSeqId
+        );
+        updatedItem.showKitComponents = orderItem.showKitComponents
+          ? false
+          : true;
         if (!updatedItem.kitComponents) {
-          updatedItem.kitComponents = this.getProduct(updatedItem.productId).productComponents.map((productComponent: any) => productComponent.productIdTo)
+          updatedItem.kitComponents = this.getProduct(
+            updatedItem.productId
+          ).productComponents.map(
+            (productComponent: any) => productComponent.productIdTo
+          );
         }
       }
     },
-    getRejectionReasonDescription (rejectionReasonId: string) {
-      const reason = this.rejectReasonOptions?.find((reason: any) => reason.enumId === rejectionReasonId)
-      return reason?.description ? reason.description : reason?.enumDescription ? reason.enumDescription : reason?.enumId;
+    getRejectionReasonDescription(rejectionReasonId: string) {
+      const reason = this.rejectReasonOptions?.find(
+        (reason: any) => reason.enumId === rejectionReasonId
+      );
+      return reason?.description
+        ? reason.description
+        : reason?.enumDescription
+        ? reason.enumDescription
+        : reason?.enumId;
     },
     isEntierOrderRejectionEnabled(order: any) {
-      return !this.partialOrderRejectionConfig && order.hasRejectedItem
+      return !this.partialOrderRejectionConfig && order.hasRejectedItem;
     },
-    async printPicklist (order: any) {
-      await OrderService.printPicklist(order.picklistId)
+    async printPicklist(order: any) {
+      await OrderService.printPicklist(order.picklistId);
     },
-    async openShipmentBoxPopover(ev: Event, item: any, order: any, kitProducts?: any, orderItemSeqId?: number) {
+    async openShipmentBoxPopover(
+      ev: Event,
+      item: any,
+      order: any,
+      kitProducts?: any,
+      orderItemSeqId?: number
+    ) {
       const popover = await popoverController.create({
         component: ShipmentBoxPopover,
-        componentProps: { 
-          shipmentPackages: order.shipmentPackages
+        componentProps: {
+          shipmentPackages: order.shipmentPackages,
         },
         showBackdrop: false,
-        event: ev
+        event: ev,
       });
 
       popover.present();
@@ -731,11 +1403,11 @@ export default defineComponent({
 
       if (result.data && item.selectedBox !== result.data) {
         order.items.map((orderItem: any) => {
-          if(orderItem.orderItemSeqId === item.orderItemSeqId) {
-            orderItem.selectedBox = result.data
+          if (orderItem.orderItemSeqId === item.orderItemSeqId) {
+            orderItem.selectedBox = result.data;
           }
-        })
-        }
+        });
+      }
       return result.data;
     },
     async orderActionsPopover(order: any, ev: Event) {
@@ -743,16 +1415,18 @@ export default defineComponent({
         component: OrderActionsPopover,
         componentProps: { order },
         showBackdrop: false,
-        event: ev
+        event: ev,
       });
       return popover.present();
     },
-    fetchProductStock(productId: string, facilityId = '') {
-      this.store.dispatch('stock/fetchStock', { productId, facilityId })
+    fetchProductStock(productId: string, facilityId = "") {
+      this.store.dispatch("stock/fetchStock", { productId, facilityId });
     },
     async packOrder(order: any) {
       if (order.hasRejectedItem) {
-        const itemsToReject = order.items.filter((item: any) => item.rejectReason)
+        const itemsToReject = order.items.filter(
+          (item: any) => item.rejectReason
+        );
         this.reportIssue(order, itemsToReject);
         return;
       }
@@ -762,108 +1436,147 @@ export default defineComponent({
       let forceScan = this.isForceScanEnabled;
       if (this.isEntierOrderRejectionEnabled(order)) {
         //no need to scan when all the items are going to reject when partial order rejection is not allowed
-        forceScan = false
+        forceScan = false;
       } else if (forceScan) {
         //no need to scan when all the items are going to reject
-        forceScan = !order.items.every((item: any) => item.rejectReason)
+        forceScan = !order.items.every((item: any) => item.rejectReason);
       }
 
       if (order.hasAllRejectedItem) {
-        const isSuccess = await this.rejectEntireOrder(order, updateParameter)
+        const isSuccess = await this.rejectEntireOrder(order, updateParameter);
         if (isSuccess) {
-          this.router.push('/in-progress')
+          this.router.push("/in-progress");
         }
       } else if (forceScan) {
-        await this.scanOrder(order, updateParameter)
+        await this.scanOrder(order, updateParameter);
       } else {
         await this.confirmPackOrder(order, updateParameter);
       }
     },
     async rejectEntireOrder(order: any, updateParameter?: string) {
-      emitter.emit('presentLoader');
+      emitter.emit("presentLoader");
       try {
-        const updatedOrderDetail = await this.getUpdatedOrderDetail(order, updateParameter)
+        const updatedOrderDetail = await this.getUpdatedOrderDetail(
+          order,
+          updateParameter
+        );
         const params = {
           shipmentId: order.shipmentId,
           orderId: order.orderId,
           facilityId: order.originFacilityId,
-          rejectedOrderItems: updatedOrderDetail.rejectedOrderItems
-        }
+          rejectedOrderItems: updatedOrderDetail.rejectedOrderItems,
+        };
         const resp = await OrderService.packOrder(params);
 
         if (hasError(resp)) {
-          throw resp.data
+          throw resp.data;
         }
 
         // await Promise.all([this.fetchPickersInformation(), this.updateOrderQuery("", "", true)]);
-        showToast(translate('Order rejected successfully'));
+        showToast(translate("Order rejected successfully"));
         return true;
       } catch (err) {
-        logger.error('Failed to reject order', err)
-        showToast(translate('Failed to reject order'))
+        logger.error("Failed to reject order", err);
+        showToast(translate("Failed to reject order"));
       } finally {
         emitter.emit("dismissLoader");
       }
-      return false
+      return false;
     },
-    async confirmPackOrder(order: any, updateParameter?: string, trackingCode?: string) {
-      const confirmPackOrder = await alertController
-        .create({
-          header: translate("Pack order"),
-          message: translate("You are packing an order. Select additional documents that you would like to print.", {space: '<br /><br />'}),
-          inputs: [{
-            name: 'printShippingLabel',
-            type: 'checkbox',
-            label: translate('Shipping labels'),
-            value: 'printShippingLabel',
+    async confirmPackOrder(
+      order: any,
+      updateParameter?: string,
+      trackingCode?: string
+    ) {
+      const confirmPackOrder = await alertController.create({
+        header: translate("Pack order"),
+        message: translate(
+          "You are packing an order. Select additional documents that you would like to print.",
+          { space: "<br /><br />" }
+        ),
+        inputs: [
+          {
+            name: "printShippingLabel",
+            type: "checkbox",
+            label: translate("Shipping labels"),
+            value: "printShippingLabel",
             checked: this.userPreference.printShippingLabel,
-          }, {
-            name: 'printPackingSlip',
-            type: 'checkbox',
-            label: translate('Packing slip'),
-            value: 'printPackingSlip',
-            checked: this.userPreference.printPackingSlip
-          }],
-          buttons: [{
+          },
+          {
+            name: "printPackingSlip",
+            type: "checkbox",
+            label: translate("Packing slip"),
+            value: "printPackingSlip",
+            checked: this.userPreference.printPackingSlip,
+          },
+        ],
+        buttons: [
+          {
             text: translate("Cancel"),
-            role: 'cancel'
-          }, {
+            role: "cancel",
+          },
+          {
             text: translate("Pack"),
-            role: 'confirm',
+            role: "confirm",
             handler: async (data) => {
-              const packingResponse = await this.executePackOrder(order, updateParameter, trackingCode, data)
+              const packingResponse = await this.executePackOrder(
+                order,
+                updateParameter,
+                trackingCode,
+                data
+              );
               if (!packingResponse.isPacked) {
                 //On error in packing, fetching update detail expecially to fetch carrier, shipment method, gteway message etc. If there is error (gatewayMessage not empty) opening Generate tracking code modal to enter tracking detail manually
-                const updatedOrder = await this.store.dispatch('order/updateShipmentPackageDetail', order)
-                await this.generateTrackingCodeForPacking(updatedOrder, updateParameter, data, packingResponse.errors)
+                const updatedOrder = await this.store.dispatch(
+                  "order/updateShipmentPackageDetail",
+                  order
+                );
+                await this.generateTrackingCodeForPacking(
+                  updatedOrder,
+                  updateParameter,
+                  data,
+                  packingResponse.errors
+                );
               }
-            }
-          }]
-        });
+            },
+          },
+        ],
+      });
       return confirmPackOrder.present();
     },
-    async executePackOrder(order: any, updateParameter?: string, trackingCode?: string, documentOptions?: any) {
-      emitter.emit('presentLoader');
+    async executePackOrder(
+      order: any,
+      updateParameter?: string,
+      trackingCode?: string,
+      documentOptions?: any
+    ) {
+      emitter.emit("presentLoader");
       let toast: any;
-      const shipmentIds = [order.shipmentId]
-      const manualTrackingCode = trackingCode
+      const shipmentIds = [order.shipmentId];
+      const manualTrackingCode = trackingCode;
 
       try {
-        const updatedOrderDetail = await this.getUpdatedOrderDetail(order, updateParameter) as any
+        const updatedOrderDetail = (await this.getUpdatedOrderDetail(
+          order,
+          updateParameter
+        )) as any;
         const params = {
           shipmentId: order.shipmentId,
           orderId: order.primaryOrderId,
           facilityId: order.originFacilityId,
           rejectedOrderItems: updatedOrderDetail.rejectedOrderItems,
           shipmentPackageContents: updatedOrderDetail.shipmentPackageContents,
-          trackingCode: manualTrackingCode
-        }
+          trackingCode: manualTrackingCode,
+        };
 
         const resp = await OrderService.packOrder(params);
         if (hasError(resp)) {
-          throw resp.data
+          throw resp.data;
         }
-        await this.store.dispatch('order/updateShipmentPackageDetail', this.order)
+        await this.store.dispatch(
+          "order/updateShipmentPackageDetail",
+          this.order
+        );
         const shippingLabelPdfUrls: string[] = Array.from(
           new Set(
             (this.order.shipmentPackages ?? [])
@@ -872,99 +1585,137 @@ export default defineComponent({
           )
         );
 
-        emitter.emit('dismissLoader');
+        emitter.emit("dismissLoader");
 
         if (documentOptions.length) {
           // additional parameters for dismiss button and manual dismiss ability
-          toast = await showToast(translate('Order packed successfully. Document generation in process'), { canDismiss: true, manualDismiss: true })
-          toast.present()
+          toast = await showToast(
+            translate(
+              "Order packed successfully. Document generation in process"
+            ),
+            { canDismiss: true, manualDismiss: true }
+          );
+          toast.present();
 
-          if (documentOptions.includes('printPackingSlip') && documentOptions.includes('printShippingLabel')) {
+          if (
+            documentOptions.includes("printPackingSlip") &&
+            documentOptions.includes("printShippingLabel")
+          ) {
             if (shippingLabelPdfUrls && shippingLabelPdfUrls.length > 0) {
-              await OrderService.printPackingSlip(shipmentIds)
-              await OrderService.printShippingLabel(shipmentIds, shippingLabelPdfUrls, order.shipmentPackages);
+              await OrderService.printPackingSlip(shipmentIds);
+              await OrderService.printShippingLabel(
+                shipmentIds,
+                shippingLabelPdfUrls,
+                order.shipmentPackages
+              );
             } else {
-              await OrderService.printShippingLabelAndPackingSlip(shipmentIds, order.shipmentPackages)
+              await OrderService.printShippingLabelAndPackingSlip(
+                shipmentIds,
+                order.shipmentPackages
+              );
             }
-          } else if (documentOptions.includes('printPackingSlip')) {
-            await OrderService.printPackingSlip(shipmentIds)
-          } else if (documentOptions.includes('printShippingLabel') && !manualTrackingCode && !this.order.missingLabelImage) {
-            await OrderService.printShippingLabel(shipmentIds, shippingLabelPdfUrls, order.shipmentPackages);
+          } else if (documentOptions.includes("printPackingSlip")) {
+            await OrderService.printPackingSlip(shipmentIds);
+          } else if (
+            documentOptions.includes("printShippingLabel") &&
+            !manualTrackingCode &&
+            !this.order.missingLabelImage
+          ) {
+            await OrderService.printShippingLabel(
+              shipmentIds,
+              shippingLabelPdfUrls,
+              order.shipmentPackages
+            );
           }
           if (order.shipmentPackages?.[0].internationalInvoiceUrl) {
-            await OrderService.printCustomDocuments([order.shipmentPackages?.[0].internationalInvoiceUrl]);
+            await OrderService.printCustomDocuments([
+              order.shipmentPackages?.[0].internationalInvoiceUrl,
+            ]);
           }
 
-          toast.dismiss()
+          toast.dismiss();
         } else {
-          showToast(translate('Order packed successfully'));
+          showToast(translate("Order packed successfully"));
         }
-        this.router.replace(`/completed/shipment-detail/${this.orderId}/${this.shipmentId}`)
-        return {isPacked: true}
+        this.router.replace(
+          `/completed/shipment-detail/${this.orderId}/${this.shipmentId}`
+        );
+        return { isPacked: true };
       } catch (err: any) {
         // in case of error, if loader and toast are not dismissed above
-        if (toast) toast.dismiss()
-        emitter.emit('dismissLoader');
-        showToast(translate('Failed to pack order'))
-        logger.error('Failed to pack order', err)
-        return {isPacked: false, errors: err?.response?.data?.errors}
+        if (toast) toast.dismiss();
+        emitter.emit("dismissLoader");
+        showToast(translate("Failed to pack order"));
+        logger.error("Failed to pack order", err);
+        return { isPacked: false, errors: err?.response?.data?.errors };
       } finally {
         emitter.emit("dismissLoader");
       }
     },
     async fetchPickersInformation() {
       const payload = {
-          shipmentMethodTypeId: 'STOREPICKUP',
-          shipmentMethodTypeId_not: 'Y',
-          shipmentMethodTypeId_op: 'equals',
-          facilityId: this.currentFacility?.facilityId,
-          statusId: 'PICKLIST_ASSIGNED',
-          pageIndex: 0,
-          pageSize: 50
-      }
+        shipmentMethodTypeId: "STOREPICKUP",
+        shipmentMethodTypeId_not: "Y",
+        shipmentMethodTypeId_op: "equals",
+        facilityId: this.currentFacility?.facilityId,
+        statusId: "PICKLIST_ASSIGNED",
+        pageIndex: 0,
+        pageSize: 50,
+      };
       try {
         const resp = await OrderService.fetchPicklists(payload);
-        if(!hasError(resp)) {
-
+        if (!hasError(resp)) {
           this.picklists = resp.data.map((picklist: any) => {
-            picklist.roles = picklist.roles.filter((role: any) => !role.thruDate)
+            picklist.roles = picklist.roles.filter(
+              (role: any) => !role.thruDate
+            );
 
-            let pickersName = (picklist?.roles ?? [])
-              .map((role:any) => {
-                if (role?.person) {
-                  return `${role.person.firstName} ${role.person.lastName}`;
-                } else if (role?.partyGroup) {
-                  return role.partyGroup.groupName;
-                }
-                return null;
-              })
-              .filter(Boolean)
-              .join(", ") ?? ""; 
+            let pickersName =
+              (picklist?.roles ?? [])
+                .map((role: any) => {
+                  if (role?.person) {
+                    return `${role.person.firstName} ${role.person.lastName}`;
+                  } else if (role?.partyGroup) {
+                    return role.partyGroup.groupName;
+                  }
+                  return null;
+                })
+                .filter(Boolean)
+                .join(", ") ?? "";
 
-            let pickerIds = (picklist?.roles ?? []).map((role:any) => role?.partyId) ?? [];
+            let pickerIds =
+              (picklist?.roles ?? []).map((role: any) => role?.partyId) ?? [];
 
             return {
               ...picklist,
               id: picklist.picklistId,
               pickersName,
               pickerIds,
-              date: picklist.picklistDate ? DateTime.fromMillis(picklist?.picklistDate).toLocaleString(DateTime.TIME_SIMPLE) : null,
+              date: picklist.picklistDate
+                ? DateTime.fromMillis(picklist?.picklistDate).toLocaleString(
+                    DateTime.TIME_SIMPLE
+                  )
+                : null,
             };
           });
         } else {
-          throw resp.data
+          throw resp.data;
         }
-      } catch(err) {
-        logger.error('Failed to fetch picklists', err)
+      } catch (err) {
+        logger.error("Failed to fetch picklists", err);
       }
     },
     async updateOrderQuery(size?: any, queryString?: any) {
-      const inProgressOrdersQuery = JSON.parse(JSON.stringify(this.inProgressOrders.query))
+      const inProgressOrdersQuery = JSON.parse(
+        JSON.stringify(this.inProgressOrders.query)
+      );
 
-      size && (inProgressOrdersQuery.viewSize = size)
-      queryString && (inProgressOrdersQuery.queryString = '')
-      inProgressOrdersQuery.viewIndex = 0 // If the size changes, list index should be reintialised
-      await this.store.dispatch('order/updateInProgressQuery', { ...inProgressOrdersQuery })
+      size && (inProgressOrdersQuery.viewSize = size);
+      queryString && (inProgressOrdersQuery.queryString = "");
+      inProgressOrdersQuery.viewIndex = 0; // If the size changes, list index should be reintialised
+      await this.store.dispatch("order/updateInProgressQuery", {
+        ...inProgressOrdersQuery,
+      });
     },
     async packagingPopover(ev: Event) {
       const popover = await popoverController.create({
@@ -975,7 +1726,12 @@ export default defineComponent({
       });
       return popover.present();
     },
-    async openRejectReasonPopover(ev: Event, item: any, order: any, kitProducts?: any) {
+    async openRejectReasonPopover(
+      ev: Event,
+      item: any,
+      order: any,
+      kitProducts?: any
+    ) {
       const reportIssuePopover = await popoverController.create({
         component: ReportIssuePopover,
         event: ev,
@@ -987,14 +1743,16 @@ export default defineComponent({
 
       const result = await reportIssuePopover.onDidDismiss();
 
-      if(result.data) {
+      if (result.data) {
         order.items.map((orderItem: any) => {
-          if(orderItem.orderItemSeqId === item.orderItemSeqId) {
-            orderItem.rejectReason = result.data
+          if (orderItem.orderItemSeqId === item.orderItemSeqId) {
+            orderItem.rejectReason = result.data;
           }
-        })
-        order.hasRejectedItem = true
-        order.hasAllRejectedItem = this.isEntierOrderRejectionEnabled(order) || order.items.every((item: any) => item.rejectReason)
+        });
+        order.hasRejectedItem = true;
+        order.hasAllRejectedItem =
+          this.isEntierOrderRejectionEnabled(order) ||
+          order.items.every((item: any) => item.rejectReason);
 
         /*
         Commenting this out to avoid directly updating items. Now user need to click on the save button to save the detail.
@@ -1007,19 +1765,25 @@ export default defineComponent({
       delete item["kitComponents"];
 
       item.rejectReason = "";
-        order.items.map((orderItem: any) => {
-          if(orderItem.orderItemSeqId === item.orderItemSeqId) {
-            delete orderItem["rejectReason"];
-            delete orderItem["kitComponents"];
-          }
-        })
-        order.hasRejectedItem = order.items.some((item:any) => item.rejectReason);
-        order.hasAllRejectedItem = this.isEntierOrderRejectionEnabled(order) || order.items.every((item: any) => item.rejectReason)
+      order.items.map((orderItem: any) => {
+        if (orderItem.orderItemSeqId === item.orderItemSeqId) {
+          delete orderItem["rejectReason"];
+          delete orderItem["kitComponents"];
+        }
+      });
+      order.hasRejectedItem = order.items.some(
+        (item: any) => item.rejectReason
+      );
+      order.hasAllRejectedItem =
+        this.isEntierOrderRejectionEnabled(order) ||
+        order.items.every((item: any) => item.rejectReason);
     },
     rejectKitComponent(order: any, item: any, componentProductId: string) {
-      let kitComponents = item.kitComponents ? item.kitComponents : []
+      let kitComponents = item.kitComponents ? item.kitComponents : [];
       if (kitComponents.includes(componentProductId)) {
-        kitComponents = kitComponents.filter((rejectedComponent: any) => rejectedComponent !== componentProductId)
+        kitComponents = kitComponents.filter(
+          (rejectedComponent: any) => rejectedComponent !== componentProductId
+        );
       } else {
         kitComponents.push(componentProductId);
       }
@@ -1028,24 +1792,30 @@ export default defineComponent({
         if (orderItem.orderItemSeqId === item.orderItemSeqId) {
           orderItem.kitComponents = kitComponents;
         }
-      })
+      });
     },
     async assignPickers() {
       const assignPickerModal = await modalController.create({
         component: AssignPickerModal,
-        componentProps: { order: this.order }
+        componentProps: { order: this.order },
       });
 
       // dismissing the popover once the picker modal is closed
       assignPickerModal.onDidDismiss().then((result: any) => {
         popoverController.dismiss();
         // redirect to in-progress page only when we have picklist created successfully for the order
-        if (result?.data?.value?.picklistId && result?.data?.value?.shipmentIds && result?.data?.value?.shipmentIds.length) {
-          let newShipmentId = this.shipmentId
+        if (
+          result?.data?.value?.picklistId &&
+          result?.data?.value?.shipmentIds &&
+          result?.data?.value?.shipmentIds.length
+        ) {
+          let newShipmentId = this.shipmentId;
           if (!newShipmentId) {
-            newShipmentId = result?.data?.value?.shipmentIds[0]
+            newShipmentId = result?.data?.value?.shipmentIds[0];
           }
-          this.router.replace(`/in-progress/shipment-detail/${this.orderId}/${newShipmentId}`)
+          this.router.replace(
+            `/in-progress/shipment-detail/${this.orderId}/${newShipmentId}`
+          );
         }
       });
 
@@ -1060,42 +1830,51 @@ export default defineComponent({
       return packageType;
     },
     getShipmentBoxTypes(carrierPartyId: string) {
-      return this.carrierShipmentBoxTypes[carrierPartyId] ? this.carrierShipmentBoxTypes[carrierPartyId] : [];
+      return this.carrierShipmentBoxTypes[carrierPartyId]
+        ? this.carrierShipmentBoxTypes[carrierPartyId]
+        : [];
     },
     async regenerateShippingLabel(order: any) {
       // If there are no product store shipment method configured, then not generating the label and displaying an error toast
-      if(this.productStoreShipmentMethCount <= 0) {
-        showToast(translate('Unable to generate shipping label due to missing product store shipping method configuration'))
+      if (this.productStoreShipmentMethCount <= 0) {
+        showToast(
+          translate(
+            "Unable to generate shipping label due to missing product store shipping method configuration"
+          )
+        );
         return;
       }
 
-
       // if the request to print shipping label is not yet completed, then clicking multiple times on the button
       // should not do anything
-      if(order.isGeneratingShippingLabel) {
+      if (order.isGeneratingShippingLabel) {
         return;
       }
 
       order.isGeneratingShippingLabel = true;
 
-      if(order.missingLabelImage) {
-        const response = await this.retryShippingLabel(order)
-        if(response?.isGenerated) {
-          await this.printShippingLabel(response.order)
+      if (order.missingLabelImage) {
+        const response = await this.retryShippingLabel(order);
+        if (response?.isGenerated) {
+          await this.printShippingLabel(response.order);
         } else {
-          this.fetchShipmentLabelError()
+          this.fetchShipmentLabelError();
         }
       } else {
-        await this.printShippingLabel(order)
+        await this.printShippingLabel(order);
       }
 
       this.order.isGeneratingShippingLabel = false;
     },
     async initialiseOrderQuery() {
-      const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
-      completedOrdersQuery.viewIndex = 0 // If the size changes, list index should be reintialised
-      completedOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE
-      await this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery })
+      const completedOrdersQuery = JSON.parse(
+        JSON.stringify(this.completedOrders.query)
+      );
+      completedOrdersQuery.viewIndex = 0; // If the size changes, list index should be reintialised
+      completedOrdersQuery.viewSize = process.env.VUE_APP_VIEW_SIZE;
+      await this.store.dispatch("order/updateCompletedQuery", {
+        ...completedOrdersQuery,
+      });
     },
     async shippingPopover(ev: Event) {
       const popover = await popoverController.create({
@@ -1119,75 +1898,94 @@ export default defineComponent({
       const internationalInvoiceUrls: string[] = Array.from(
         new Set(
           order.shipmentPackages
-            ?.filter((shipmentPackage: any) => shipmentPackage.internationalInvoiceUrl)
-            .map((shipmentPackage: any) => shipmentPackage.internationalInvoiceUrl) || []
+            ?.filter(
+              (shipmentPackage: any) => shipmentPackage.internationalInvoiceUrl
+            )
+            .map(
+              (shipmentPackage: any) => shipmentPackage.internationalInvoiceUrl
+            ) || []
         )
       );
 
-      if(!shipmentIds?.length) {
-        showToast(translate('Failed to generate shipping label'))
+      if (!shipmentIds?.length) {
+        showToast(translate("Failed to generate shipping label"));
         return;
       }
 
-      await OrderService.printShippingLabel(shipmentIds, shippingLabelPdfUrls, order.shipmentPackages)
+      await OrderService.printShippingLabel(
+        shipmentIds,
+        shippingLabelPdfUrls,
+        order.shipmentPackages
+      );
       if (internationalInvoiceUrls.length) {
         await OrderService.printCustomDocuments([internationalInvoiceUrls[0]]);
       }
     },
     async addShipmentBox(order: any) {
-      this.addingBoxForShipmentIds.push(order.shipmentId)
+      this.addingBoxForShipmentIds.push(order.shipmentId);
 
-      const { carrierPartyId, shipmentMethodTypeId } = order
-      
-      if(!Object.keys(this.defaultShipmentBoxType).length) {
+      const { carrierPartyId, shipmentMethodTypeId } = order;
+
+      if (!Object.keys(this.defaultShipmentBoxType).length) {
         this.defaultShipmentBoxType = await this.fetchDefaultShipmentBox();
       }
 
       let packageName = "A";
-      const packageNames = order?.shipmentPackages.
-          filter((shipmentPackage:any) => shipmentPackage.packageName).
-          map((shipmentPackage:any) => shipmentPackage.packageName);
+      const packageNames = order?.shipmentPackages
+        .filter((shipmentPackage: any) => shipmentPackage.packageName)
+        .map((shipmentPackage: any) => shipmentPackage.packageName);
       if (packageNames && packageNames.length) {
-          packageNames.sort((a:any, b:any) => b.localeCompare(a));
-          packageName = String.fromCharCode(packageNames[0].charCodeAt(0) + 1);
+        packageNames.sort((a: any, b: any) => b.localeCompare(a));
+        packageName = String.fromCharCode(packageNames[0].charCodeAt(0) + 1);
       }
 
       const params = {
         shipmentId: order.shipmentId,
         shipmentBoxTypeId: this.defaultShipmentBoxType?.shipmentBoxTypeId,
-        boxLength	: this.defaultShipmentBoxType?.boxLength,
-        boxHeight	: this.defaultShipmentBoxType?.boxHeight,
-        boxWidth	: this.defaultShipmentBoxType?.boxWidth,
-        weightUomId :	this.defaultShipmentBoxType?.weightUomId,
-        dimensionUomId : this.defaultShipmentBoxType?.dimensionUomId,
+        boxLength: this.defaultShipmentBoxType?.boxLength,
+        boxHeight: this.defaultShipmentBoxType?.boxHeight,
+        boxWidth: this.defaultShipmentBoxType?.boxWidth,
+        weightUomId: this.defaultShipmentBoxType?.weightUomId,
+        dimensionUomId: this.defaultShipmentBoxType?.dimensionUomId,
         packageName,
-        dateCreated: DateTime.now().toMillis()
-      } as any
+        dateCreated: DateTime.now().toMillis(),
+      } as any;
 
-      carrierPartyId && (params['carrierPartyId'] = carrierPartyId)
-      shipmentMethodTypeId && (params['shipmentMethodTypeId'] = shipmentMethodTypeId)
+      carrierPartyId && (params["carrierPartyId"] = carrierPartyId);
+      shipmentMethodTypeId &&
+        (params["shipmentMethodTypeId"] = shipmentMethodTypeId);
 
       try {
-        const resp = await OrderService.addShipmentBox(params)
+        const resp = await OrderService.addShipmentBox(params);
 
-        if(!hasError(resp)) {
-          showToast(translate('Box added successfully'))
-          await this.store.dispatch('order/getInProgressOrder', { orderId: this.orderId, shipmentId: this.shipmentId})
-          this.store.dispatch('order/updateInProgressOrder', this.order);
+        if (!hasError(resp)) {
+          showToast(translate("Box added successfully"));
+          await this.store.dispatch("order/getInProgressOrder", {
+            orderId: this.orderId,
+            shipmentId: this.shipmentId,
+          });
+          this.store.dispatch("order/updateInProgressOrder", this.order);
         } else {
-          throw resp.data
+          throw resp.data;
         }
       } catch (err) {
-        showToast(translate('Failed to add box'))
-        logger.error('Failed to add box', err)
+        showToast(translate("Failed to add box"));
+        logger.error("Failed to add box", err);
       }
-      this.addingBoxForShipmentIds.splice(this.addingBoxForShipmentIds.indexOf(order.shipmentId), 1)
+      this.addingBoxForShipmentIds.splice(
+        this.addingBoxForShipmentIds.indexOf(order.shipmentId),
+        1
+      );
     },
-    async updateShipmentBoxType(shipmentPackage: any, order: any, ev: CustomEvent) {
+    async updateShipmentBoxType(
+      shipmentPackage: any,
+      order: any,
+      ev: CustomEvent
+    ) {
       // Don't open popover when not having shipmentBoxTypes available
-      const shipmentBoxTypes = this.getShipmentBoxTypes(order.carrierPartyId)
+      const shipmentBoxTypes = this.getShipmentBoxTypes(order.carrierPartyId);
       if (!shipmentBoxTypes.length) {
-        logger.error('Failed to fetch shipment box types')
+        logger.error("Failed to fetch shipment box types");
         return;
       }
 
@@ -1195,7 +1993,7 @@ export default defineComponent({
         component: ShipmentBoxTypePopover,
         event: ev,
         showBackdrop: false,
-        componentProps: { shipmentBoxTypes }
+        componentProps: { shipmentBoxTypes },
       });
 
       popover.present();
@@ -1204,37 +2002,40 @@ export default defineComponent({
 
       if (result.data) {
         shipmentPackage.shipmentBoxTypeId = result.data;
-        this.store.dispatch('order/updateInProgressOrder', order);
+        this.store.dispatch("order/updateInProgressOrder", order);
       }
     },
     async fetchDefaultShipmentBox() {
-      let defaultBoxTypeId = 'YOURPACKNG'
-      let defaultBoxType = {}
+      let defaultBoxTypeId = "YOURPACKNG";
+      let defaultBoxType = {};
 
       try {
         let resp = await UtilService.fetchDefaultShipmentBox({
           systemResourceId: "shipment",
           systemPropertyId: "shipment.default.boxtype",
           fieldsToSelect: ["systemPropertyValue", "systemResourceId"],
-          pageSize: 1
-        })
+          pageSize: 1,
+        });
 
-        if(!hasError(resp)) {
-          defaultBoxTypeId = resp.data?.[0].systemPropertyValue
+        if (!hasError(resp)) {
+          defaultBoxTypeId = resp.data?.[0].systemPropertyValue;
         } else {
-          throw resp.data
+          throw resp.data;
         }
-        
+
         const payload = {
-          "shipmentBoxTypeId": defaultBoxTypeId,
-          "pageSize": 1
-        }
+          shipmentBoxTypeId: defaultBoxTypeId,
+          pageSize: 1,
+        };
         resp = await UtilService.fetchShipmentBoxType(payload);
         if (!hasError(resp)) {
           defaultBoxType = resp.data[0];
         }
       } catch (err) {
-        logger.error('Failed to fetch default shipment box type information', err)
+        logger.error(
+          "Failed to fetch default shipment box type information",
+          err
+        );
       }
 
       return defaultBoxType;
@@ -1242,176 +2043,246 @@ export default defineComponent({
     async reportIssue(order: any, itemsToReject: any) {
       let message;
       const rejectedItem = itemsToReject[0];
-      const productName = rejectedItem.productName
+      const productName = rejectedItem.productName;
 
       let ordersCount = 0;
 
-      if(this.collateralRejectionConfig) {
+      if (this.collateralRejectionConfig) {
         // TODO: ordersCount is not correct as current we are identifying orders count by only checking items visible on UI and not other orders
-        ordersCount = this.inProgressOrders.list.map((inProgressOrder: any) => inProgressOrder.items.filter((item: any) => itemsToReject.some((itemToReject: any) => itemToReject.productId === item.productId) && item.shipmentId !== order.shipmentId))?.filter((item: any) => item.length).length;
+        ordersCount = this.inProgressOrders.list
+          .map((inProgressOrder: any) =>
+            inProgressOrder.items.filter(
+              (item: any) =>
+                itemsToReject.some(
+                  (itemToReject: any) =>
+                    itemToReject.productId === item.productId
+                ) && item.shipmentId !== order.shipmentId
+            )
+          )
+          ?.filter((item: any) => item.length).length;
       }
 
       if (itemsToReject.length === 1 && ordersCount) {
-        message = translate("is identified as unfulfillable. other containing this product will be unassigned from this store and sent to be rebrokered.", { productName, space: '<br /><br />', orders: ordersCount, orderText: ordersCount > 1 ? 'orders' : 'order' })
+        message = translate(
+          "is identified as unfulfillable. other containing this product will be unassigned from this store and sent to be rebrokered.",
+          {
+            productName,
+            space: "<br /><br />",
+            orders: ordersCount,
+            orderText: ordersCount > 1 ? "orders" : "order",
+          }
+        );
       } else if (itemsToReject.length === 1 && !ordersCount) {
-        message = translate("is identified as unfulfillable. This order item will be unassigned from this store and sent to be rebrokered.", { productName, space: '<br /><br />' })
+        message = translate(
+          "is identified as unfulfillable. This order item will be unassigned from this store and sent to be rebrokered.",
+          { productName, space: "<br /><br />" }
+        );
       } else if (itemsToReject.length > 1 && ordersCount) {
-        message = translate(", and other products are identified as unfulfillable. other containing these products will be unassigned from this store and sent to be rebrokered.", { productName, products: itemsToReject.length - 1, space: '<br /><br />', orders: ordersCount, orderText: ordersCount > 1 ? 'orders' : 'order' })
+        message = translate(
+          ", and other products are identified as unfulfillable. other containing these products will be unassigned from this store and sent to be rebrokered.",
+          {
+            productName,
+            products: itemsToReject.length - 1,
+            space: "<br /><br />",
+            orders: ordersCount,
+            orderText: ordersCount > 1 ? "orders" : "order",
+          }
+        );
       } else {
-        message = translate(", and other products are identified as unfulfillable. These order items will be unassigned from this store and sent to be rebrokered.", { productName, products: itemsToReject.length - 1, space: '<br /><br />' })
+        message = translate(
+          ", and other products are identified as unfulfillable. These order items will be unassigned from this store and sent to be rebrokered.",
+          {
+            productName,
+            products: itemsToReject.length - 1,
+            space: "<br /><br />",
+          }
+        );
       }
-      const alert = await alertController
-        .create({
-          header: translate("Report an issue"),
-          message,
-          buttons: [{
+      const alert = await alertController.create({
+        header: translate("Report an issue"),
+        message,
+        buttons: [
+          {
             text: translate("Cancel"),
-            role: 'cancel'
-          }, {
+            role: "cancel",
+          },
+          {
             text: translate("Report"),
-            role: 'confirm',
-            handler: async() => {
-              await this.initiatePackOrder(order, 'report')
-            }
-          }]
-        });
-      
+            role: "confirm",
+            handler: async () => {
+              await this.initiatePackOrder(order, "report");
+            },
+          },
+        ],
+      });
+
       return alert.present();
     },
     async getUpdatedOrderDetail(order: any, updateParameter?: string) {
       const items = JSON.parse(JSON.stringify(order.items));
-      
+
       // creating updated data for items
       const rejectedOrderItems = [] as any;
       const shipmentPackageContents = [] as any;
       items.map((item: any, index: number) => {
-        const shipmentPackage = order.shipmentPackages.find((shipmentPackage: any) => shipmentPackage.packageName === item.selectedBox)
-        if (updateParameter === 'report' && item.rejectReason) {
+        const shipmentPackage = order.shipmentPackages.find(
+          (shipmentPackage: any) =>
+            shipmentPackage.packageName === item.selectedBox
+        );
+        if (updateParameter === "report" && item.rejectReason) {
           const rejectedItemInfo = {
-            "orderId": item.orderId,
-            "orderItemSeqId": item.orderItemSeqId,
-            "shipmentId": item.shipmentId,
-            "shipmentItemSeqId": item.shipmentItemSeqId,
-            "productId": item.productId,
-            "facilityId": this.currentFacility?.facilityId,
-            "updateQOH": this.affectQohConfig || false,
-            "maySplit": this.isEntierOrderRejectionEnabled(order) ? "N" : "Y",
-            "cascadeRejectByProduct": this.collateralRejectionConfig ? "Y" : "N",
-            "rejectionReasonId": item.rejectReason,
-            "kitComponents": item.kitComponents,
-            "comments": "Store Rejected Inventory"
-          } as any
+            orderId: item.orderId,
+            orderItemSeqId: item.orderItemSeqId,
+            shipmentId: item.shipmentId,
+            shipmentItemSeqId: item.shipmentItemSeqId,
+            productId: item.productId,
+            facilityId: this.currentFacility?.facilityId,
+            updateQOH: this.affectQohConfig || false,
+            maySplit: this.isEntierOrderRejectionEnabled(order) ? "N" : "Y",
+            cascadeRejectByProduct: this.collateralRejectionConfig ? "Y" : "N",
+            rejectionReasonId: item.rejectReason,
+            kitComponents: item.kitComponents,
+            comments: "Store Rejected Inventory",
+          } as any;
 
           if (this.excludeOrderBrokerDays !== undefined) {
-            rejectedItemInfo["excludeOrderFacilityDuration"] = this.excludeOrderBrokerDays
+            rejectedItemInfo["excludeOrderFacilityDuration"] =
+              this.excludeOrderBrokerDays;
           }
-          rejectedOrderItems.push(rejectedItemInfo)
+          rejectedOrderItems.push(rejectedItemInfo);
         } else if (item.selectedBox !== item.currentBox) {
           shipmentPackageContents.push({
             shipmentId: item.shipmentId,
             shipmentItemSeqId: item.shipmentItemSeqId,
             shipmentPackageSeqId: shipmentPackage.shipmentPackageSeqId,
-            quantity: item.quantity
-          })
+            quantity: item.quantity,
+          });
         }
-      })
-      return {rejectedOrderItems, shipmentPackageContents}
+      });
+      return { rejectedOrderItems, shipmentPackageContents };
     },
     hasPackedShipments(order: any) {
       // TODO check if ternary check is needed or we could handle on UI
-      return order.statusId === 'SHIPMENT_PACKED'
+      return order.statusId === "SHIPMENT_PACKED";
     },
     async shipOrder(order: any) {
       try {
-        const resp = await OrderService.shipOrder({shipmentId: order.shipmentId})
+        const resp = await OrderService.shipOrder({
+          shipmentId: order.shipmentId,
+        });
 
         if (!hasError(resp)) {
-          showToast(translate('Order shipped successfully'))
+          showToast(translate("Order shipped successfully"));
 
           // updating order locally after ship action is success, as solr takes some time to update
-          order.statusId = 'SHIPMENT_SHIPPED'
-          this.store.dispatch('order/updateCurrent', order)
+          order.statusId = "SHIPMENT_SHIPPED";
+          this.store.dispatch("order/updateCurrent", order);
         } else {
-          throw resp.data
+          throw resp.data;
         }
       } catch (err) {
-        logger.error('Failed to ship order', err)
-        showToast(translate('Failed to ship order'))
+        logger.error("Failed to ship order", err);
+        showToast(translate("Failed to ship order"));
       }
     },
     async fetchOrderInvoicingStatus() {
-      let orderInvoicingInfo = {} as any, resp;
+      let orderInvoicingInfo = {} as any,
+        resp;
 
       const params = {
-        customParametersMap:{
-          "orderId": this.order.orderId,
-          "orderByField": "-entryDate",
-          "pageSize": 1
+        customParametersMap: {
+          orderId: this.order.orderId,
+          orderByField: "-entryDate",
+          pageSize: 1,
         },
-        dataDocumentId: "ApiCommunicationEventOrder"
-      }
+        dataDocumentId: "ApiCommunicationEventOrder",
+      };
 
       try {
         resp = await OrderService.findOrderInvoicingInfo(params);
 
-        if(!hasError(resp) && resp.data?.entityValueList?.length) {
-          const response = resp.data?.entityValueList[0]
+        if (!hasError(resp) && resp.data?.entityValueList?.length) {
+          const response = resp.data?.entityValueList[0];
 
-          const content = Object.keys(response.content).length ? JSON.parse(response.content) : {}
+          const content = Object.keys(response.content).length
+            ? JSON.parse(response.content)
+            : {};
 
-          const invoicingFacility = this.userProfile.facilities.find((facility: any) => facility.facilityId === content?.request?.InvoicingStore)
+          const invoicingFacility = this.userProfile.facilities.find(
+            (facility: any) =>
+              facility.facilityId === content?.request?.InvoicingStore
+          );
 
           orderInvoicingInfo = {
             id: response.orderId,
             createdDate: this.getInvoicingConfirmationDate(response.entryDate),
-            response : Object.keys(content.response).length ? content?.response : {},
+            response: Object.keys(content.response).length
+              ? content?.response
+              : {},
             status: content.status,
             statusCode: content.statusCode,
-            invoicingFacility
-          }
+            invoicingFacility,
+          };
 
           const params = {
             orderId: this.order.orderId,
-            attrName: "retailProStatus"
-          }
+            attrName: "retailProStatus",
+          };
 
-          const retailProStatus = this.order.attributes.find((attribute: any) => attribute.attrName === "retailProStatus");
-          if (Object.keys(retailProStatus).length && retailProStatus?.attrValue === "Invoiced") {
-            orderInvoicingInfo["invoicingConfirmationDate"] = retailProStatus?.lastUpdatedStamp
+          const retailProStatus = this.order.attributes.find(
+            (attribute: any) => attribute.attrName === "retailProStatus"
+          );
+          if (
+            Object.keys(retailProStatus).length &&
+            retailProStatus?.attrValue === "Invoiced"
+          ) {
+            orderInvoicingInfo["invoicingConfirmationDate"] =
+              retailProStatus?.lastUpdatedStamp;
           }
         } else {
           throw resp.data;
         }
-      } catch(error: any) {
+      } catch (error: any) {
         logger.error(error);
       }
 
-      this.orderInvoicingInfo = orderInvoicingInfo
+      this.orderInvoicingInfo = orderInvoicingInfo;
     },
     getOrderInvoicingMessage() {
       let message = "";
       let isMessageRequired = false;
 
-      if(this.orderInvoicingInfo.status === "success") {
-        message = "Successfully sent to Retail Pro Server."
+      if (this.orderInvoicingInfo.status === "success") {
+        message = "Successfully sent to Retail Pro Server.";
       } else {
-        if(!this.orderInvoicingInfo.statusCode && !Object.keys(this.orderInvoicingInfo.response).length) {
-          message = "Failed to send to Retail Pro Server due to connection issues with Retail Pro, please try again."
+        if (
+          !this.orderInvoicingInfo.statusCode &&
+          !Object.keys(this.orderInvoicingInfo.response).length
+        ) {
+          message =
+            "Failed to send to Retail Pro Server due to connection issues with Retail Pro, please try again.";
         } else {
-          message = "Failed to send to Retail Pro Server due to the following error, please contact support:."
+          message =
+            "Failed to send to Retail Pro Server due to the following error, please contact support:.";
           isMessageRequired = true;
         }
       }
 
-      return isMessageRequired ? translate(message, { message: this.orderInvoicingInfo.response.Message }) : translate(message);
+      return isMessageRequired
+        ? translate(message, {
+            message: this.orderInvoicingInfo.response.Message,
+          })
+        : translate(message);
     },
     getInvoicingConfirmationDate(date: any) {
-      return DateTime.fromMillis(date).setZone(this.userProfile.userTimeZone).toFormat('dd MMMM yyyy hh:mm a ZZZZ')
+      return DateTime.fromMillis(date)
+        .setZone(this.userProfile.userTimeZone)
+        .toFormat("dd MMMM yyyy hh:mm a ZZZZ");
     },
     async printPackingSlip(order: any) {
       // if the request to print packing slip is not yet completed, then clicking multiple times on the button
       // should not do anything
-      if(order.isGeneratingPackingSlip) {
+      if (order.isGeneratingPackingSlip) {
         return;
       }
 
@@ -1420,62 +2291,85 @@ export default defineComponent({
       order.isGeneratingPackingSlip = false;
     },
     async unpackOrder(order: any) {
-      const unpackOrderAlert = await alertController
-        .create({
-           header: translate("Unpack"),
-           message: translate("Unpacking this order will send it back to 'In progress' and it will have to be repacked."),
-           buttons: [{
+      const unpackOrderAlert = await alertController.create({
+        header: translate("Unpack"),
+        message: translate(
+          "Unpacking this order will send it back to 'In progress' and it will have to be repacked."
+        ),
+        buttons: [
+          {
             role: "cancel",
             text: translate("Cancel"),
-          }, {
+          },
+          {
             text: translate("Unpack"),
             handler: async () => {
               try {
-                const resp = await OrderService.unpackOrder({shipmentId: order.shipmentId, statusId: 'SHIPMENT_APPROVED'})
+                const resp = await OrderService.unpackOrder({
+                  shipmentId: order.shipmentId,
+                  statusId: "SHIPMENT_APPROVED",
+                });
 
-                if(resp.status == 200 && !hasError(resp)) {
-                  showToast(translate('Order unpacked successfully'))
-                  this.router.replace(`/in-progress/shipment-detail/${this.orderId}/${this.shipmentId}`)
+                if (resp.status == 200 && !hasError(resp)) {
+                  showToast(translate("Order unpacked successfully"));
+                  this.router.replace(
+                    `/in-progress/shipment-detail/${this.orderId}/${this.shipmentId}`
+                  );
                 } else {
-                  throw resp.data
+                  throw resp.data;
                 }
-              } catch(err) {
-                logger.error('Failed to unpack the order', err)
-                showToast(translate('Failed to unpack the order'))
+              } catch (err) {
+                logger.error("Failed to unpack the order", err);
+                showToast(translate("Failed to unpack the order"));
               }
-            }
-          }]
-        });
+            },
+          },
+        ],
+      });
       return unpackOrderAlert.present();
     },
     isTrackingRequiredForAnyShipmentPackage(order: any) {
-      return order.isTrackingRequired === 'Y'
+      return order.isTrackingRequired === "Y";
     },
     async scanOrder(order: any, updateParameter?: string) {
       const modal = await modalController.create({
         component: ScanOrderItemModal,
-        componentProps: { order }
-      })
+        componentProps: { order },
+      });
 
       modal.onDidDismiss().then((result: any) => {
-        if(result.data?.packOrder) {
+        if (result.data?.packOrder) {
           this.confirmPackOrder(order, updateParameter);
         }
-      })
+      });
 
       modal.present();
     },
-    async generateTrackingCodeForPacking(order: any, updateParameter?: string, documentOptions?: any, packingError?: string) {
+    async generateTrackingCodeForPacking(
+      order: any,
+      updateParameter?: string,
+      documentOptions?: any,
+      packingError?: string
+    ) {
       const modal = await modalController.create({
         component: GenerateTrackingCodeModal,
-        componentProps: { order, updateCarrierShipmentDetails: this.updateCarrierShipmentDetails, executePackOrder: this.executePackOrder, rejectEntireOrder: this.rejectEntireOrder, updateParameter, documentOptions, packingError, isDetailPage: "Y" }
-      })
+        componentProps: {
+          order,
+          updateCarrierShipmentDetails: this.updateCarrierShipmentDetails,
+          executePackOrder: this.executePackOrder,
+          rejectEntireOrder: this.rejectEntireOrder,
+          updateParameter,
+          documentOptions,
+          packingError,
+          isDetailPage: "Y",
+        },
+      });
       modal.present();
     },
     async openTrackingCodeModal() {
       const addTrackingCodeModal = await modalController.create({
         component: TrackingCodeModal,
-        componentProps: { carrierPartyId: this.carrierPartyId }
+        componentProps: { carrierPartyId: this.carrierPartyId },
       });
 
       return addTrackingCodeModal.present();
@@ -1483,78 +2377,109 @@ export default defineComponent({
     async openGiftCardActivationModal(item: any) {
       const modal = await modalController.create({
         component: GiftCardActivationModal,
-        componentProps: { item }
-      })
+        componentProps: { item },
+      });
 
       modal.onDidDismiss().then((result: any) => {
-        if(result.data?.isGCActivated) {
-          this.store.dispatch("order/updateCurrentItemGCActivationDetails", { item, category: this.category, isDetailsPage: true })
+        if (result.data?.isGCActivated) {
+          this.store.dispatch("order/updateCurrentItemGCActivationDetails", {
+            item,
+            category: this.category,
+            isDetailsPage: true,
+          });
         }
-      })
+      });
 
       modal.present();
     },
     async fetchCODPaymentInfo() {
       try {
-        const isPendingCODPayment = this.order?.paymentPreferences?.some((paymentPref: any) => paymentPref.paymentMethodTypeId === "EXT_SHOP_CASH_ON_DEL" && paymentPref.statusId === "PAYMENT_NOT_RECEIVED")
+        const isPendingCODPayment = this.order?.paymentPreferences?.some(
+          (paymentPref: any) =>
+            paymentPref.paymentMethodTypeId === "EXT_SHOP_CASH_ON_DEL" &&
+            paymentPref.statusId === "PAYMENT_NOT_RECEIVED"
+        );
         if (isPendingCODPayment) {
-          this.isCODPaymentPending = true
-          this.orderHeaderAdjustmentTotal = 0
-          this.orderAdjustments = this.order?.adjustments.filter((adjustment: any) => {
-            // Considered that the adjustment will not be made at shipGroup level
-            if((adjustment.orderItemSeqId === "_NA_" || !adjustment.orderItemSeqId) && !adjustment.billingShipmentId) {
-              this.orderHeaderAdjustmentTotal += adjustment.amount
-              return true;
-            } else {
-              this.adjustmentsByGroup[adjustment.shipGroupSeqId] ? (this.adjustmentsByGroup[adjustment.shipGroupSeqId].push(adjustment)) : (this.adjustmentsByGroup[adjustment.shipGroupSeqId] = [adjustment])
-              return false;
+          this.isCODPaymentPending = true;
+          this.orderHeaderAdjustmentTotal = 0;
+          this.orderAdjustments = this.order?.adjustments.filter(
+            (adjustment: any) => {
+              // Considered that the adjustment will not be made at shipGroup level
+              if (
+                (adjustment.orderItemSeqId === "_NA_" ||
+                  !adjustment.orderItemSeqId) &&
+                !adjustment.billingShipmentId
+              ) {
+                this.orderHeaderAdjustmentTotal += adjustment.amount;
+                return true;
+              } else {
+                this.adjustmentsByGroup[adjustment.shipGroupSeqId]
+                  ? this.adjustmentsByGroup[adjustment.shipGroupSeqId].push(
+                      adjustment
+                    )
+                  : (this.adjustmentsByGroup[adjustment.shipGroupSeqId] = [
+                      adjustment,
+                    ]);
+                return false;
+              }
             }
-          })
-          this.isOrderAdjustmentPending = this.order?.adjustments.some((adjustment: any) => !adjustment.billingShipmentId)
+          );
+          this.isOrderAdjustmentPending = this.order?.adjustments.some(
+            (adjustment: any) => !adjustment.billingShipmentId
+          );
 
-          if(!this.isOrderAdjustmentPending) {
-            const adjustment = this.order?.adjustments.find((adjustment: any) => adjustment.billingShipmentId)
-            this.orderAdjustmentShipmentId = adjustment.billingShipmentId
+          if (!this.isOrderAdjustmentPending) {
+            const adjustment = this.order?.adjustments.find(
+              (adjustment: any) => adjustment.billingShipmentId
+            );
+            this.orderAdjustmentShipmentId = adjustment.billingShipmentId;
           }
         }
-      } catch(err) {
+      } catch (err) {
         logger.error(err);
       }
     },
     async openOrderAdjustmentInfo() {
-      if(this.isCODPaymentPending && !this.isOrderAdjustmentPending) {
-        let message = "Order level charges like shipping fees and taxes were already charged to the customer on the first label generated for this order."
-        let facilityName = ""
-        let trackingCode = ""
+      if (this.isCODPaymentPending && !this.isOrderAdjustmentPending) {
+        let message =
+          "Order level charges like shipping fees and taxes were already charged to the customer on the first label generated for this order.";
+        let facilityName = "";
+        let trackingCode = "";
         let buttons = [
           {
             text: translate("Dismiss"),
-            role: "cancel"
-          }
-        ] as any
+            role: "cancel",
+          },
+        ] as any;
 
-        if(this.orderAdjustmentShipmentId) {
-          const shipGroup = this.order.otherShipGroups.find((group: any) => group.shipmentId == this.orderAdjustmentShipmentId)
-          facilityName = shipGroup.facilityName || shipGroup.facilityId
-          trackingCode = shipGroup.trackingCode
+        if (this.orderAdjustmentShipmentId) {
+          const shipGroup = this.order.otherShipGroups.find(
+            (group: any) => group.shipmentId == this.orderAdjustmentShipmentId
+          );
+          facilityName = shipGroup.facilityName || shipGroup.facilityId;
+          trackingCode = shipGroup.trackingCode;
 
           // As mentioned above, if shipGroup is not found we won't have facility and trackingCode, thus not displaying the second para in that case.
-          if(trackingCode) {
-            message += "Label was generated by facility with tracking code"
+          if (trackingCode) {
+            message += "Label was generated by facility with tracking code";
             buttons.push({
               text: translate("Copy tracking code"),
               handler: () => {
-                copyToClipboard(trackingCode, "Copied to clipboard")
-              }
-            })
+                copyToClipboard(trackingCode, "Copied to clipboard");
+              },
+            });
           }
         }
 
         const alert = await alertController.create({
-          message: translate(message, { space: "<br/><br/>", facilityName, trackingCode }),
+          message: translate(message, {
+            space: "<br/><br/>",
+            facilityName,
+            trackingCode,
+          }),
           header: translate("COD calculation"),
-          buttons
-        })
+          buttons,
+        });
 
         return alert.present();
       } else {
@@ -1565,30 +2490,36 @@ export default defineComponent({
             orderId: this.orderId,
             orderAdjustments: this.orderAdjustments,
             orderHeaderAdjustmentTotal: this.orderHeaderAdjustmentTotal,
-            adjustmentsByGroup: this.adjustmentsByGroup
-          }
-        })
+            adjustmentsByGroup: this.adjustmentsByGroup,
+          },
+        });
 
         return modal.present();
       }
     },
     getSelectedCarrier(carrierPartyId: string) {
-      const facilityCarrier = this.facilityCarriers.find((carrier: any) => carrier.partyId === carrierPartyId)
+      const facilityCarrier = this.facilityCarriers.find(
+        (carrier: any) => carrier.partyId === carrierPartyId
+      );
       return facilityCarrier ? facilityCarrier.groupName : carrierPartyId;
     },
     getSelectedShipmentMethod(shipmentMethodTypeId: string) {
-      const shippingMethod = this.carrierMethods.find((method: any) => method.shipmentMethodTypeId === shipmentMethodTypeId);
+      const shippingMethod = this.carrierMethods.find(
+        (method: any) => method.shipmentMethodTypeId === shipmentMethodTypeId
+      );
       return shippingMethod ? shippingMethod.description : shipmentMethodTypeId;
-    }
+    },
   },
   setup() {
     const store = useStore();
     const router = useRouter();
-    const userStore = useUserStore()
+    const userStore = useUserStore();
     const productIdentificationStore = useProductIdentificationStore();
-    let productIdentificationPref = computed(() => productIdentificationStore.getProductIdentificationPref)
-    let currentFacility: any = computed(() => userStore.getCurrentFacility) 
-    let currentEComStore: any = computed(() => userStore.getCurrentEComStore)
+    let productIdentificationPref = computed(
+      () => productIdentificationStore.getProductIdentificationPref
+    );
+    let currentFacility: any = computed(() => userStore.getCurrentFacility);
+    let currentEComStore: any = computed(() => userStore.getCurrentEComStore);
 
     return {
       addOutline,
@@ -1628,9 +2559,9 @@ export default defineComponent({
       translate,
       ribbonOutline,
       getColorByDesc,
-      formatCurrency
+      formatCurrency,
     };
-  }
+  },
 });
 </script>
 
@@ -1656,7 +2587,8 @@ ion-card-header {
   height: 30px;
 }
 
-ion-segment > ion-segment-button > ion-skeleton-text, ion-item > ion-skeleton-text {
+ion-segment > ion-segment-button > ion-skeleton-text,
+ion-item > ion-skeleton-text {
   width: 100%;
   height: 30px;
 }


### PR DESCRIPTION
### Related Issue
- Fixes https://github.com/hotwax/fulfillment/issues/1558

### Short Description and Why It's Useful
- Added `data-test-id` attributes for Sales Order Fulfilment flow screens
- These IDs are required to enable stable Playwright automation
- No functional or business logic changes

### Screens / Components Affected
- Assign Picker Modal
- Sales Order Fulfilment related views

### Testing
- Verified UI behavior remains unchanged
- Changes are non-functional and safe for deployment

### Contribution Rules
- [x] I read and followed the contribution guidelines

- [ ] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)