### PR TITLE
Improved: Renamed firebase project aliases to dev, uat and prod

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,8 +1,8 @@
 {
   "projects": {
-    "default": "hotwax-digital-commerce",
+    "dev": "hotwax-digital-commerce",
     "uat": "hotwax-digital-commerce-uat",
-    "production": "digital-commerce-71eb8"
+    "prod": "digital-commerce-71eb8"
   },
   "targets": {
     "hotwax-digital-commerce": {


### PR DESCRIPTION
Renames the firebase project aliases in `.firebaserc` from `default`/`production` to explicit `dev`, `uat` and `prod`, so the same alias names are used across all accxui apps for deploys.

No hosting targets or project ids changed.