### PR TITLE
Improved: increased viewSize to 200 when fetching user permissions

### DIFF
--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -111,7 +111,7 @@ export const useUserStore = defineStore("user", {
     async fetchPermissions() {
       const permissionId = import.meta.env.VITE_APP_PERMISSION_ID
       const serverPermissions = [] as string[]
-      const viewSize = 50
+      const viewSize = 200
       let viewIndex = 0
 
       try {


### PR DESCRIPTION
### Related Issues

#

### Short Description and Why It's Useful

Increased `viewSize` from 50 to 200 when fetching user permissions, matching `company`, `job-manager`, `order-routing` and `products`.

The paging loop still runs until a page comes back empty, so the resulting permission set is unchanged — this only reduces the number of requests made during login.

### Screenshots of Visual Changes before/after (If There Are Any)

N/A — no UI changes.

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/hotwax/fulfillment#contribution-guideline)