### PR TITLE
Migrate deprecated OMS product-store calls to admin APIs

### DIFF
--- a/src/services/CarrierService.ts
+++ b/src/services/CarrierService.ts
@@ -144,7 +144,7 @@ const createProductStoreShipmentMethod = async (payload: any): Promise<any> => {
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
   return apiClient({
-    url: `/oms/productStores/${payload.productStoreId}/shipmentMethods`,
+    url: `/admin/productStores/${payload.productStoreId}/shipmentMethods`,
     method: "POST",
     baseURL,
     headers: {
@@ -159,7 +159,7 @@ const updateProductStoreShipmentMethod = async (payload: any): Promise<any> => {
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
   return apiClient({
-    url: `/oms/productStores/${payload.productStoreId}/shipmentMethods`,
+    url: `/admin/productStores/${payload.productStoreId}/shipmentMethods`,
     method: "PUT",
     baseURL,
     headers: {
@@ -174,7 +174,7 @@ const removeProductStoreShipmentMethod = async (payload: any): Promise<any> => {
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
   return apiClient({
-    url: `/oms/productStores/${payload.productStoreId}/shipmentMethods`,
+    url: `/admin/productStores/${payload.productStoreId}/shipmentMethods`,
     method: "PUT",
     baseURL,
     headers: {

--- a/src/services/UtilService.ts
+++ b/src/services/UtilService.ts
@@ -232,7 +232,7 @@ const findProductStoreShipmentMethCount = async (query: any): Promise<any> => {
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
   return apiClient({
-    url: `/oms/productStores/shipmentMethods/counts`,
+    url: `/admin/productStores/shipmentMethods/counts`,
     method: "GET",
     baseURL,
     headers: {
@@ -311,7 +311,7 @@ const fetchProductStores = async (payload: any): Promise<any> => {
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
   return apiClient({
-    url: `/oms/productStores`,
+    url: `/admin/productStores`,
     method: "GET",
     baseURL,
     headers: {
@@ -327,7 +327,7 @@ const fetchProductStoreDetails = async (payload: any): Promise<any> => {
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
   return apiClient({
-    url: `/oms/productStores/${payload.productStoreId}`,
+    url: `/admin/productStores/${payload.productStoreId}`,
     method: "GET",
     baseURL,
     headers: {
@@ -377,7 +377,7 @@ const fetchProductStoreFacilities = async (): Promise<any> => {
     };
 
     const resp = await apiClient({
-      url: `/oms/productStores/${productStoreId}/facilities`,
+      url: `/admin/productStores/${productStoreId}/facilities`,
       method: "GET",
       baseURL,
       headers: {
@@ -647,7 +647,7 @@ const updateProductStoreSetting = async (payload: any): Promise<any> => {
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
   return apiClient({
-    url: `/oms/productStores/${payload.productStoreId}/settings`,
+    url: `/admin/productStores/${payload.productStoreId}/settings`,
     method: "POST",
     baseURL,
     headers: {
@@ -663,7 +663,7 @@ const createProductStoreSetting = async (payload: any): Promise<any> => {
   const baseURL = store.getters['user/getMaargBaseUrl'];
 
   return apiClient({
-    url: `/oms/productStores/${payload.productStoreId}/settings`,
+    url: `/admin/productStores/${payload.productStoreId}/settings`,
     method: "POST",
     baseURL,
     headers: {


### PR DESCRIPTION
Refs hotwax/oms#529.

Migrates fulfillment product-store, shipment-method, facility, and settings calls from deprecated `/oms/productStores` resources to `/admin/productStores` replacements. Response handling was reviewed against the existing callers and no app-side shape changes were needed.