### PR TITLE
Use fulfillment permissions for app actions

### DIFF
--- a/src/components/EditPickersModal.vue
+++ b/src/components/EditPickersModal.vue
@@ -42,7 +42,7 @@
       </div>
     </ion-list>
     <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-      <ion-fab-button :disabled="arePickersNotSelected()" @click="confirmSave()">
+      <ion-fab-button :disabled="arePickersNotSelected() || !canEditPickers" @click="confirmSave()">
         <ion-icon :icon="saveOutline" />
       </ion-fab-button>
     </ion-fab>
@@ -66,6 +66,7 @@ import { useUserStore } from "@/store/user";
 const props = defineProps(["selectedPicklist"]);
 const userStore = useUserStore();
 const currentFacility = computed(() => useAppProductStore().getCurrentFacility);
+const canEditPickers = computed(() => userStore.hasPermission("EDIT_PICKLIST_PICKER OR PICKLIST_ASSIGN OR FULFILL_PICKLIST_ADMIN"));
 
 const selectedPickers = ref([] as any[]);
 const queryString = ref("");

--- a/src/components/HistoricalManifestModal.vue
+++ b/src/components/HistoricalManifestModal.vue
@@ -19,7 +19,7 @@
           {{ translate("Manifest") }}
           <p>{{ DateTime.fromMillis(manifest.fromDate).toFormat("dd MMMM yyyy hh:mm a ZZZZ") }}</p>
         </ion-label>
-        <ion-button fill="outline" @click="downloadCarrierManifest(manifest)">
+        <ion-button fill="outline" :disabled="!canViewManifest" @click="downloadCarrierManifest(manifest)">
           <ion-icon :icon="printOutline" slot="start"/>
           {{ translate("Print") }}
           <ion-spinner name="crescent" slot="end" v-if="loadingContentId === manifest.contentId" />
@@ -42,9 +42,11 @@ import { commonUtil, logger, useShopify, translate } from "@common";
 import { useProductStore as useAppProductStore } from "@/store/productStore";
 import { DateTime } from "luxon";
 import { useCarrierStore } from "@/store/carrier";
+import { useUserStore } from "@/store/user";
 
 const props = defineProps(["selectedCarrierPartyId", "carrierConfiguration"]);
 const currentFacility = computed(() => useAppProductStore().getCurrentFacility);
+const canViewManifest = computed(() => useUserStore().hasPermission("GENERATE_MANIFEST_VIEW"));
 const loadingContentId = ref(null as any);
 const carrierStore = useCarrierStore();
 

--- a/src/components/OrderActionsPopover.vue
+++ b/src/components/OrderActionsPopover.vue
@@ -6,7 +6,7 @@
         <ion-icon slot="end" :icon="copyOutline" />
         {{ translate("Copy ID") }}
       </ion-item>
-      <ion-item v-if="category === 'open'" button @click="assignPickers">
+      <ion-item v-if="category === 'open'" button :disabled="!canCreateAndPrintPicklist" @click="assignPickers">
         <ion-icon slot="end" :icon="bagCheckOutline" />
         {{ translate("Pick order") }}
       </ion-item>
@@ -19,15 +19,19 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps } from "vue";
+import { computed, defineProps } from "vue";
 import { IonContent, IonIcon, IonItem, IonList, IonListHeader, modalController, popoverController } from "@ionic/vue";
 import { arrowForwardOutline, bagCheckOutline, copyOutline } from "ionicons/icons";
 import { commonUtil, emitter, translate } from "@common";
 import AssignPickerModal from "@/views/AssignPickerModal.vue";
 import { useOrderStore } from "@/store/order";
+import { useUserStore } from "@/store/user";
 import router from "@/router";
 
 const props = defineProps(["order", "category"]);
+const userStore = useUserStore();
+const canCreatePicklist = computed(() => userStore.hasPermission("FULFILL_PICKLIST_CREATE OR PICKLIST_CREATE OR FULFILL_PICKLIST_ADMIN"));
+const canCreateAndPrintPicklist = computed(() => canCreatePicklist.value && userStore.hasPermission("PICKLIST_PRINT OR FULFILL_PICKLIST_ADMIN"));
 
 const closePopover = () => {
   popoverController.dismiss();

--- a/src/components/OrderLookupLabelActionsPopover.vue
+++ b/src/components/OrderLookupLabelActionsPopover.vue
@@ -6,7 +6,7 @@
         {{ getCarriersTrackingInfo(shipGroup.carrierPartyId)?.carrierName ? getCarriersTrackingInfo(shipGroup.carrierPartyId).carrierName : shipGroup.carrierPartyId }}
         <ion-icon slot="end" :icon="openOutline" />
       </ion-item>
-      <ion-item button @click="printShippingLabel()" lines="none">
+      <ion-item button :disabled="!canCreateShipment" @click="printShippingLabel()" lines="none">
         {{ translate("View Label") }}
         <ion-icon slot="end" :icon="documentOutline" />
       </ion-item>
@@ -18,11 +18,13 @@
 import { IonContent, IonIcon, IonItem, IonList, IonListHeader, popoverController } from "@ionic/vue";
 import { documentOutline, openOutline } from "ionicons/icons";
 import { translate } from "@common";
-import { defineProps } from "vue";
+import { computed, defineProps } from "vue";
 import { useOrderLookupStore } from "@/store/orderLookup";
+import { useUserStore } from "@/store/user";
 
 const props = defineProps(["shipGroup"]);
 const getCarriersTrackingInfo = (partyId: string) => useOrderLookupStore().getCarriersTrackingInfo(partyId);
+const canCreateShipment = computed(() => useUserStore().hasPermission("FULFILL_SHIPMENT_CREATE OR FULFILL_SHIPMENT_ADMIN OR SALES_SHIPMENT_ADMIN"));
 
 const printShippingLabel = async () => {
   const shipmentPackageRouteSegDetails = props.shipGroup.shipmentPackageRouteSegDetails;

--- a/src/components/ScanOrderItemModal.vue
+++ b/src/components/ScanOrderItemModal.vue
@@ -46,7 +46,7 @@
   </ion-content>
 
   <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-    <ion-fab-button :disabled="!areAllItemsSelected()" @click="packOrder()">
+    <ion-fab-button :disabled="!areAllItemsSelected() || !canPickOrders" @click="packOrder()">
       <ion-icon :icon="saveOutline" />
     </ion-fab-button>
   </ion-fab>
@@ -70,6 +70,7 @@ const lastScannedId = ref("");
 
 const productIdentificationPref = computed(() => useAppProductStore().getProductIdentificationPref);
 const barcodeIdentifier = computed(() => useAppProductStore().getBarcodeIdentifierPref);
+const canPickOrders = computed(() => useAuthStore().hasPermission("PICKLIST_PICK OR FULFILL_PICKLIST_ADMIN"));
 const getProduct = (productId: string) => useProductStore().getProduct(productId);
 
 onMounted(() => {

--- a/src/components/ShippingLabelActionPopover.vue
+++ b/src/components/ShippingLabelActionPopover.vue
@@ -2,11 +2,11 @@
     <ion-content>
       <ion-list>
         <ion-list-header>{{ currentOrder?.trackingCode }}</ion-list-header>
-        <ion-item button @click="printShippingLabel(currentOrder)">
+        <ion-item button :disabled="!canCreateShipment" @click="printShippingLabel(currentOrder)">
           {{ translate("View Label") }}
           <ion-icon slot="end" :icon="documentOutline" />
         </ion-item>
-        <ion-item button lines="none" @click="voidShippingLabel(currentOrder)">
+        <ion-item button lines="none" :disabled="!canCreateShipment" @click="voidShippingLabel(currentOrder)">
           {{ translate("Void Label") }}
           <ion-icon slot="end" :icon="trashOutline" />
         </ion-item>
@@ -15,14 +15,16 @@
   </template>
   
   <script setup lang="ts">
-import { defineProps } from "vue";
+import { computed, defineProps } from "vue";
   import { IonContent, IonIcon, IonItem, IonList, IonListHeader, popoverController } from "@ionic/vue";
   import { documentOutline, trashOutline } from "ionicons/icons";
 import { commonUtil, logger, translate } from "@common";
   import { useOrderStore } from "@/store/order";
+  import { useUserStore } from "@/store/user";
 
 const props = defineProps(["currentOrder"]);
 const orderStore = useOrderStore();
+const canCreateShipment = computed(() => useUserStore().hasPermission("FULFILL_SHIPMENT_CREATE OR FULFILL_SHIPMENT_ADMIN OR SALES_SHIPMENT_ADMIN"));
 
   const printShippingLabel = async (order: any) => {
     const shipmentIds = [order.shipmentId];

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -45,7 +45,7 @@ const routes: Array<RouteRecordRaw> = [
     component: OpenOrders,
     beforeEnter: authGuard,
     meta: {
-      permissionId: "",
+      permissionId: "READYTOPACK_ORDERS_VIEW OR STOREFULFILLMENT_VIEW",
       title: "Open",
       icon: mailUnreadOutline,
       menuIndex: 1,
@@ -58,7 +58,7 @@ const routes: Array<RouteRecordRaw> = [
     component: InProgress,
     beforeEnter: authGuard,
     meta: {
-      permissionId: "",
+      permissionId: "READYTOPACK_ORDERS_VIEW OR STOREFULFILLMENT_VIEW",
       title: "In Progress",
       icon: mailOpenOutline,
       menuIndex: 2,
@@ -71,7 +71,7 @@ const routes: Array<RouteRecordRaw> = [
     component: Completed,
     beforeEnter: authGuard,
     meta: {
-      permissionId: "",
+      permissionId: "READYTOSHIP_ORDERS_VIEW OR STOREFULFILLMENT_VIEW",
       title: "Completed",
       icon: checkmarkDoneOutline,
       menuIndex: 3,
@@ -96,14 +96,20 @@ const routes: Array<RouteRecordRaw> = [
     name: 'CreateTransferOrder',
     component: CreateTransferOrder,
     beforeEnter: authGuard,
-    props: true
+    props: true,
+    meta: {
+      permissionId: "ORD_TRANSFER_ORDER_VIEW OR ORD_TRANSFER_ORDER_ADMIN"
+    }
   },
   {
     path: '/ship-transfer-order/:shipmentId',
     name: 'ShipTransferOrder',
     component: ShipTransferOrder,
     beforeEnter: authGuard,
-    props: true
+    props: true,
+    meta: {
+      permissionId: "ORD_TRANSFER_ORDER_VIEW OR ORD_TRANSFER_ORDER_ADMIN"
+    }
   },
   {
     path: '/transfer-order-details/:orderId/:category',
@@ -120,7 +126,10 @@ const routes: Array<RouteRecordRaw> = [
     name: 'ShipTransferOrderFromOrderDetail',
     component: ShipTransferOrder,
     beforeEnter: authGuard,
-    props: true
+    props: true,
+    meta: {
+      permissionId: "ORD_TRANSFER_ORDER_VIEW OR ORD_TRANSFER_ORDER_ADMIN"
+    }
   },
   {
     path: '/:category/order-detail/:orderId/:shipGroupSeqId',
@@ -129,7 +138,7 @@ const routes: Array<RouteRecordRaw> = [
     beforeEnter: authGuard,
     props: true,
     meta: {
-      permissionId: ""
+      permissionId: "READYTOPACK_ORDERS_VIEW OR READYTOSHIP_ORDERS_VIEW OR STOREFULFILLMENT_VIEW"
     }
   },
   {
@@ -139,7 +148,7 @@ const routes: Array<RouteRecordRaw> = [
     beforeEnter: authGuard,
     props: true,
     meta: {
-      permissionId: ""
+      permissionId: "READYTOPACK_ORDERS_VIEW OR READYTOSHIP_ORDERS_VIEW OR STOREFULFILLMENT_VIEW"
     }
   },
   {

--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -42,7 +42,7 @@
   </ion-content>
 
   <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-    <ion-fab-button :disabled="!selectedPickers.length" @click="printPicklist()">
+    <ion-fab-button :disabled="!selectedPickers.length || !canCreateAndPrintPicklist" @click="printPicklist()">
       <ion-icon :icon="saveOutline" />
     </ion-fab-button>
   </ion-fab>
@@ -65,6 +65,8 @@ const utilStore = useUtilStore();
 const userStore = useDxpUserStore();
 const currentFacility = computed(() => useAppProductStore().getCurrentFacility);
 const openOrders = computed(() => useOrderStore().getOpenOrders);
+const canCreatePicklist = computed(() => userStore.hasPermission("FULFILL_PICKLIST_CREATE OR PICKLIST_CREATE OR FULFILL_PICKLIST_ADMIN"));
+const canCreateAndPrintPicklist = computed(() => canCreatePicklist.value && userStore.hasPermission("PICKLIST_PRINT OR FULFILL_PICKLIST_ADMIN"));
 const selectedPickers = ref([]) as any;
 const queryString = ref("");
 const pickers = ref([]) as any;

--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -49,7 +49,7 @@
 
       <div v-if="completedOrders.total">
         <div class="results">
-          <ion-button :disabled="isProductStoreSettingEnabled('DISABLE_SHIPNOW') || hasAnyMissingInfo() || (hasAnyShipmentTrackingInfoMissing() && !userStore.hasPermission('COMMON_ADMIN'))" expand="block" class="bulk-action desktop-only" fill="outline" size="large" @click="bulkShipOrders()">{{ translate("Ship") }}</ion-button>
+          <ion-button :disabled="!canCreateShipment || isProductStoreSettingEnabled('DISABLE_SHIPNOW') || hasAnyMissingInfo() || (hasAnyShipmentTrackingInfoMissing() && !userStore.hasPermission('COMMON_ADMIN'))" expand="block" class="bulk-action desktop-only" fill="outline" size="large" @click="bulkShipOrders()">{{ translate("Ship") }}</ion-button>
           <ion-card class="order" v-for="(order, index) in completedOrdersList" :key="index">
             <div class="order-header">
               <div class="order-primary-info">
@@ -133,7 +133,7 @@
 
             <div class="mobile-only">
               <ion-item>
-                <ion-button :disabled="isProductStoreSettingEnabled('DISABLE_SHIPNOW') || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || ((isTrackingRequiredForAnyShipmentPackage(order) && !order.trackingCode) && !userStore.hasPermission('COMMON_ADMIN'))" fill="clear">{{ translate("Ship Now") }}</ion-button>
+                <ion-button :disabled="!canCreateShipment || isProductStoreSettingEnabled('DISABLE_SHIPNOW') || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || ((isTrackingRequiredForAnyShipmentPackage(order) && !order.trackingCode) && !userStore.hasPermission('COMMON_ADMIN'))" fill="clear">{{ translate("Ship Now") }}</ion-button>
                 <ion-button slot="end" fill="clear" color="medium" @click.stop="shippingPopover">
                   <ion-icon slot="icon-only" :icon="ellipsisVerticalOutline" />
                 </ion-button>
@@ -143,12 +143,12 @@
             <div class="actions">
               <div class="desktop-only">
                 <ion-button v-if="!hasPackedShipments(order)" :disabled="true">{{ translate("Shipped") }}</ion-button>
-                <ion-button v-else :disabled="isProductStoreSettingEnabled('DISABLE_SHIPNOW') || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || ((isTrackingRequiredForAnyShipmentPackage(order) && !order.trackingCode) && !userStore.hasPermission('COMMON_ADMIN'))" @click.stop="shipOrder(order)">{{ translate("Ship Now") }}</ion-button>
-                <ion-button :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo" fill="outline" @click.stop="regenerateShippingLabel(order)">
+                <ion-button v-else :disabled="!canCreateShipment || isProductStoreSettingEnabled('DISABLE_SHIPNOW') || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || ((isTrackingRequiredForAnyShipmentPackage(order) && !order.trackingCode) && !userStore.hasPermission('COMMON_ADMIN'))" @click.stop="shipOrder(order)">{{ translate("Ship Now") }}</ion-button>
+                <ion-button :disabled="!canCreateShipment || order.hasMissingShipmentInfo || order.hasMissingPackageInfo" fill="outline" @click.stop="regenerateShippingLabel(order)">
                   {{ translate(order.missingLabelImage ? "Regenerate Shipping Label" : "Print Shipping Label") }}
                   <ion-spinner color="primary" slot="end" v-if="order.isGeneratingShippingLabel" name="crescent" />
                 </ion-button>
-                <ion-button :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo" fill="outline" @click.stop="localPrintPackingSlip(order)">
+                <ion-button :disabled="!canCreateShipment || order.hasMissingShipmentInfo || order.hasMissingPackageInfo" fill="outline" @click.stop="localPrintPackingSlip(order)">
                   {{ translate("Print Customer Letter") }}
                   <ion-spinner color="primary" slot="end" v-if="order.isGeneratingPackingSlip" name="crescent" />
                 </ion-button>
@@ -169,7 +169,7 @@
         <ion-spinner name="crescent"></ion-spinner>
       </div>
       <ion-fab v-else-if="completedOrders.total" class="mobile-only" vertical="bottom" horizontal="end" slot="fixed">
-        <ion-fab-button :disabled="hasAnyMissingInfo() || (hasAnyShipmentTrackingInfoMissing() && !userStore.hasPermission('COMMON_ADMIN'))" @click="bulkShipOrders()">
+        <ion-fab-button :disabled="!canCreateShipment || hasAnyMissingInfo() || (hasAnyShipmentTrackingInfoMissing() && !userStore.hasPermission('COMMON_ADMIN'))" @click="bulkShipOrders()">
           <ion-icon :icon="checkmarkDoneOutline" />
         </ion-fab-button>
       </ion-fab>
@@ -178,14 +178,14 @@
       </div>
     </ion-content>
 
-    <ion-footer v-if="selectedCarrierPartyId">
+    <ion-footer v-if="selectedCarrierPartyId && canViewManifest">
       <ion-toolbar>
         <ion-buttons slot="end">
           <ion-button fill="outline" color="primary" @click="openHistoricalManifestModal">
             <ion-icon slot="start" :icon="timeOutline" />
             {{ translate("View historical manifests") }}
           </ion-button>
-          <ion-button fill="solid" color="primary" :disabled="!carrierConfiguration[selectedCarrierPartyId]?.['MANIFEST_GEN_REQUEST']" @click="generateCarrierManifest">
+          <ion-button fill="solid" color="primary" :disabled="!carrierConfiguration[selectedCarrierPartyId]?.['MANIFEST_GEN_REQUEST'] || !canViewManifest" @click="generateCarrierManifest">
             <ion-icon slot="start" :icon="printOutline" />
             {{ translate("Generate Manifest") }}
             <ion-spinner name="crescent" slot="end" v-if="isGeneratingManifest" />
@@ -251,6 +251,8 @@ const isProductStoreSettingEnabled = computed(() => (settingTypeEnumId: string) 
 const currentProductStore = computed(() => useProductStore().getCurrentProductStore);
 const currentFacility = computed(() => useProductStore().getCurrentFacility);
 const productIdentificationPref = computed(() => useProductStore().getProductIdentificationPref);
+const canCreateShipment = computed(() => userStore.hasPermission("FULFILL_SHIPMENT_CREATE OR FULFILL_SHIPMENT_ADMIN OR SALES_SHIPMENT_ADMIN"));
+const canViewManifest = computed(() => userStore.hasPermission("GENERATE_MANIFEST_VIEW"));
 
 const getTime = (time: any) => {
   return time ? DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED) : "";

--- a/src/views/CreateTransferOrder.vue
+++ b/src/views/CreateTransferOrder.vue
@@ -184,7 +184,7 @@
           <ion-button data-testid="ship-later-btn-create-transfer-order-page" size="small" fill="outline" :disabled="!currentOrder.items?.length || hasInvalidPickedQuantity() || pendingProductIds.size" @click="shiplater">
             {{ translate("Ship later") }}
           </ion-button>
-          <ion-button data-testid="pack-and-ship-order-btn" size="small" color="primary" fill="solid" :disabled="!currentOrder.items?.length || hasInvalidPickedQuantity() || pendingProductIds.size" @click="packAndShipOrder">
+          <ion-button data-testid="pack-and-ship-order-btn" size="small" color="primary" fill="solid" :disabled="!canCreateShipment || !currentOrder.items?.length || hasInvalidPickedQuantity() || pendingProductIds.size" @click="packAndShipOrder">
             {{ translate("Pack and ship order") }}
           </ion-button>
         </ion-buttons>
@@ -208,6 +208,7 @@ import { useProductQueue } from "@/composables/useProductQueue";
 import { useProductStore as useProduct } from "@/store/product";
 import { useTransferOrderStore } from "@/store/transferorder";
 import { useOrderStore } from "@/store/order";
+import { useUserStore } from "@/store/user";
 
 const route = router.currentRoute.value;
 const productIdentificationPref = computed(() => useProductStore().getProductIdentificationPref);
@@ -234,6 +235,7 @@ const barcodeIdentifier = computed(() => useProductStore().getBarcodeIdentifierP
 const getProduct = (productId: string) => useProduct().getProduct(productId);
 const currentOrder = computed(() => useTransferOrderStore().getCurrent);
 const isProductStoreSettingEnabled = computed(() => (settingTypeEnumId: string) => useProductStore().isProductStoreSettingEnabled(settingTypeEnumId));
+const canCreateShipment = computed(() => useUserStore().hasPermission("FULFILL_SHIPMENT_CREATE OR FULFILL_SHIPMENT_ADMIN OR SALES_SHIPMENT_ADMIN"));
 
 watch(queryString, (value) => {
   if (mode.value === "scan") return;

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -45,7 +45,7 @@
 
       <div v-if="inProgressOrders.total">
         <div class="results">
-          <ion-button expand="block" class="bulk-action desktop-only" fill="outline" size="large" v-if="!isProductStoreSettingEnabled('FULFILL_FORCE_SCAN')" @click="packOrders()">{{ translate("Pack orders") }}</ion-button>
+          <ion-button expand="block" class="bulk-action desktop-only" fill="outline" size="large" v-if="!isProductStoreSettingEnabled('FULFILL_FORCE_SCAN')" :disabled="!canPickOrders" @click="packOrders()">{{ translate("Pack orders") }}</ion-button>
           <ion-card class="order" v-for="(order, index) in getInProgressOrders()" :key="index" :class="isProductStoreSettingEnabled('FULFILL_FORCE_SCAN') ? 'ion-margin-top' : ''">
             <div class="order-header">
               <div class="order-primary-info">
@@ -176,7 +176,7 @@
 
             <div class="mobile-only">
               <ion-item>
-                <ion-button fill="clear" @click.stop="packOrder(order)">{{ translate("Pack using default packaging") }}</ion-button>
+                <ion-button fill="clear" :disabled="!canPickOrders" @click.stop="packOrder(order)">{{ translate("Pack using default packaging") }}</ion-button>
                 <ion-button slot="end" fill="clear" color="medium" @click.stop="packagingPopover">
                   <ion-icon slot="icon-only" :icon="ellipsisVerticalOutline" />
                 </ion-button>
@@ -185,7 +185,7 @@
 
             <div class="actions">
               <div>
-                <ion-button :color="order.hasAllRejectedItem ? 'danger' : ''" @click.stop="packOrder(order)">{{ translate(order.hasAllRejectedItem ? "Reject" : order.hasRejectedItem ? "Save and Pack" : "Pack") }}</ion-button>
+                <ion-button :color="order.hasAllRejectedItem ? 'danger' : ''" :disabled="!canPickOrders" @click.stop="packOrder(order)">{{ translate(order.hasAllRejectedItem ? "Reject" : order.hasRejectedItem ? "Save and Pack" : "Pack") }}</ion-button>
               </div>
 
               <div class="desktop-only">
@@ -203,7 +203,7 @@
       </div>
       <template v-else-if="inProgressOrders.total">
         <ion-fab v-if="!isProductStoreSettingEnabled('FULFILL_FORCE_SCAN')" class="mobile-only" vertical="bottom" horizontal="end" slot="fixed">
-          <ion-fab-button @click="packOrders()">
+          <ion-fab-button :disabled="!canPickOrders" @click="packOrders()">
             <ion-icon :icon="checkmarkDoneOutline" />
           </ion-fab-button>
         </ion-fab>
@@ -215,11 +215,11 @@
     <ion-footer v-if="selectedPicklistId && inProgressOrders.total">
       <ion-toolbar>
         <ion-buttons slot="end">
-          <ion-button fill="outline" color="primary" @click="editPickers(getPicklist(selectedPicklistId))">
+          <ion-button fill="outline" color="primary" :disabled="!canEditPickers" @click="editPickers(getPicklist(selectedPicklistId))">
             <ion-icon slot="start" :icon="pencilOutline" />
             {{ translate("Edit Pickers") }}
           </ion-button>
-          <ion-button fill="solid" color="primary" @click="printPicklist(getPicklist(selectedPicklistId))">
+          <ion-button fill="solid" color="primary" :disabled="!canPrintPicklist" @click="printPicklist(getPicklist(selectedPicklistId))">
             <ion-spinner v-if="getPicklist(selectedPicklistId).isGeneratingPicklist" slot="start" name="crescent" />
             <ion-icon v-else slot="start" :icon="printOutline" />
             {{ translate("Print Picklist") }}
@@ -286,6 +286,9 @@ const carrierShipmentBoxTypes = computed(() => useUtilStore().getCarrierShipment
 const productIdentificationPref = computed(() => useProductStore().getProductIdentificationPref);
 const currentProductStore = computed(() => useProductStore().getCurrentProductStore);
 const currentFacility = computed(() => useProductStore().getCurrentFacility as any);
+const canPickOrders = computed(() => userStore.hasPermission("PICKLIST_PICK OR FULFILL_PICKLIST_ADMIN"));
+const canPrintPicklist = computed(() => userStore.hasPermission("PICKLIST_PRINT OR FULFILL_PICKLIST_ADMIN"));
+const canEditPickers = computed(() => userStore.hasPermission("EDIT_PICKLIST_PICKER OR PICKLIST_ASSIGN OR FULFILL_PICKLIST_ADMIN"));
 
 const getProduct = (productId: string) => useProduct().getProduct(productId);
 const boxTypeDesc = (boxTypeId: string) => useUtilStore().getShipmentBoxDesc(boxTypeId);

--- a/src/views/OpenOrders.vue
+++ b/src/views/OpenOrders.vue
@@ -37,7 +37,7 @@
       <Component :is="productCategoryFilterExt" :orderQuery="openOrders.query" :currentFacility="currentFacility" :currentProductStore="currentProductStore" @updateOpenQuery="updateOpenQuery" />
       <div v-if="openOrders.total">
         <div class="results">
-          <ion-button class="bulk-action desktop-only" size="large" @click="assignPickers">{{ translate("Print Picklist") }}</ion-button>
+          <ion-button class="bulk-action desktop-only" size="large" :disabled="!canCreateAndPrintPicklist" @click="assignPickers">{{ translate("Print Picklist") }}</ion-button>
 
           <ion-card class="order" v-for="(order, index) in getOpenOrders()" :key="index">
             <div class="order-header">
@@ -126,7 +126,7 @@
         <ion-spinner name="crescent"></ion-spinner>
       </div>
       <ion-fab v-else-if="openOrders.total" class="mobile-only" vertical="bottom" horizontal="end" slot="fixed">
-        <ion-fab-button @click="assignPickers">
+        <ion-fab-button :disabled="!canCreateAndPrintPicklist" @click="assignPickers">
           <ion-icon :icon="printOutline" />
         </ion-fab-button>
       </ion-fab>
@@ -180,6 +180,8 @@ const getProductStock = (productId: string) => useStockStore().getProductStock(p
 const currentFacility = computed(() => useAppProductStore().getCurrentFacility);
 const currentProductStore = computed(() => useAppProductStore().getCurrentProductStore);
 const productIdentificationPref = computed(() => useAppProductStore().getProductIdentificationPref);
+const canCreatePicklist = computed(() => userStore.hasPermission("FULFILL_PICKLIST_CREATE OR PICKLIST_CREATE OR FULFILL_PICKLIST_ADMIN"));
+const canCreateAndPrintPicklist = computed(() => canCreatePicklist.value && userStore.hasPermission("PICKLIST_PRINT OR FULFILL_PICKLIST_ADMIN"));
 
 const updateOpenQuery = (payload: any) => {
   useOrderStore().updateOpenQuery(payload);

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -17,7 +17,7 @@
               <ion-icon :icon="pricetagOutline" />
               <ion-label>{{ order.orderId }}</ion-label>
             </ion-chip>
-            <ion-chip v-if="category !== 'open'" outline @click="printPicklist(order)">
+            <ion-chip v-if="category !== 'open'" outline :disabled="!canPrintPicklist" @click="printPicklist(order)">
               <ion-icon :icon="documentTextOutline" />
               <ion-label>{{ translate('Linked picklist') }}: {{ order.picklistId }}</ion-label>
             </ion-chip>
@@ -155,7 +155,7 @@
 
           <div v-if="category === 'in-progress'" class="mobile-only">
             <ion-item>
-              <ion-button fill="clear" @click="packOrder(order)">{{ translate("Pack using default packaging") }}</ion-button>
+              <ion-button fill="clear" :disabled="!canPickOrders" @click="packOrder(order)">{{ translate("Pack using default packaging") }}</ion-button>
               <ion-button slot="end" fill="clear" color="medium" @click="packagingPopover">
                 <ion-icon slot="icon-only" :icon="ellipsisVerticalOutline" />
               </ion-button>
@@ -164,7 +164,7 @@
 
           <div v-else-if="category === 'completed'" class="mobile-only">
             <ion-item>
-              <ion-button :disabled="isProductStoreSettingEnabled('DISABLE_SHIPNOW') || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || ((isTrackingRequiredForAnyShipmentPackage(order) && !order.trackingCode) && !userStore.hasPermission('COMMON_ADMIN'))" fill="clear">{{ translate("Ship Now") }}</ion-button>
+              <ion-button :disabled="!canCreateShipment || isProductStoreSettingEnabled('DISABLE_SHIPNOW') || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || ((isTrackingRequiredForAnyShipmentPackage(order) && !order.trackingCode) && !userStore.hasPermission('COMMON_ADMIN'))" fill="clear">{{ translate("Ship Now") }}</ion-button>
               <ion-button slot="end" fill="clear" color="medium" @click.stop="shippingPopover">
                 <ion-icon slot="icon-only" :icon="ellipsisVerticalOutline" />
               </ion-button>
@@ -174,13 +174,13 @@
           <div class="actions">
             <div>
               <template v-if="category === 'in-progress'">
-                <ion-button :color="order.hasAllRejectedItem ? 'danger' : ''" @click="packOrder(order)">
+                <ion-button :color="order.hasAllRejectedItem ? 'danger' : ''" :disabled="!canPickOrders" @click="packOrder(order)">
                   <ion-icon slot="start" :icon="archiveOutline" />
                   {{ translate(order.hasAllRejectedItem ? "Reject order" : order.hasRejectedItem ? "Save and Pack Order" : "Pack order") }}
                 </ion-button>
                 <Component :is="printDocumentsExt" :category="category" :order="order" :currentFacility="currentFacility" :hasMissingInfo="order.missingLabelImage" />
               </template>
-              <ion-button v-else-if="category === 'open'" @click="assignPickers">
+              <ion-button v-else-if="category === 'open'" :disabled="!canCreateAndPrintPicklist" @click="assignPickers">
                 <ion-icon slot="start" :icon="personAddOutline" />
                 {{ translate("Pick order") }}
               </ion-button>
@@ -189,11 +189,11 @@
                   <ion-icon slot="start" :icon="bagCheckOutline" />
                   {{ translate("Shipped") }}
                 </ion-button>
-                <ion-button v-else :disabled="isProductStoreSettingEnabled('DISABLE_SHIPNOW') || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || ((isTrackingRequiredForAnyShipmentPackage(order) && !order.trackingCode) && !userStore.hasPermission('COMMON_ADMIN'))" @click.stop="shipOrder(order)">
+                <ion-button v-else :disabled="!canCreateShipment || isProductStoreSettingEnabled('DISABLE_SHIPNOW') || order.hasMissingShipmentInfo || order.hasMissingPackageInfo || ((isTrackingRequiredForAnyShipmentPackage(order) && !order.trackingCode) && !userStore.hasPermission('COMMON_ADMIN'))" @click.stop="shipOrder(order)">
                   <ion-icon slot="start" :icon="bagCheckOutline" />
                   {{ translate("Ship order") }}
                 </ion-button>
-                <ion-button :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo" fill="outline" @click.stop="printPackingSlip(order)">
+                <ion-button :disabled="!canCreateShipment || order.hasMissingShipmentInfo || order.hasMissingPackageInfo" fill="outline" @click.stop="printPackingSlip(order)">
                   {{ translate("Print Customer Letter") }}
                   <ion-spinner data-spinner-size="medium" color="primary" slot="end" v-if="order.isGeneratingPackingSlip" name="crescent" />
                 </ion-button>
@@ -299,11 +299,11 @@
                 </ion-label>
               </ion-item>
               <template v-if="category === 'completed'">
-                <ion-button :disabled="!shipmentMethodTypeId || !hasPackedShipments(order)" fill="outline" expand="block" class="ion-margin" @click.stop="regenerateShippingLabel(order)">
+                <ion-button :disabled="!canCreateShipment || !shipmentMethodTypeId || !hasPackedShipments(order)" fill="outline" expand="block" class="ion-margin" @click.stop="regenerateShippingLabel(order)">
                   {{ shipmentLabelErrorMessage ? translate("Retry Label") : translate("Generate Label") }}
                   <ion-spinner color="primary" slot="end" data-spinner-size="medium" v-if="order.isGeneratingShippingLabel" name="crescent" />
                 </ion-button>
-                <ion-button :disabled="!shipmentMethodTypeId || !carrierPartyId || !hasPackedShipments(order)" fill="clear" expand="block" color="medium" @click="openTrackingCodeModal()">
+                <ion-button :disabled="!canCreateShipment || !shipmentMethodTypeId || !carrierPartyId || !hasPackedShipments(order)" fill="clear" expand="block" color="medium" @click="openTrackingCodeModal()">
                   {{ translate("Add tracking code manually") }}
                 </ion-button>
               </template>
@@ -313,7 +313,7 @@
                 {{ order.trackingCode }}
                 <p>{{ translate("tracking code") }}</p>
               </ion-label>        
-              <ion-button slot="end" fill="clear" color="medium" @click="shippingLabelActionPopover($event, order)">
+              <ion-button slot="end" fill="clear" color="medium" :disabled="!canCreateShipment" @click="shippingLabelActionPopover($event, order)">
                 <ion-icon slot="icon-only" :icon="ellipsisVerticalOutline" />
               </ion-button>
             </ion-item>
@@ -426,6 +426,11 @@ const props = defineProps(["category", "orderId", "shipGroupSeqId", "shipmentId"
 const userStore = useUserStore();
 const orderStore = useOrderStore();
 const carrierStore = useCarrierStore();
+const canCreatePicklist = computed(() => userStore.hasPermission("FULFILL_PICKLIST_CREATE OR PICKLIST_CREATE OR FULFILL_PICKLIST_ADMIN"));
+const canCreateAndPrintPicklist = computed(() => canCreatePicklist.value && userStore.hasPermission("PICKLIST_PRINT OR FULFILL_PICKLIST_ADMIN"));
+const canPrintPicklist = computed(() => userStore.hasPermission("PICKLIST_PRINT OR FULFILL_PICKLIST_ADMIN"));
+const canPickOrders = computed(() => userStore.hasPermission("PICKLIST_PICK OR FULFILL_PICKLIST_ADMIN"));
+const canCreateShipment = computed(() => userStore.hasPermission("FULFILL_SHIPMENT_CREATE OR FULFILL_SHIPMENT_ADMIN OR SALES_SHIPMENT_ADMIN"));
 
 const addingBoxForShipmentIds = ref([] as any);
 const isUpdatingCarrierDetail = ref(false);

--- a/src/views/ShipTransferOrder.vue
+++ b/src/views/ShipTransferOrder.vue
@@ -63,7 +63,7 @@
               </ion-button>
             </ion-item>
             <ion-card-content>
-              <ion-button data-testid="reprint-label-btn" fill="outline" color="primary" @click="printShippingLabel">
+              <ion-button data-testid="reprint-label-btn" fill="outline" color="primary" :disabled="!canCreateShipment" @click="printShippingLabel">
                 <ion-icon :icon="printOutline" slot="start" size="small" />
                 {{ translate("Re-print shipping label") }}
               </ion-button>
@@ -135,7 +135,7 @@
       <ion-toolbar>
         <ion-buttons slot="end">
           <ion-button data-testid="ship-later-btn-ship-transfer-order-page" :disabled="shipmentDetails?.carrierServiceStatusId === 'SHRSCS_ACCEPTED' || isProcessingShipment || !!selectedCarrierService" fill="outline" color="primary" @click="shipLater()">{{ translate("Ship later") }}</ion-button>
-          <ion-button data-testid="ship-order-btn" :disabled="isProcessingShipment || !!selectedCarrierService" fill="solid" color="primary" @click="shipOrder">
+          <ion-button data-testid="ship-order-btn" :disabled="!canCreateShipment || isProcessingShipment || !!selectedCarrierService" fill="solid" color="primary" @click="shipOrder">
             <ion-spinner v-if="isProcessingShipment" slot="start" name="crescent" />
             {{ translate("Ship order") }}
           </ion-button>
@@ -168,6 +168,7 @@ const userStore = useUserStore();
 const orderStore = useOrderStore();
 const transferOrderStore = useTransferOrderStore();
 const carrierStore = useCarrierStore();
+const canCreateShipment = computed(() => userStore.hasPermission("FULFILL_SHIPMENT_CREATE OR FULFILL_SHIPMENT_ADMIN OR SALES_SHIPMENT_ADMIN"));
 
 const getProduct = (productId: string) => useProductStore().getProduct(productId);
 const shipmentMethodsByCarrier = computed(() => useUtilStore().getShipmentMethodsByCarrier);

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -93,7 +93,7 @@
 
                 <div class="actions">
                   <div class="desktop-only">
-                    <ion-button fill="outline" @click.stop="regenerateShippingLabel(shipment)">
+                    <ion-button fill="outline" :disabled="!canCreateShipment" @click.stop="regenerateShippingLabel(shipment)">
                       {{ translate("Regenerate Shipping Label") }}
                       <ion-spinner color="primary" slot="start" v-if="shipment.isGeneratingShippingLabel" name="crescent" />
                     </ion-button>
@@ -124,11 +124,11 @@
             <ion-icon slot="start" :icon="trashOutline" />
             {{ translate("Reject Items") }}
           </ion-button>
-          <ion-button color="primary" fill="outline" :disabled="!userStore.hasPermission('STOREFULFILLMENT_ADMIN') || isCreatingShipment" @click="printTransferOrderPicklist()">
+          <ion-button color="primary" fill="outline" :disabled="!canPrintPicklist || isCreatingShipment" @click="printTransferOrderPicklist()">
             <ion-icon slot="start" :icon="printOutline" />
             {{ translate('Picklist') }}
           </ion-button>
-          <ion-button color="primary" fill="solid" :disabled="!userStore.hasPermission('STOREFULFILLMENT_ADMIN') || !isEligibleForCreatingShipment() || isCreatingShipment" @click="confirmCreateShipment">
+          <ion-button color="primary" fill="solid" :disabled="!canCreateShipment || !isEligibleForCreatingShipment() || isCreatingShipment" @click="confirmCreateShipment">
             <ion-spinner v-if="isCreatingShipment" slot="start" name="crescent" />
             {{ translate('Create shipment') }}
           </ion-button>
@@ -160,6 +160,8 @@ import router from "@/router";
 const userStore = useUserStore();
 const orderStore = useOrderStore();
 const transferOrderStore = useTransferOrderStore();
+const canPrintPicklist = computed(() => userStore.hasPermission("PICKLIST_PRINT OR FULFILL_PICKLIST_ADMIN"));
+const canCreateShipment = computed(() => userStore.hasPermission("FULFILL_SHIPMENT_CREATE OR FULFILL_SHIPMENT_ADMIN OR SALES_SHIPMENT_ADMIN"));
 
 const getProductIdentificationValue = commonUtil.getProductIdentificationValue;
 


### PR DESCRIPTION
## Business summary
Closes #1623.

Visible SGC_FULFILL permissions in the Users app should map to real Fulfillment app behavior instead of appearing as unused administrative noise. This PR wires existing fulfillment, picklist, shipment, and manifest permissions into the current Fulfillment screens and actions using the app's existing permission-store and route-meta pattern.

## Changes
- Adds route permission gates for open, in-progress, completed, and detail screens.
- Gates picklist create/print/pick/edit controls with existing picklist permissions and admin fallbacks.
- Gates shipment creation, label, and transfer shipment controls with shipment permissions and admin fallbacks.
- Gates carrier manifest viewing/printing behind `GENERATE_MANIFEST_VIEW`.
- Keeps the changes to permission expressions and existing controls only; no CSS or layout changes.

## Validation
- `git diff --check` passed.
- `pnpm build` reached Vite but failed on existing dependency resolution: missing `workbox-window` from `vite-plugin-pwa`.
- `pnpm lint` is blocked by resolved ESLint v10 expecting `eslint.config.*`, while this repo has `.eslintrc.js`.
- `vue-tsc --noEmit --ignoreDeprecations 6.0` ran but failed on broad existing type issues in shared/common stores and existing app files; no diagnostics pointed at the new permission checks.
