### PR TITLE
Fix: accurately resolve destination store address for SHIP_TO_STORE orders

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -506,7 +506,6 @@ const actions: ActionTree<OrderState, RootState> = {
           if (!hasError(facilityContactResp)) {
             const { data } = facilityContactResp;
             const address = data.facilityContactMechs?.find((contactMech: any) => contactMech.contactMechId === (order.destinationContactMechId || currentShipGroup.contactMechId));
-            console.log(address)
             if (address) {
               shippingAddress = { 
                 ...address, 

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -505,7 +505,8 @@ const actions: ActionTree<OrderState, RootState> = {
           const facilityContactResp = await UtilService.fetchFacilityAddresses({ facilityId });
           if (!hasError(facilityContactResp)) {
             const { data } = facilityContactResp;
-            const address = data?.facilityContactMechs?.find((cm: any) => cm.contactMechId === (order.destinationContactMechId || currentShipGroup.contactMechId));
+            const address = data.facilityContactMechs?.find((contactMech: any) => contactMech.contactMechId === (order.destinationContactMechId || currentShipGroup.contactMechId));
+            console.log(address)
             if (address) {
               shippingAddress = { 
                 ...address, 
@@ -513,8 +514,8 @@ const actions: ActionTree<OrderState, RootState> = {
                 countryName: address.countryGeoName, 
                 toName: currentShipGroup.facilityName || address.facilityName || address.toName || shippingAddress?.toName 
               }
-              const phone = data.facilityContactMechs.find((cm: any) => cm.contactMechId === currentShipGroup.telecomContactMechId);
-              if (phone?.telecomNumber) telecomNumber = phone.telecomNumber;
+              const { contactNumber } = data.facilityContactMechs.find((contactMech: any) => contactMech.contactMechId === currentShipGroup.telecomContactMechId) || {};
+              if (contactNumber) telecomNumber = { contactNumber };
             }
           } else {
             logger.error(`Failed to fetch facility addresses for facility ${facilityId}`, facilityContactResp.data);


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
closes #1569 
#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Resolved the incorrect destination address display for `SHIP_TO_STORE` orders:
- **Proactive Resolution**: Updated [fetchOrderDetail](cci:1://file:///home/yashverma/Ionic/fulfillment/src/store/modules/order/actions.ts:491:2-544:3) to proactively fetch destination facility contact mechanisms using `orderFacilityId`.
- **Accurate Identification**: Matches the specific `contactMechId` from the ship group to resolve the correct pickup store location.
- **Improved Mapping**: Fixed mapping of flattened API fields (e.g., `stateGeoName`, `countryGeoName`) to the app's structured address format.
- **Store Attribution**: Ensures the "Destination" section correctly reflects the pickup store's name and full address rather than the origin warehouse.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)