### PR TITLE
Fixed: issue on TO list page, as the order information is not being displayed

### DIFF
--- a/src/store/modules/transferorder/actions.ts
+++ b/src/store/modules/transferorder/actions.ts
@@ -20,7 +20,8 @@ const actions: ActionTree<TransferOrderState, RootState> = {
     const params: any = {
       originFacilityId: getCurrentFacilityId(),
       limit: transferOrderQuery.viewSize,
-      pageIndex: transferOrderQuery.viewIndex
+      pageIndex: transferOrderQuery.viewIndex,
+      fieldsToSelect: "orderId,orderName,orderExternalId,orderStatusId,orderStatusDesc,facilityId,orderFacilityId,orderDate"
     };
     
     // If searching, add queryString


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->


### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
As we have added support for fieldsToSelect in the get#TransferOrders service in backend, the api response does not include all the information required on the list page as fieldsToSelect are not getting passed in the payload, because previously the list is hardcoded on backend.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

Before:

<img width="1764" height="1106" alt="image" src="https://github.com/user-attachments/assets/888f0480-f823-4fc2-806a-b3594684257e" />


After:

<img width="1764" height="1106" alt="image" src="https://github.com/user-attachments/assets/9cdbed57-0133-4277-bd32-89a050278133" />



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)