### PR TITLE
Fixed: Cleared stale shipment label error messages upon voiding a shipping label

### DIFF
--- a/src/components/ShippingLabelActionPopover.vue
+++ b/src/components/ShippingLabelActionPopover.vue
@@ -39,6 +39,7 @@ const orderStore = useOrderStore();
   };
   
   const voidShippingLabel = async (order: any) => {
+    let voided = false;
     try {
       await orderStore.voidShipmentLabel({
         shipmentId: order.shipmentId,
@@ -47,10 +48,11 @@ const orderStore = useOrderStore();
   
       commonUtil.showToast(translate("Shipping label voided successfully."));
       await useOrderStore().updateShipmentPackageDetail(order);
+      voided = true;
     } catch (err) {
       logger.error("Failed to void shipping label", err);
       commonUtil.showToast(translate("Failed to void shipping label"));
     }
-    popoverController.dismiss();
+    popoverController.dismiss({ voided });
   };
   </script>

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -494,7 +494,7 @@ const getTime = (time: any) => {
 const fetchShipmentLabelError = async () => {
   const shipmentId = order.value?.shipmentId;
   const labelError = await orderStore.fetchShipmentLabelError(shipmentId) as any;
-  shipmentLabelErrorMessage.value = labelError;
+  shipmentLabelErrorMessage.value = labelError || "";
 };
 
 const getProductStoreShipmentMethods = async (carrierPartyIdValue: string) => {

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -494,10 +494,7 @@ const getTime = (time: any) => {
 const fetchShipmentLabelError = async () => {
   const shipmentId = order.value?.shipmentId;
   const labelError = await orderStore.fetchShipmentLabelError(shipmentId) as any;
-
-  if (labelError) {
-    shipmentLabelErrorMessage.value = labelError;
-  }
+  shipmentLabelErrorMessage.value = labelError;
 };
 
 const getProductStoreShipmentMethods = async (carrierPartyIdValue: string) => {
@@ -1382,7 +1379,12 @@ const shippingLabelActionPopover = async(ev: Event, currentOrder: any) => {
     showBackdrop: false
   });
 
-  return popover.present()
+   await popover.present();
+
+  const result = await popover.onDidDismiss();
+  if (result.data?.voided) {
+    await fetchShipmentLabelError();
+  }
 }
 
 const openTrackingCodeModal = async() => {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#1512

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Currently, when a shipment label is voided, stale error messages from previous label generation attempts persist in the Order Detail view because the error state is not cleared.

This PR resolves the issue by:
- Returning a `voided` flag from `ShippingLabelActionPopover` when a shipping label is successfully voided.
- Listening for the popover dismissal in `OrderDetail.vue` and re-fetching/updating the shipment label error messages if the flag is true.
- Updating `fetchShipmentLabelError` to always set `shipmentLabelErrorMessage` (even when `labelError` is null or empty) so that previous error states are properly cleared.

This ensures the UI stays synchronized with the actual shipment state in real time.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
N/A

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)
