### PR TITLE
Fixed: useProductStore replaced with useAppProductStore in printPicklist

### DIFF
--- a/src/store/order.ts
+++ b/src/store/order.ts
@@ -1158,7 +1158,7 @@ export const useOrderStore = defineStore("order", {
     },
     async printPicklist(picklistId: string) {
       try {
-        const isPicklistDownloadEnabled = useProductStore().isProductStoreSettingEnabled("FF_DOWNLOAD_PICKLIST")
+        const isPicklistDownloadEnabled = useAppProductStore().isProductStoreSettingEnabled("FF_DOWNLOAD_PICKLIST")
         if (isPicklistDownloadEnabled) {
           await this.downloadPicklist(picklistId)
           return;


### PR DESCRIPTION
Fixes #1629

## Business summary
Picklist printing silently fails in the Fulfillment app because the 
`printPicklist` function incorrectly references `useProductStore()`, 
which does not expose the `isProductStoreSettingEnabled` method. 
This fix restores picklist print and download functionality by using 
the correct store.

## What changed
- Replaced `useProductStore()` with `useAppProductStore()` in the 
  `printPicklist` function (`src/store/order.ts`) to correctly resolve 
  the `FF_DOWNLOAD_PICKLIST` product-store setting.

## Root cause
During the store refactoring, `useProductStore` and `useAppProductStore` 
were separated. The `isProductStoreSettingEnabled` method lives on 
`useAppProductStore`, but `printPicklist` was left pointing to 
`useProductStore`, causing the setting check to fail and the picklist 
print/download to never trigger.

## Validation
- Tested locally: clicking "Print Picklist" now correctly opens the 
  picklist PDF via the `/fop/apps/pdf/PrintPicklist` endpoint.
- Single-line change with no impact on other functionality.
- `FF_DOWNLOAD_PICKLIST` setting is now correctly evaluated; 
  download flow also verified to work when the setting is enabled.


cc @ymaheshwari1 @Banibrata-Manna  for review
