### PR TITLE
Removed: unwanted recycle all button from the bulk pack alert(#1661)

### DIFF
--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -657,18 +657,6 @@ const packOrders = async () => {
             emitter.emit("dismissLoader");
           }
         }
-      }, {
-        text: translate("Recycle all"),
-        handler: async () => {
-          try {
-            await orderStore.recycleInProgressOrders({});
-
-            commonUtil.showToast(translate("All orders recycled successfully."));
-          } catch (err) {
-            commonUtil.showToast(translate("Failed to recycle all orders."));
-            console.error(err);
-          }
-        }
       }]
     });
   return alert.present();


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #1661

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Removed recycle all option from the bulk pack orders action, as we already have recycle button in header and there is no need for recycle button in confirmation alert related to packing

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)