### PR TITLE
fix(ui): resolve order item separator bugs with sibling combinator

### DIFF
--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -327,17 +327,22 @@ img {
   grid-template-columns: repeat(2, 1fr);
   align-items: center;
   padding: var(--spacer-xs) 0;
-  border-bottom: var(--border-medium);
+  /*border-bottom: var(--border-medium);*/
 }
 
-@media (max-width: 991px) {
-  .order-item {
-    border-bottom: none;
-  }
-}
+/*@media (max-width: 991px) {*/
+/*  .order-item {*/
+/*    border-bottom: none;*/
+/*  }*/
+/*}*/
 
-.order-item:last-child {
-  border-bottom: none;
+/*.order-item:last-child {*/
+/*  border-bottom: none;*/
+/*}*/
+
+/* This draws a line between two order items */
+.order-item + .order-item {
+  border-top: var(--border-medium);
 }
 
 .product-metadata {

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -329,7 +329,6 @@ img {
   padding: var(--spacer-xs) 0;
 }
 
-/* This draws a line between two order items */
 .order-item + .order-item {
   border-top: var(--border-medium);
 }

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -327,18 +327,7 @@ img {
   grid-template-columns: repeat(2, 1fr);
   align-items: center;
   padding: var(--spacer-xs) 0;
-  /*border-bottom: var(--border-medium);*/
 }
-
-/*@media (max-width: 991px) {*/
-/*  .order-item {*/
-/*    border-bottom: none;*/
-/*  }*/
-/*}*/
-
-/*.order-item:last-child {*/
-/*  border-bottom: none;*/
-/*}*/
 
 /* This draws a line between two order items */
 .order-item + .order-item {


### PR DESCRIPTION
### Short Description and Why It's Useful
This PR addresses a mobile UI layout bug and refactors the CSS border logic for `.order-item` elements, acting as a follow-up fix for the DOM simplification introduced in PR #966. 

**Changes included:**
* **Fixed Mobile Separators:** Removed the `@media (max-width: 991px)` rule that was unintentionally stripping all horizontal separator lines between products on mobile devices.
* **Refactored Border Logic:** Replaced error-prone `:last-child` hacks with the adjacent sibling combinator (`.order-item + .order-item`).
* **Why it's useful:** The sibling combinator guarantees that border lines are *only* drawn between two items. This restores the missing separators on mobile, keeps the desktop view clean, and automatically prevents the buggy double-border from appearing right above the action footers (like the "PACK" button) on the In Progress and Completed pages.

### Screenshots of Visual Changes before/after
---
**Before (Mobile Bug)**

<img width="512" height="415" alt="image" src="https://github.com/user-attachments/assets/38efa841-e425-43e0-bdbf-b6d0f6041c8a" />

---

**After (Mobile Fix)**
 
<img width="512" height="293" alt="image" src="https://github.com/user-attachments/assets/cd7b0afc-90f7-44c5-ac61-f376ef941d4e" />

---

**Desktop (Verified)**

<img width="1605" height="920" alt="image" src="https://github.com/user-attachments/assets/62e58b1b-d455-4cea-8d6c-bc152630c396" />