### PR TITLE
Improved: Added watcher to update component's data property on change in props to prevent stale data usage (#1536)

### DIFF
--- a/src/components/TransferOrderItem.vue
+++ b/src/components/TransferOrderItem.vue
@@ -127,6 +127,14 @@ export default defineComponent({
       defaultRejectReasonId: "NO_VARIANCE_LOG"  // default variance reason, to be used when any other item is selected for rejection
     }
   },
+  // Added this watcher to update local item reference when prop changes. 
+  // This fixes the issue of stale data usage where data properties were not being updated on change in props.
+  watch: {
+    itemDetail(newItem) {
+      this.item = newItem;
+      this.pickedQuantity = newItem.pickedQuantity;
+    }
+  },
   computed: {
     ...mapGetters({
       currentOrder: 'transferorder/getCurrent',


### PR DESCRIPTION
Changelog: Changed

### Related Issues
#1536 

### Description
 Added a watcher for itemDetail to synchronize the local item and pickedQuantity data properties whenever the prop changes. This ensures the component always reflects the current state from the parent.
 
- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)