### PR TITLE
Fixed: logout loader to only get displayed when the logout action is called explicitly and not in other cases

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -143,11 +143,10 @@ const actions: ActionTree<UserState, RootState> = {
     // store the url on which we need to redirect the user after logout api completes in case of SSO enabled
     let redirectionUrl = ''
 
-    emitter.emit('presentLoader', { message: 'Logging out', backdropDismiss: false })
-
     // Calling the logout api to flag the user as logged out, only when user is authorised
     // if the user is already unauthorised then not calling the logout api as it returns 401 again that results in a loop, thus there is no need to call logout api if the user is unauthorised
     if(!payload?.isUserUnauthorised) {
+      emitter.emit('presentLoader', { message: 'Logging out', backdropDismiss: false })
       let resp;
 
       // wrapping the parsing logic in try catch as in some case the logout api makes redirection, and then we are unable to parse the resp and thus the logout process halts
@@ -163,6 +162,8 @@ const actions: ActionTree<UserState, RootState> = {
       if(resp?.logoutAuthType == 'SAML2SSO') {
         redirectionUrl = resp.logoutUrl
       }
+
+      emitter.emit('dismissLoader')
     }
 
     const authStore = useAuthStore()
@@ -190,7 +191,6 @@ const actions: ActionTree<UserState, RootState> = {
       window.location.href = redirectionUrl
     }
 
-    emitter.emit('dismissLoader')
     return redirectionUrl;
   },
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)