### PR TITLE
Fix: Migrate product store settings API from dataDocumentView to REST resource (#1655)

### DIFF
--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -587,26 +587,22 @@ export const useProductStore = defineStore('productStore', {
       const productStoreSettings = {} as any
 
       if (productStoreId) {
-        const payload = {
-          productStoreId,
-          settingTypeEnumId: Object.keys(defaultProductStoreSettings),
-          settingTypeEnumId_op: "in",
-          pageIndex: 0,
-          pageSize: 50
-        }
         try {
           const resp = await api({
-            url: `/oms/dataDocumentView`,
-            method: "POST",
-            data: {
-              dataDocumentId: "ProductStoreSetting",
-              customParametersMap: payload
+            url: `/admin/productStores/${productStoreId}/settings`,
+            method: "GET",
+            params: {
+              settingTypeEnumId: Object.keys(defaultProductStoreSettings),
+              settingTypeEnumId_op: "in",
+              pageSize: 50
             }
           }) as any
 
-          resp?.data?.entityValueList?.forEach((productSetting: any) => {
-            productStoreSettings[productSetting.settingTypeEnumId] = productSetting.settingValue
-          })
+          if (!commonUtil.hasError(resp) && resp.data) {
+            resp.data.forEach((productSetting: any) => {
+              productStoreSettings[productSetting.settingTypeEnumId] = productSetting.settingValue
+            })
+          }
         } catch (error) {
           logger.error("Failed to fetch settings", error)
         }


### PR DESCRIPTION
## Description

Fixes a `400 Bad Request` error on the Fulfillment app Settings page when fetching product store settings.

Previously, the app requested product store settings using `POST /oms/dataDocumentView` with `dataDocumentId: "ProductStoreSetting"`. This request failed because `ProductStoreSetting` is not available as a DataDocument in the target OMS environment.

This change migrates the request to the Product Store Settings REST resource.

## Changes Made

- Updated `src/store/productStore.ts`
  - Replaced `POST /oms/dataDocumentView` with:
    ```
    GET /admin/productStores/{productStoreId}/settings
    ```
  - Updated the response handling to parse the REST API response.

## Related Issue

Closes #1655

## Verification

- Verified the Fulfillment app Settings page loads successfully.
- Confirmed the request to:
  ```
  GET /admin/productStores/STORE/settings
  ```
  returns `200 OK`.
- Verified product store configuration settings are loaded correctly.