### PR TITLE
Fix: Refresh order detail after packing order (#1633)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -37,7 +37,7 @@
           </ion-list>
         </ion-content>
       </ion-menu>
-      <ion-router-outlet id="main-content" />
+      <ion-router-outlet id="main-content" :key="router.currentRoute.value.fullPath" />
     </ion-split-pane>
   </ion-app>
 </template>

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -713,7 +713,7 @@ const executePackOrder = async (currentOrder: any, updateParameter?: string, tra
     } else {
       commonUtil.showToast(translate("Order packed successfully"));
     }
-    router.replace(`/completed/shipment-detail/${props.orderId}/${props.shipmentId}`);
+    window.location.href = `/completed/shipment-detail/${props.orderId}/${props.shipmentId}`;
     return { isPacked: true };
   } catch (err: any) {
     if (toast) toast.dismiss();


### PR DESCRIPTION
### Related Issue
Closes #1633

### Context & Description
When an order is packed from the **Order Details** page, the backend successfully updates the shipment status to `SHIPMENT_PACKED`.

However, navigating to the Completed order detail using Vue Router did not refresh the Order Details UI with the latest backend state. As a result, the page could continue displaying stale order information until the browser was manually refreshed.

A full browser navigation is now performed after a successful packing operation so that the Order Details page is initialized again with the latest shipment state.

### Changes Made
- Updated `executePackOrder()` in `src/views/OrderDetail.vue`.
- Replaced the client-side `router.replace()` navigation with `window.location.href` for the Completed order detail route.
- This ensures the page performs a full navigation and fetches the latest order/shipment state after packing.

### Verification
1. Open an order in **In Progress**.
2. Navigate to the Order Details page.
3. Click **Pack Order** and confirm the packing operation.
4. Verify the pack API completes successfully.
5. Verify the page navigates to:
   `/completed/shipment-detail/:orderId/:shipmentId`
6. Verify the Order Details page is reloaded with the latest `SHIPMENT_PACKED` state.
7. Verify the **Completed** status and corresponding actions such as **Ship Order**, **Print Customer Letter**, and **Unpack** are displayed correctly.
8. Verify no manual browser refresh is required.