### PR TITLE
Fixed: payment preferences not being displayed on the order lookup details page

### DIFF
--- a/src/store/modules/orderLookup/actions.ts
+++ b/src/store/modules/orderLookup/actions.ts
@@ -171,7 +171,7 @@ const actions: ActionTree<OrderLookupState, RootState> = {
         // preparing brokering information for order
         if (orderFacilityChangeResp.status === 'fulfilled' && !hasError(orderFacilityChangeResp.value)) {
           order["shipGroupFacilityAllocationTime"] = {}
-          order["firstBrokeredDate"] = orderFacilityChangeResp.value.data[0].changeDatetime
+          order["firstBrokeredDate"] = orderFacilityChangeResp.value.data[0] ? orderFacilityChangeResp.value.data[0].changeDatetime : ""
           orderFacilityChangeResp.value.data.map((brokeringInfo: any) => {
             order["shipGroupFacilityAllocationTime"][brokeringInfo.shipGroupSeqId] = brokeringInfo.changeDatetime
           })


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
In some cases the payment preference information is not being displayed on the order lookup details page, as facility change does not contains any record, and thus when accessing 0th index, the flow breaks resulting in moving to catch block and not running any code after that check, so added a value check for facility change resp, so that even when data is not present the rest of the flow works correctly.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)