### PR TITLE
Fix: Standardize reject action button naming across fulfillment screens (#1659)

### DIFF
--- a/src/components/GenerateTrackingCodeModal.vue
+++ b/src/components/GenerateTrackingCodeModal.vue
@@ -38,7 +38,7 @@
         <ion-label>{{ translate("Manual tracking details") }}</ion-label>
       </ion-segment-button>
       <ion-segment-button value="reject-order">
-        <ion-label>{{ translate("Reject order") }}</ion-label>
+        <ion-label>{{ translate("Reject") }}</ion-label>
       </ion-segment-button>
     </ion-segment>
     <div class="segments">

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -172,7 +172,7 @@
               <template v-if="category === 'in-progress'">
                 <ion-button :color="order.hasAllRejectedItem ? 'danger' : ''" @click="packOrder(order)">
                   <ion-icon slot="start" :icon="archiveOutline" />
-                  {{ translate(order.hasAllRejectedItem ? "Reject order" : order.hasRejectedItem ? "Save and Pack Order" : "Pack order") }}
+                  {{ translate(order.hasAllRejectedItem ? "Reject" : order.hasRejectedItem ? "Save and Pack Order" : "Pack order") }}
                 </ion-button>
               </template>
               <ion-button v-else-if="category === 'open'" @click="assignPickers">

--- a/src/views/PackagingPopover.vue
+++ b/src/views/PackagingPopover.vue
@@ -11,7 +11,7 @@
       </ion-item>
       <ion-item button lines="none">
         <ion-icon slot="start" :icon="refresh" />
-        {{ translate("Reject order") }}
+        {{ translate("Reject") }}
       </ion-item>
     </ion-list>
   </ion-content>


### PR DESCRIPTION
## Summary

Fixes #1659 by standardizing the label for the reject action across Fulfillment screens.

Previously, the same reject action was displayed with different labels such as `Reject order` and `Reject`. The affected UI elements now consistently use `Reject`.

## Changes Made

- **`src/views/OrderDetail.vue`**
  - Changed the reject action button label from `Reject order` to `Reject`.

- **`src/views/PackagingPopover.vue`**
  - Changed the mobile popover reject action label from `Reject order` to `Reject`.

- **`src/components/GenerateTrackingCodeModal.vue`**
  - Changed the reject segment label from `Reject order` to `Reject`.

## Verification

- Verified the reject action is consistently labeled `Reject` across the affected screens.
- Verified the existing reject functionality remains unchanged.
- Verified the UI changes do not affect the underlying reject workflow.