### PR TITLE
refactor: consolidate InProgress viewSize and total getters

### DIFF
--- a/src/components/ViewSizeSelector.vue
+++ b/src/components/ViewSizeSelector.vue
@@ -34,19 +34,15 @@ const title = computed(() => {
   return "Result Size";
 });
 
-const viewSize = computed(() => {
-  if (route.name === "OpenOrders") return useOrderStore().getOpenOrders.query.viewSize;
-  if (route.name === "InProgress") return useOrderStore().getInProgressOrders.query.viewSize;
-  if (route.name === "Completed") return useOrderStore().getCompletedOrders.query.viewSize;
-  return 0;
+const orderState = computed(() => {
+  if (route.name === "OpenOrders") return useOrderStore().getOpenOrders;
+  if (route.name === "InProgress") return useOrderStore().getInProgressOrders;
+  if (route.name === "Completed") return useOrderStore().getCompletedOrders;
+  return { query: { viewSize: 0 }, total: 0 };
 });
 
-const total = computed(() => {
-  if (route.name === "OpenOrders") return useOrderStore().getOpenOrders.total;
-  if (route.name === "InProgress") return useOrderStore().getInProgressOrders.total;
-  if (route.name === "Completed") return useOrderStore().getCompletedOrders.total;
-  return 0;
-});
+const viewSize = computed(() => orderState.value.query.viewSize);
+const total = computed(() => orderState.value.total);
 
 const prepareViewSizeOptions = () => {
   const maxViewSize = total.value > 100 ? 100 : total.value;


### PR DESCRIPTION
This addresses a TODO in ViewSizeSelector.vue to use a single getter for getting viewSize and total data across OpenOrders, InProgress, and Completed order lists. A single computed property orderState has been introduced to pull the correct Pinia store list base on route.name, and the individual values derive from that, solving duplicate repetitive logic and keeping full Vue 3 reactivity.

---
*PR created automatically by Jules for task [7662935362396065187](https://jules.google.com/task/7662935362396065187) started by @dt2patel*