### PR TITLE
Migrate deprecated OMS product-store calls to admin APIs

### DIFF
--- a/src/store/carrier.ts
+++ b/src/store/carrier.ts
@@ -348,7 +348,7 @@ export const useCarrierStore = defineStore("carrier", {
     async updateProductStoreShipmentMethod(productStoreId: string, shipmentMethod: any) {
       try {
         const resp = await api({
-          url: `/oms/productStores/${productStoreId}/shipmentMethods`,
+          url: `/admin/productStores/${productStoreId}/shipmentMethods`,
           method: "PUT",
           data: {
             shipmentGatewayConfigId: shipmentMethod.shipmentGatewayConfigId,
@@ -376,7 +376,7 @@ export const useCarrierStore = defineStore("carrier", {
         let resp;
         if (isChecked) {
           resp = await api({
-            url: `/oms/productStores/${productStoreId}/shipmentMethods`,
+            url: `/admin/productStores/${productStoreId}/shipmentMethods`,
             method: "POST",
             data: {
               productStoreId,
@@ -388,7 +388,7 @@ export const useCarrierStore = defineStore("carrier", {
           })
         } else {
           resp = await api({
-            url: `/oms/productStores/${productStoreId}/shipmentMethods`,
+            url: `/admin/productStores/${productStoreId}/shipmentMethods`,
             method: "PUT",
             data: {
               productStoreShipMethId: shipmentMethod.productStoreShipMethId,
@@ -628,7 +628,7 @@ export const useCarrierStore = defineStore("carrier", {
     },
     async findProductStoreShipmentMethCount(query: any): Promise<any> {
       return api({
-        url: `/oms/productStores/shipmentMethods/counts`,
+        url: `/admin/productStores/shipmentMethods/counts`,
         method: "GET",
         params: query
       });

--- a/src/store/product.ts
+++ b/src/store/product.ts
@@ -242,7 +242,7 @@ export const useProductStore = defineStore("product", {
 
       try {
         await api({
-          url: `oms/productStores/${productStoreId}/settings`,
+          url: `admin/productStores/${productStoreId}/settings`,
           method: "POST",
           data: {
             productStoreId,

--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -294,7 +294,7 @@ export const useProductStore = defineStore('productStore', {
           // Fetching all stores for the store name
           try {
             const productStoresResp = await api({
-              url: "oms/productStores",
+              url: "admin/productStores",
               method: "GET",
               params: {
                 pageSize: 200
@@ -423,7 +423,7 @@ export const useProductStore = defineStore('productStore', {
         };
 
         const resp = await api({
-          url: `/oms/productStores/${productStoreId}/facilities`,
+          url: `/admin/productStores/${productStoreId}/facilities`,
           method: "GET",
           params
         });
@@ -499,7 +499,7 @@ export const useProductStore = defineStore('productStore', {
         }
 
         const resp = await api({
-          url: `/oms/productStores`,
+          url: `/admin/productStores`,
           method: "GET",
           params: payload
         });
@@ -558,7 +558,7 @@ export const useProductStore = defineStore('productStore', {
 
       try {
         const resp = await api({
-          url: `/oms/productStores/shipmentMethods/counts`,
+          url: `/admin/productStores/shipmentMethods/counts`,
           method: "GET",
           params
         });

--- a/src/store/util.ts
+++ b/src/store/util.ts
@@ -197,20 +197,20 @@ export const useUtilStore = defineStore("util", {
     },
     async fetchProductStoreDetails(payload: any): Promise<any> {
       return api({
-        url: `/oms/productStores/${payload.productStoreId}`,
+        url: `/admin/productStores/${payload.productStoreId}`,
         method: "GET",
       });
     },
     async updateProductStoreSetting(payload: any): Promise<any> {
       return api({
-        url: `/oms/productStores/${payload.productStoreId}/settings`,
+        url: `/admin/productStores/${payload.productStoreId}/settings`,
         method: "POST",
         data: payload
       });
     },
     async createProductStoreSetting(payload: any): Promise<any> {
       return api({
-        url: `/oms/productStores/${payload.productStoreId}/settings`,
+        url: `/admin/productStores/${payload.productStoreId}/settings`,
         method: "POST",
         data: payload
       });
@@ -883,7 +883,7 @@ export const useUtilStore = defineStore("util", {
         let response
         if (isSettingAlreadyExists) {
           response = await api({
-            url: `/oms/productStores/${useAppProductStore().getCurrentProductStore?.productStoreId}/settings`,
+            url: `/admin/productStores/${useAppProductStore().getCurrentProductStore?.productStoreId}/settings`,
             method: "POST",
             data: {
               productStoreId: useAppProductStore().getCurrentProductStore?.productStoreId,


### PR DESCRIPTION
Refs hotwax/oms#529.

Targets `fulfillment-refactored` instead of `main`. Migrates the remaining deprecated `/oms/productStores` REST calls in the refactored Pinia stores to `/admin/productStores` replacements, including product-store details/settings, facilities, shipment method counts, and shipment-method create/update flows.

Response handling was reviewed against the refactored stores; existing list/reduce and mutation handling remains compatible.