### PR TITLE
Changed: Get Shopify Shop Location only if the app is running in POS

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -82,7 +82,7 @@ const actions: ActionTree<UserState, RootState> = {
       }
 
       const authStore = useAuthStore()
-      if(authStore.isEmbedded) {
+      if(authStore.isEmbedded && authStore.posContext?.locationId) {
         const locationId = authStore.posContext.locationId
         const payload = {
           shopifyLocationId: locationId

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -464,15 +464,17 @@ const getPendingFulfillmentOrders = async () => {
         pageNoLimit: true,
         orderTypeId: "SALES_ORDER",
         orderStatusId: "ORDER_APPROVED",
-        itemStatusId: "ITEM_CANCELLED",
+        itemStatusId: "ITEM_CANCELLED,ITEM_COMPLETED",
+        itemStatusId_op: "in",
         itemStatusId_not: "Y",
         facilityId: currentFacility.value.facilityId,
         facilityId_op: "in",
         shipmentStatus_op: "in",
         shipmentStatus_not: "Y",
         shipmentStatus: "SHIPMENT_PACKED,SHIPMENT_SHIPPED,SHIPMENT_CANCELLED,SHIPMENT_INPUT",
-        shipmentMethodTypeId: "STOREPICKUP",
+        shipmentMethodTypeId: "STOREPICKUP,POS_COMPLETED",
         shipmentMethodTypeId_not: "Y",
+        shipmentMethodTypeId_op: "in",
         productStoreId: currentEcomStore.value.productStoreId
       }
     });


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR introduces following:
- Fix: Wrong Facility Filtering when the app runs in Admin Embedded mode, The Location API call is done without the location id returning with all locations on instance and matching the first among them in User's Profile's facilities, eventually ending up with error "User not Asscociated with any facility" since the match is done wrong if the user is not associated with that facility.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)