### PR TITLE
Fix: Prevent Open Orders list from becoming empty after assigning picker (#1672)

### DIFF
--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -133,12 +133,6 @@ const printPicklist = async () => {
       }
 
       await useOrderStore().findOpenOrders();
-      if (orderIdsToPick.length) {
-        const updatedOpenOrders = openOrders.value?.list.filter((openOrder: any) => !orderIdsToPick.includes(openOrder.orderId));
-        const outdatedOpenOrderCount = openOrders.value.list.reduce((count: number, openOrder: any) => orderIdsToPick.includes(openOrder.orderId) ? count + 1 : count, 0);
-        await useOrderStore().updateOpenOrderQuery({ ...openOrders.value.query, viewSize: updatedOpenOrders.length });
-        await useOrderStore().updateOpenOrders({ orders: updatedOpenOrders, total: openOrders.value.total - outdatedOpenOrderCount });
-      }
     } else {
       throw resp.data;
     }


### PR DESCRIPTION
### Related Issue
Closes #1672

### Problem
After assigning a picker from the Open Orders workflow, the Open Orders page could display an empty list even though other valid Open orders were still available.

### Root Cause
In `AssignPickerModal.vue`, after creating the picklist, `findOpenOrders()` was called to fetch the latest Open Orders from the backend.

An additional local filtering operation was then performed on `openOrders.value.list`. This filtering could remove the orders from the freshly fetched list and leave the store with an empty order list.

As a result, the Open Orders page could display an incorrect state such as `0 of 465 orders` while no order cards were rendered.

### Solution
Removed the redundant local filtering logic from `AssignPickerModal.vue`.

The application now relies on:

```ts
await useOrderStore().findOpenOrders()